### PR TITLE
fix(docker-monitoring): add required volume mounts for cAdvisor

### DIFF
--- a/docker-monitoring/docker-compose.yml
+++ b/docker-monitoring/docker-compose.yml
@@ -59,4 +59,9 @@ services:
    volumes:
      - ./config.alloy:/etc/alloy/config.alloy
      - /var/run/docker.sock:/var/run/docker.sock
+     - /:/rootfs:ro
+     - /var/run:/var/run:ro
+     - /sys:/sys:ro
+     - /var/lib/docker/:/var/lib/docker:ro
+     - /dev/disk/:/dev/disk:ro
    command: run --server.http.listen-addr=0.0.0.0:12345 --storage.path=/var/lib/alloy/data /etc/alloy/config.alloy


### PR DESCRIPTION
The docker-monitoring scenario was missing essential volume mounts for cAdvisor to properly collect container and disk metrics. This commit adds the following volumes to the Alloy container definition:
```
  - /:/rootfs:ro
  - /var/run:/var/run:ro
  - /sys:/sys:ro
  - /var/lib/docker/:/var/lib/docker:ro
  - /dev/disk/:/dev/disk:ro
```

These are required by the cAdvisor exporter to access container metadata, filesystem stats, and disk I/O details. Without them, key container metrics will be missing or incorrect.

Reference:
- [cAdvisor doc](https://github.com/google/cadvisor)
- [Prometheus cadvisor guides](https://prometheus.io/docs/guides/cadvisor/)