### PR TITLE
Migrate k8s scenarios to k8s-monitoring chart v4

### DIFF
--- a/k8s/logs/README.md
+++ b/k8s/logs/README.md
@@ -66,10 +66,10 @@ Note that within the `grafana-values.yml` file, the `grafana.ini` configuration 
 
 ## Install the K8s Monitoring Helm Chart
 
-The final step is to install the K8s monitoring Helm chart. This will install Alloy in the `meta` namespace. The `k8s-monitoring-values.yml` file contains the configuration for the K8s monitoring Helm chart. To install the K8s monitoring Helm chart, run the following command:
+The final step is to install the K8s monitoring Helm chart. This will install Alloy in the `meta` namespace. The `k8s-monitoring-values.yml` file contains the configuration for the K8s monitoring Helm chart. This scenario requires `grafana/k8s-monitoring` chart v4 or later. To install the K8s monitoring Helm chart, run the following command:
 
 ```bash
-helm install --values ./k8s-monitoring-values.yml k8s grafana/k8s-monitoring -n meta --create-namespace
+helm install --values ./k8s-monitoring-values.yml k8s grafana/k8s-monitoring --version "^4.0.0" -n meta --create-namespace
 ```
 Within the `k8s-monitoring-values.yml` file we declare the Alloy configuration. This configuration specifies the log sources that Alloy will collect logs from. In this scenario, we are collecting logs from two different sources: Pod Logs and Kubernetes Events.
 

--- a/k8s/logs/k8s-monitoring-values.yml
+++ b/k8s/logs/k8s-monitoring-values.yml
@@ -3,50 +3,28 @@ cluster:
   name: meta-monitoring-tutorial
 
 destinations:
-  - name: loki
+  loki:
     type: loki
     url: http://loki-gateway.meta.svc.cluster.local/loki/api/v1/push
 
-
 clusterEvents:
   enabled: true
-  collector: alloy-logs
+  collector: alloy-singleton
   namespaces:
     - meta
     - prod
 
-nodeLogs:
-  enabled: false
-
-podLogs:
+podLogsViaKubernetesApi:
   enabled: true
-  gatherMethod: kubernetesApi
   collector: alloy-logs
-  labelsToKeep: ["app_kubernetes_io_name","container","instance","job","level","namespace","service_name","service_namespace","deployment_environment","deployment_environment_name"]
+  namespaces:
+    - meta
+    - prod
   structuredMetadata:
-    pod: pod  # Set structured metadata "pod" from label "pod"
-  namespaces:
-    - meta
-    - prod
+    pod: pod
 
-# Collectors
-alloy-singleton:
-  enabled: false
-
-alloy-metrics:
-  enabled: false
-
-alloy-logs:
-  enabled: true
-  alloy:
-    mounts:
-      varlog: false
-      dockercontainers: false
-    clustering:
-      enabled: true
-
-alloy-profiles:
-  enabled: false
-
-alloy-receiver:
-  enabled: false
+collectors:
+  alloy-singleton:
+    presets: [singleton]
+  alloy-logs:
+    presets: [clustered]

--- a/k8s/metrics/README.md
+++ b/k8s/metrics/README.md
@@ -55,8 +55,10 @@ helm install --values grafana-values.yml grafana grafana/grafana -n meta
 
 ## Install the K8s Monitoring Helm Chart
 
+This scenario requires `grafana/k8s-monitoring` chart v4 or later.
+
 ```bash
-helm install --values k8s-monitoring-values.yml k8s grafana/k8s-monitoring -n meta
+helm install --values k8s-monitoring-values.yml k8s grafana/k8s-monitoring --version "^4.0.0" -n meta
 ```
 
 ## Accessing the Grafana UI

--- a/k8s/metrics/k8s-monitoring-values.yml
+++ b/k8s/metrics/k8s-monitoring-values.yml
@@ -3,42 +3,21 @@ cluster:
   name: meta-monitoring-tutorial
 
 destinations:
-  - name: prometheus
+  prometheus:
     type: prometheus
     url: http://prometheus-server.meta.svc.cluster.local:80/api/v1/write
 
 clusterMetrics:
   enabled: true
-  collector: alloy-metrics
-
-clusterEvents:
-  enabled: false
-
-nodeLogs:
-  enabled: false
-
-podLogs:
-  enabled: false
 
 annotationAutodiscovery:
   enabled: true
   collector: alloy-metrics
 
-# Collectors
-alloy-singleton:
-  enabled: false
+collectors:
+  alloy-metrics:
+    presets: [clustered, statefulset]
 
-alloy-metrics:
-  enabled: true
-  alloy:
-    clustering:
-      enabled: true
-
-alloy-logs:
-  enabled: false
-
-alloy-profiles:
-  enabled: false
-
-alloy-receiver:
-  enabled: false
+telemetryServices:
+  kube-state-metrics:
+    deploy: true

--- a/k8s/profiling/README.md
+++ b/k8s/profiling/README.md
@@ -53,8 +53,10 @@ helm install --values grafana-values.yml grafana grafana/grafana -n meta
 
 ## Install the K8s Monitoring Helm Chart
 
+This scenario requires `grafana/k8s-monitoring` chart v4 or later.
+
 ```bash
-helm install --values k8s-monitoring-values.yml k8s grafana/k8s-monitoring -n meta
+helm install --values k8s-monitoring-values.yml k8s grafana/k8s-monitoring --version "^4.0.0" -n meta
 ```
 
 ## Accessing the Grafana UI

--- a/k8s/profiling/k8s-monitoring-values.yml
+++ b/k8s/profiling/k8s-monitoring-values.yml
@@ -3,38 +3,16 @@ cluster:
   name: meta-monitoring-tutorial
 
 destinations:
-  - name: pyroscope
+  pyroscope:
     type: pyroscope
     url: http://pyroscope.meta.svc.cluster.local:4040
 
 profiling:
   enabled: true
   collector: alloy-profiles
+  pprof:
+    enabled: true
 
-clusterMetrics:
-  enabled: false
-
-clusterEvents:
-  enabled: false
-
-nodeLogs:
-  enabled: false
-
-podLogs:
-  enabled: false
-
-# Collectors
-alloy-singleton:
-  enabled: false
-
-alloy-metrics:
-  enabled: false
-
-alloy-logs:
-  enabled: false
-
-alloy-profiles:
-  enabled: true
-
-alloy-receiver:
-  enabled: false
+collectors:
+  alloy-profiles:
+    presets: [privileged, daemonset]

--- a/k8s/tracing/README.md
+++ b/k8s/tracing/README.md
@@ -54,8 +54,10 @@ helm install --values grafana-values.yml grafana grafana/grafana -n meta
 
 ## Install the K8s Monitoring Helm Chart
 
+This scenario requires `grafana/k8s-monitoring` chart v4 or later.
+
 ```bash
-helm install --values k8s-monitoring-values.yml k8s grafana/k8s-monitoring -n meta
+helm install --values k8s-monitoring-values.yml k8s grafana/k8s-monitoring --version "^4.0.0" -n meta
 ```
 
 This configures Alloy to receive OTLP traces on ports 4317 (gRPC) and 4318 (HTTP), then forward them to Tempo.

--- a/k8s/tracing/k8s-monitoring-values.yml
+++ b/k8s/tracing/k8s-monitoring-values.yml
@@ -3,7 +3,7 @@ cluster:
   name: meta-monitoring-tutorial
 
 destinations:
-  - name: tempo
+  tempo:
     type: otlp
     url: http://tempo.meta.svc.cluster.local:4317
     metrics:
@@ -16,41 +16,17 @@ destinations:
 applicationObservability:
   enabled: true
   collector: alloy-receiver
+  receivers:
+    otlp:
+      grpc:
+        enabled: true
+      http:
+        enabled: true
+  metrics:
+    enabled: false
+  logs:
+    enabled: false
 
-clusterMetrics:
-  enabled: false
-
-clusterEvents:
-  enabled: false
-
-nodeLogs:
-  enabled: false
-
-podLogs:
-  enabled: false
-
-# Collectors
-alloy-singleton:
-  enabled: false
-
-alloy-metrics:
-  enabled: false
-
-alloy-logs:
-  enabled: false
-
-alloy-profiles:
-  enabled: false
-
-alloy-receiver:
-  enabled: true
-  alloy:
-    extraPorts:
-      - name: otlp-grpc
-        port: 4317
-        targetPort: 4317
-        protocol: TCP
-      - name: otlp-http
-        port: 4318
-        targetPort: 4318
-        protocol: TCP
+collectors:
+  alloy-receiver:
+    presets: [deployment]


### PR DESCRIPTION
## Summary

- Rewrites `k8s-monitoring-values.yml` in all four k8s scenarios (`logs`, `metrics`, `profiling`, `tracing`) to the chart v4 schema — destinations as a map, collectors nested under `collectors:` with presets, and the new v4-specific feature knobs (`podLogsViaKubernetesApi`, `telemetryServices.kube-state-metrics.deploy`, `profiling.pprof.enabled`, `applicationObservability.receivers.otlp.{grpc,http}.enabled`).
- Pins each scenario's `helm install` command to `--version "^4.0.0"` and notes the v4 requirement, so the scenarios won't silently break on the next breaking chart release.
- Fixes #55.

## Test plan

- [x] `helm template k8s grafana/k8s-monitoring --version "^4.0.0" --values k8s-monitoring-values.yml -n meta` succeeds for all four scenarios (logs/metrics/profiling/tracing) — no schema or validation errors.
- [x] Rendered output includes the expected Alloy collectors per scenario:
  - logs → `k8s-alloy-logs` + `k8s-alloy-singleton`
  - metrics → `k8s-alloy-metrics` + bundled `k8s-kube-state-metrics`
  - profiling → `k8s-alloy-profiles`
  - tracing → `k8s-alloy-receiver` with OTLP 4317/4318 service ports
- [x] End-to-end on a local `kind` cluster per each scenario's README — backend + Grafana install, k8s-monitoring install succeeds, pods reach `Running`, telemetry appears in Grafana Explore.