### PR TITLE
Add White Walkers Attack single-player map

### DIFF
--- a/game-of-tracing/AGENTS.md
+++ b/game-of-tracing/AGENTS.md
@@ -60,6 +60,39 @@ One Docker volume, `game-data`, mounted at `/data`. **Two SQLite databases live 
 
 Overriding `DATABASE_FILE` (game_state) or `GAME_SESSIONS_DB` (game_sessions) env vars on `war_map` is supported.
 
+### Extra tables added for multi-map support
+
+`game_state.db` also holds:
+
+- **`game_config`** — key/value store; the `active_map_id` row is authoritative at runtime. `war_map`'s `/select_map` route writes this; every location service reads it on boot and `/reload`.
+- **`faction_economy`** — `(faction, corpses)`. Holds the White Walkers' corpse pool on the WWA map. Populated by the post-battle hook in `LocationServer.receive_army` and by the passive corpse tick at the WW fortress. Consumed by `LocationServer.create_army` when the faction's currency is `corpses`.
+- **`wall_hold`** — `(map_id, faction, ticks, last_update)`. Written by `war_map`'s `_wall_tick_thread`. Non-zero rows mean that faction currently holds every wall keep on that map.
+
+`game_sessions.db` has a `map_id` column added to the `game_actions` table so replay queries can filter by map. Fresh installs seed `map_id=NULL` for any legacy rows; an additive `ALTER TABLE` migration runs on first boot after the upgrade.
+
+## Maps
+
+`app/game_config.py` defines a `MAPS` dict with two entries:
+
+| Map id | Players | Factions | Win | Notable rules |
+|---|---|---|---|---|
+| `war_of_kingdoms` (default) | 2 | `southern`, `northern`, `neutral` | Capture enemy capital | Classic — 30 resources per army, 20 resource/collect at capitals, village passive +10/15 s |
+| `white_walkers_attack` | 1 (player is `nights_watch`) | `nights_watch`, `white_walkers`, `barbarian`, `neutral` | Hold every `wall` keep for 5 × 30 s ticks | `wall` settlement type doubles defenders; WW spends 5 corpses per army (no resources); barbarian villages grow +1 army every 30 s; WW fortress passively +1 corpse every 15 s |
+
+Each map also defines a **slot assignments** dict (`slot_1` → logical location id) so the 8 physical containers can serve either map. See "Slot identity" below.
+
+### Slot identity
+
+Each location container has a fixed `SLOT_ID` env var (`slot_1` … `slot_8`). On boot, the container:
+
+1. Reads the shared `active_map_id` from `game_state.db`'s `game_config` table.
+2. Looks up `MAPS[active_map_id]["slot_assignments"][SLOT_ID]` → its logical `location_id`.
+3. Loads config from `MAPS[active_map_id]["locations"][location_id]`.
+
+The container's **SERVICE_NAME** (used by Grafana dashboards) stays stable (`southern-capital`, `village-1`, etc.) regardless of the map — the *logical* location id is published as the `location.id` span attribute, not the service name.
+
+Runtime map switching: `war_map/select_map` writes a new `active_map_id`, POSTs `/reset` to any one container to wipe the `locations` table, then POSTs `/reload` to every container so they rebind in place without a restart.
+
 ## Two Alloy configurations
 
 ### Default — River (HCL)

--- a/game-of-tracing/CLAUDE.md
+++ b/game-of-tracing/CLAUDE.md
@@ -4,9 +4,13 @@
 
 ## Start here
 
-1. Read `./AGENTS.md` for the scenario overview.
+1. Read `./AGENTS.md` for the scenario overview — including the **Maps** and **Slot identity** sections.
 2. Read the submodule `CLAUDE.md` matching the area you are touching: [`app/CLAUDE.md`](app/CLAUDE.md), [`ai_opponent/CLAUDE.md`](ai_opponent/CLAUDE.md), [`war_map/CLAUDE.md`](war_map/CLAUDE.md).
 3. If the task involves span links, trace replay, cross-service context propagation, or AI decision logic — delegate to the sub-agent below.
+
+### Two maps, one stack
+
+The scenario ships **two maps** selected via an in-UI picker at game start: `war_of_kingdoms` (default 2-player) and `white_walkers_attack` (single-player Night's Watch vs AI White Walkers with `wall` keeps, corpse economy, and a 5-tick hold-to-win condition). Both reuse the same 8 location containers — each container has a constant `SLOT_ID` env and picks up its logical identity from `MAPS[active_map_id]["slot_assignments"][SLOT_ID]` in `app/game_config.py`. Changing maps writes a new `active_map_id` to the shared `game_config` table and POSTs `/reload` to every slot.
 
 ## Sub-agent dispatch
 

--- a/game-of-tracing/README.md
+++ b/game-of-tracing/README.md
@@ -52,15 +52,33 @@ This game teaches several key concepts in distributed tracing:
 
 ## Game Overview
 
-The game simulates a war between two kingdoms, each starting from their capital city. Players must:
+Open the scenario at `http://localhost:8080` and you land on a **map picker**. Two maps ship today:
+
+### War of Kingdoms (default, 2-player)
+
+Two rival kingdoms — Southern and Northern — race to capture the enemy capital. Players:
 
 - Collect resources from their territories
-- Build armies to expand their influence
-- Capture neutral villages
+- Build armies (30 resources per unit) to expand their influence
+- Capture neutral villages (6 of them)
 - Send resources back to their capital
 - Launch strategic attacks on enemy territories
 
-The game supports both single-player (with AI opponent) and two-player modes.
+**Win condition:** capture the enemy capital.
+
+### White Walkers Attack (single-player)
+
+The Long Night has come. The human plays the **Night's Watch** (player faction); the AI opponent plays the **White Walkers**. A new **Barbarian** faction controls two villages on the flanks — passive, slowly accruing army units, good raid targets.
+
+New mechanics:
+
+- **Wall settlements** run across the middle of the map. Defenders count **2×** when a wall is attacked, making them hard to dislodge.
+- **Corpse economy.** White Walkers spend **corpses** (not resources) to raise new armies at their fortress. Corpses come from winning battles (every unit killed on either side becomes a corpse) plus a slow passive tick at the fortress itself. Cost: 5 corpses per unit.
+- **Barbarians** never attack. They accrue +1 army every 30 s — easy farm for White Walkers, but they also harass unguarded Night's Watch supply lines.
+
+**Win condition:** hold *every* wall settlement continuously for **5 ticks** (150 s, since the tick is 30 s). Any wall changing hands resets the counter.
+
+Both maps share the same 8 location containers — the active map lives in `game_state.db`, and the `/reload` endpoint on each service rebinds the slot's identity when the player switches maps via the picker.
 
 Each action in the game generates traces that can be analyzed in Grafana Tempo, demonstrating how distributed tracing works in a real application.
 

--- a/game-of-tracing/ai_opponent/CLAUDE.md
+++ b/game-of-tracing/ai_opponent/CLAUDE.md
@@ -4,7 +4,14 @@
 
 ## Purpose
 
-`ai-opponent` is a Flask service on port **8081** that takes control of a faction's capital and makes strategic decisions on a recurring loop. It is activated by `war_map` via `POST /activate` (with the faction as payload) when the player toggles "Enable AI Opponent". The AI then:
+`ai-opponent` is a Flask service on port **8081** that takes control of a faction and makes strategic decisions on a recurring loop. It is activated by `war_map` via `POST /activate` with JSON body `{"faction": ..., "map_id": ...}` — on the WoK map the player toggles it on manually; on WWA it auto-activates as `white_walkers` the moment the player picks the map.
+
+Two AI variants dispatch off the `faction` field at activation time:
+
+- **`StrategicAI`** — classic WoK opponent (southern / northern). 6-step priority cascade: capital defense → zero-risk captures → resource transfers → plan execution → plan creation → fallback.
+- **`WhiteWalkerAI(StrategicAI)`** — single-player WWA opponent. Different cascade: defend fortress → capture unowned wall → reinforce weakest wall → raid barbarian village (for corpses) → raise army from corpses (at fortress) → idle. Reads its corpse pool via `GET /faction_economy?faction=white_walkers` on any location service; spends 5 corpses per army unit instead of 30 resources.
+
+Common to both: the AI:
 
 - Fetches the state of all 8 locations.
 - Runs a priority cascade of checks to decide the next action (defend, capture, transfer, plan, fallback).

--- a/game-of-tracing/ai_opponent/CLAUDE.md
+++ b/game-of-tracing/ai_opponent/CLAUDE.md
@@ -9,7 +9,7 @@
 Two AI variants dispatch off the `faction` field at activation time:
 
 - **`StrategicAI`** — classic WoK opponent (southern / northern). 6-step priority cascade: capital defense → zero-risk captures → resource transfers → plan execution → plan creation → fallback.
-- **`WhiteWalkerAI(StrategicAI)`** — single-player WWA opponent. Different cascade: defend fortress → capture unowned wall → reinforce weakest wall → raid barbarian village (for corpses) → raise army from corpses (at fortress) → idle. Reads its corpse pool via `GET /faction_economy?faction=white_walkers` on any location service; spends 5 corpses per army unit instead of 30 resources.
+- **`WhiteWalkerAI(StrategicAI)`** — single-player WWA opponent. Different cascade: defend fortress → capture unowned wall → reinforce weakest wall (non-capital neighbours preferred; capital is a fallback when no other source has spare army, since `move_army` empties the source) → raid barbarian village (for corpses) → raise army from corpses at the fortress (only requires the capital to still belong to the AI; no minimum garrison) → idle. Reads its corpse pool via `GET /faction_economy?faction=white_walkers` on any location service; spends 5 corpses per army unit instead of 30 resources.
 
 Common to both: the AI:
 

--- a/game-of-tracing/ai_opponent/ai_server.py
+++ b/game-of-tracing/ai_opponent/ai_server.py
@@ -23,22 +23,109 @@ atexit.register(telemetry.shutdown)
 
 # ─── Constants ─────────────────────────────────────────────────────────────────
 
-MAP_GRAPH = {
-    "southern_capital": ["village_1", "village_3"],
-    "northern_capital": ["village_2", "village_6"],
-    "village_1": ["southern_capital", "village_2", "village_4"],
-    "village_2": ["northern_capital", "village_1", "village_5"],
-    "village_3": ["southern_capital", "village_5", "village_6"],
-    "village_4": ["village_1", "village_5"],
-    "village_5": ["village_2", "village_3", "village_4", "village_6"],
-    "village_6": ["northern_capital", "village_3", "village_5"],
+# Per-map adjacency lists. Keep keys in sync with
+# game-of-tracing/app/game_config.py's MAPS[*]["locations"][*]["connections"].
+MAP_GRAPHS_BY_MAP = {
+    "war_of_kingdoms": {
+        "southern_capital": ["village_1", "village_3"],
+        "northern_capital": ["village_2", "village_6"],
+        "village_1": ["southern_capital", "village_2", "village_4"],
+        "village_2": ["northern_capital", "village_1", "village_5"],
+        "village_3": ["southern_capital", "village_5", "village_6"],
+        "village_4": ["village_1", "village_5"],
+        "village_5": ["village_2", "village_3", "village_4", "village_6"],
+        "village_6": ["northern_capital", "village_3", "village_5"],
+    },
+    "white_walkers_attack": {
+        "nights_watch_fortress": [
+            "wall_west", "wall_center_west", "wall_center_east", "wall_east",
+        ],
+        "white_walker_fortress": [
+            "wall_west", "wall_center_west", "wall_center_east", "wall_east",
+        ],
+        "wall_west": [
+            "nights_watch_fortress", "white_walker_fortress",
+            "wall_center_west", "barbarian_village_west",
+        ],
+        "wall_center_west": [
+            "nights_watch_fortress", "white_walker_fortress",
+            "wall_west", "wall_center_east",
+        ],
+        "wall_center_east": [
+            "nights_watch_fortress", "white_walker_fortress",
+            "wall_center_west", "wall_east",
+        ],
+        "wall_east": [
+            "nights_watch_fortress", "white_walker_fortress",
+            "wall_center_east", "barbarian_village_east",
+        ],
+        "barbarian_village_west": ["wall_west"],
+        "barbarian_village_east": ["wall_east"],
+    },
 }
+
+# Per-map capital mapping (faction -> location_id of that faction's capital).
+CAPITALS_BY_MAP = {
+    "war_of_kingdoms": {
+        "southern": "southern_capital",
+        "northern": "northern_capital",
+    },
+    "white_walkers_attack": {
+        "nights_watch": "nights_watch_fortress",
+        "white_walkers": "white_walker_fortress",
+    },
+}
+
+# Per-map location type lookup (capital / village / wall).
+LOCATION_TYPES_BY_MAP = {
+    "war_of_kingdoms": {
+        "southern_capital": "capital", "northern_capital": "capital",
+        "village_1": "village", "village_2": "village", "village_3": "village",
+        "village_4": "village", "village_5": "village", "village_6": "village",
+    },
+    "white_walkers_attack": {
+        "nights_watch_fortress": "capital",
+        "white_walker_fortress": "capital",
+        "wall_west": "wall", "wall_center_west": "wall",
+        "wall_center_east": "wall", "wall_east": "wall",
+        "barbarian_village_west": "village",
+        "barbarian_village_east": "village",
+    },
+}
+
+# Per-map location faction (static initial ownership — what the AI reasons
+# about for walls-are-neutral / barbarian-villages-are-barbarian etc.).
+INITIAL_FACTIONS_BY_MAP = {
+    "war_of_kingdoms": {
+        "southern_capital": "southern", "northern_capital": "northern",
+        "village_1": "neutral", "village_2": "neutral", "village_3": "neutral",
+        "village_4": "neutral", "village_5": "neutral", "village_6": "neutral",
+    },
+    "white_walkers_attack": {
+        "nights_watch_fortress": "nights_watch",
+        "white_walker_fortress": "white_walkers",
+        "wall_west": "neutral", "wall_center_west": "neutral",
+        "wall_center_east": "neutral", "wall_east": "neutral",
+        "barbarian_village_west": "barbarian",
+        "barbarian_village_east": "barbarian",
+    },
+}
+
+# Per-map army cost per faction. Matches app/game_config.py's rules.army_cost.
+ARMY_COST_BY_MAP = {
+    "war_of_kingdoms": {"default": 30},
+    "white_walkers_attack": {"default": 30, "white_walkers": 5},
+}
+
+# Backward-compat alias: legacy code that references MAP_GRAPH still sees WoK.
+MAP_GRAPH = MAP_GRAPHS_BY_MAP["war_of_kingdoms"]
 
 ARMY_COST = 30
 VILLAGE_INCOME_PER_MIN = 40  # ~10 resources every 15s
 RESOURCE_TRANSFER_THRESHOLD = 30
 
-# Location configuration (matches game_config.py)
+# Single port table keyed by location id (same ports are shared across maps
+# because a slot's port is fixed and each map just renames the slot).
 LOCATION_PORTS = {
     "southern_capital": 5001,
     "northern_capital": 5002,
@@ -47,8 +134,60 @@ LOCATION_PORTS = {
     "village_3": 5005,
     "village_4": 5006,
     "village_5": 5007,
-    "village_6": 5008
+    "village_6": 5008,
+    # White Walkers Attack aliases (same physical slot → same port).
+    "nights_watch_fortress": 5001,
+    "white_walker_fortress": 5002,
+    "wall_west": 5003,
+    "wall_center_west": 5004,
+    "wall_center_east": 5005,
+    "wall_east": 5006,
+    "barbarian_village_west": 5007,
+    "barbarian_village_east": 5008,
 }
+
+# Container hostname per logical location id (resolves HTTP URLs in docker).
+CONTAINER_FOR_LOCATION_ID = {
+    # WoK ids are their own container names.
+    "southern_capital": "southern-capital",
+    "northern_capital": "northern-capital",
+    "village_1": "village-1",
+    "village_2": "village-2",
+    "village_3": "village-3",
+    "village_4": "village-4",
+    "village_5": "village-5",
+    "village_6": "village-6",
+    # WWA ids share containers with their slot peer.
+    "nights_watch_fortress": "southern-capital",
+    "white_walker_fortress": "northern-capital",
+    "wall_west": "village-1",
+    "wall_center_west": "village-2",
+    "wall_center_east": "village-3",
+    "wall_east": "village-4",
+    "barbarian_village_west": "village-5",
+    "barbarian_village_east": "village-6",
+}
+
+
+def get_map_graph(map_id):
+    return MAP_GRAPHS_BY_MAP.get(map_id, MAP_GRAPH)
+
+
+def get_capitals(map_id):
+    return CAPITALS_BY_MAP.get(map_id, CAPITALS_BY_MAP["war_of_kingdoms"])
+
+
+def get_location_types(map_id):
+    return LOCATION_TYPES_BY_MAP.get(map_id, LOCATION_TYPES_BY_MAP["war_of_kingdoms"])
+
+
+def get_initial_factions(map_id):
+    return INITIAL_FACTIONS_BY_MAP.get(map_id, INITIAL_FACTIONS_BY_MAP["war_of_kingdoms"])
+
+
+def get_army_cost_for(map_id, faction):
+    costs = ARMY_COST_BY_MAP.get(map_id, ARMY_COST_BY_MAP["war_of_kingdoms"])
+    return costs.get(faction, costs["default"])
 
 # ─── Game Phase ────────────────────────────────────────────────────────────────
 
@@ -64,7 +203,12 @@ class GamePhase(Enum):
 class MapAnalyzer:
     """Precomputed map analysis: BFS distances, strategic values, path army estimation."""
 
-    def __init__(self):
+    def __init__(self, graph=None, capitals=None):
+        # ``graph`` defaults to WoK to preserve legacy behaviour; new callers
+        # pass the active map's adjacency list. ``capitals`` is the map's
+        # faction→capital dict (needed for the strategic-value heuristic).
+        self.graph = graph if graph is not None else MAP_GRAPH
+        self.capitals = capitals if capitals is not None else CAPITALS_BY_MAP["war_of_kingdoms"]
         self.distances = self._compute_all_distances()
         self.strategic_values = self._compute_strategic_values()
 
@@ -74,7 +218,7 @@ class MapAnalyzer:
         queue = deque([start])
         while queue:
             node = queue.popleft()
-            for neighbor in MAP_GRAPH[node]:
+            for neighbor in self.graph[node]:
                 if neighbor not in visited:
                     visited[neighbor] = visited[node] + 1
                     queue.append(neighbor)
@@ -82,18 +226,25 @@ class MapAnalyzer:
 
     def _compute_all_distances(self):
         """Precompute all-pairs BFS distances."""
-        return {loc: self._bfs_distances(loc) for loc in MAP_GRAPH}
+        return {loc: self._bfs_distances(loc) for loc in self.graph}
 
     def _compute_strategic_values(self):
         """Score each location by connectivity + centrality.
-        Village 5 scores highest (4 connections, center of map)."""
+
+        High connectivity or short distance to either capital = valuable.
+        Works identically across maps because it reads capitals from the
+        per-map mapping rather than hardcoding WoK's capital names.
+        """
         values = {}
-        for loc in MAP_GRAPH:
-            connections = len(MAP_GRAPH[loc])
-            avg_capital_dist = (
-                self.distances[loc].get("southern_capital", 99) +
-                self.distances[loc].get("northern_capital", 99)
-            ) / 2.0
+        capital_ids = list(self.capitals.values())
+        for loc in self.graph:
+            connections = len(self.graph[loc])
+            if capital_ids:
+                avg_capital_dist = sum(
+                    self.distances[loc].get(cap, 99) for cap in capital_ids
+                ) / float(len(capital_ids))
+            else:
+                avg_capital_dist = 99
             values[loc] = connections + (4.0 / max(avg_capital_dist, 1))
         return values
 
@@ -101,7 +252,7 @@ class MapAnalyzer:
         return self.distances[a].get(b, 99)
 
     def neighbors(self, loc):
-        return MAP_GRAPH.get(loc, [])
+        return self.graph.get(loc, [])
 
     def path_army_estimate(self, game_state, from_loc, to_loc, my_faction):
         """Estimate total enemy army along BFS shortest path from from_loc to to_loc."""
@@ -111,7 +262,7 @@ class MapAnalyzer:
             node = queue.popleft()
             if node == to_loc:
                 break
-            for neighbor in MAP_GRAPH[node]:
+            for neighbor in self.graph[node]:
                 if neighbor not in parent:
                     parent[neighbor] = node
                     queue.append(neighbor)
@@ -268,11 +419,14 @@ class Planner:
 class StrategicAI:
     """Main decision engine with priority cascade."""
 
-    def __init__(self, faction):
+    def __init__(self, faction, map_id="war_of_kingdoms"):
         self.faction = faction
-        self.my_capital = "southern_capital" if faction == "southern" else "northern_capital"
-        self.enemy_capital = "northern_capital" if faction == "southern" else "southern_capital"
-        self.map = MapAnalyzer()
+        self.map_id = map_id
+        capitals = get_capitals(map_id)
+        self.my_capital = capitals.get(faction)
+        enemies = [cap for fac, cap in capitals.items() if fac != faction]
+        self.enemy_capital = enemies[0] if enemies else None
+        self.map = MapAnalyzer(graph=get_map_graph(map_id), capitals=capitals)
         self.memory = GameMemory()
         self.planner = Planner()
         self.phase = GamePhase.BALANCED
@@ -282,6 +436,8 @@ class StrategicAI:
         self._previous_phase = None
         self._previous_territories = set()
         self._last_evaluated = []
+        # Army cost for this faction on this map.
+        self.army_cost = get_army_cost_for(map_id, faction)
 
     def decide(self, game_state):
         """Run the priority cascade and return an action dict or None."""
@@ -780,11 +936,260 @@ class StrategicAI:
         else:
             return random.randint(5, 15)
 
+
+# ─── White Walkers AI ─────────────────────────────────────────────────────────
+
+class WhiteWalkerAI(StrategicAI):
+    """Single-player opponent on the White Walkers Attack map.
+
+    Economy: corpses, not resources. Corpses come from winning battles and
+    passive generation at the fortress. Army units cost
+    ``ARMY_COST_BY_MAP["white_walkers_attack"]["white_walkers"]`` corpses.
+
+    Priority cascade (replaces ``StrategicAI.decide``):
+
+      1. Defend the fortress when enemies are adjacent and the garrison is
+         outnumbered.
+      2. Capture any wall that the White Walkers do not already control,
+         preferring the wall that needs the fewest attacking troops to beat
+         its 2× defender multiplier.
+      3. Reinforce the weakest White Walker-held wall.
+      4. Raid the nearest barbarian village whose army is less than or equal
+         to the closest White Walker garrison — a clean harvest for corpses.
+      5. If corpses are at or above the army cost and the fortress holds any
+         troops, raise a new undead unit.
+      6. No-op fallback (corpse stream keeps flowing via the passive tick).
+    """
+
+    def decide(self, game_state):
+        self.my_territories, self.enemy_territories = self.memory.update(
+            game_state, self.faction
+        )
+        self.total_army = sum(
+            data.get('army', 0) for loc, data in game_state.items()
+            if data.get('faction') == self.faction
+        )
+        self.phase = PhaseDetector.detect(
+            self.my_territories, self.enemy_territories, self.total_army
+        )
+
+        span = trace.get_current_span()
+        span.set_attribute("ai.variant", "white_walkers")
+        span.set_attribute("game.map.id", self.map_id)
+
+        corpses = fetch_faction_corpses(self.faction)
+        span.set_attribute("ai.corpse_pool", corpses)
+
+        evaluated = []
+
+        action = self._defend_fortress(game_state)
+        if action:
+            evaluated.append(f"defend_fortress: TRIGGERED ({action.get('reason', '')})")
+            self._last_evaluated = evaluated
+            return action
+        evaluated.append("defend_fortress: skipped")
+
+        action = self._capture_unowned_wall(game_state)
+        if action:
+            evaluated.append(f"capture_wall: TRIGGERED ({action.get('reason', '')})")
+            self._last_evaluated = evaluated
+            return action
+        evaluated.append("capture_wall: skipped")
+
+        action = self._reinforce_weakest_wall(game_state)
+        if action:
+            evaluated.append(f"reinforce_wall: TRIGGERED ({action.get('reason', '')})")
+            self._last_evaluated = evaluated
+            return action
+        evaluated.append("reinforce_wall: skipped")
+
+        action = self._raid_barbarian(game_state)
+        if action:
+            evaluated.append(f"raid_barbarian: TRIGGERED ({action.get('reason', '')})")
+            self._last_evaluated = evaluated
+            return action
+        evaluated.append("raid_barbarian: skipped")
+
+        action = self._raise_army_from_corpses(game_state, corpses)
+        if action:
+            evaluated.append(f"raise_army: TRIGGERED ({action.get('reason', '')})")
+            self._last_evaluated = evaluated
+            return action
+        evaluated.append("raise_army: skipped")
+
+        self._last_evaluated = evaluated
+        return self._passive_fallback()
+
+    # ── Cascade helpers ───────────────────────────────────────────────────────
+
+    def _defend_fortress(self, game_state):
+        cap_data = game_state.get(self.my_capital, {})
+        if not cap_data or cap_data.get('faction') != self.faction:
+            return None
+
+        garrison = cap_data.get('army', 0)
+        max_threat = 0
+        threat_loc = None
+        for n in self.map.neighbors(self.my_capital):
+            n_data = game_state.get(n, {})
+            n_faction = n_data.get('faction')
+            if n_faction and n_faction != self.faction and n_faction != 'barbarian':
+                if n_data.get('army', 0) > max_threat:
+                    max_threat = n_data['army']
+                    threat_loc = n
+        if max_threat == 0 or max_threat <= garrison:
+            return None
+
+        # Pull back from the strongest adjacent wall we own (if any).
+        best_source = None
+        best_army = 0
+        for wall in self._walls():
+            w_data = game_state.get(wall, {})
+            if w_data.get('faction') == self.faction and w_data.get('army', 0) > best_army:
+                best_source = wall
+                best_army = w_data['army']
+        if best_source:
+            return {
+                "action": "move_army",
+                "from": best_source,
+                "to": self.my_capital,
+                "reason": f"defend fortress vs {threat_loc} ({max_threat} army)",
+            }
+        return None
+
+    def _capture_unowned_wall(self, game_state):
+        best = None
+        best_cost = float("inf")
+        for wall in self._walls():
+            w_data = game_state.get(wall, {})
+            if w_data.get('faction') == self.faction:
+                continue
+            defender = w_data.get('army', 0)
+            # Wall multiplier = 2 — must exceed 2 * defender to take it.
+            needed = 2 * defender + 1
+            source, source_army = self._nearest_source_with_army(game_state, wall, needed)
+            if source is None:
+                continue
+            total_cost = needed
+            if total_cost < best_cost:
+                best_cost = total_cost
+                best = (source, wall, defender)
+        if best is None:
+            return None
+        source, wall, defender = best
+        return {
+            "action": "move_army",
+            "from": source,
+            "to": self._step_toward(source, wall),
+            "reason": f"capture {wall} (defender {defender}, needed {best_cost})",
+        }
+
+    def _reinforce_weakest_wall(self, game_state):
+        mine = [
+            (w, game_state.get(w, {}).get('army', 0))
+            for w in self._walls()
+            if game_state.get(w, {}).get('faction') == self.faction
+        ]
+        if not mine:
+            return None
+        weakest, _ = min(mine, key=lambda item: item[1])
+        # Look for a friendly neighbour with spare army to send.
+        for n in self.map.neighbors(weakest):
+            n_data = game_state.get(n, {})
+            if n_data.get('faction') == self.faction and n_data.get('army', 0) > 1 and n != self.my_capital:
+                return {
+                    "action": "move_army",
+                    "from": n,
+                    "to": weakest,
+                    "reason": f"reinforce {weakest} from {n}",
+                }
+        return None
+
+    def _raid_barbarian(self, game_state):
+        targets = [
+            loc for loc, t in get_location_types(self.map_id).items()
+            if t == "village"
+            and get_initial_factions(self.map_id).get(loc) == "barbarian"
+            and game_state.get(loc, {}).get('faction') == "barbarian"
+        ]
+        if not targets:
+            return None
+
+        best = None
+        best_margin = -1
+        for target in targets:
+            defender = game_state.get(target, {}).get('army', 0)
+            source, source_army = self._nearest_source_with_army(
+                game_state, target, defender + 1
+            )
+            if source is None:
+                continue
+            margin = source_army - defender
+            if margin > best_margin:
+                best_margin = margin
+                best = (source, target, defender)
+        if best is None:
+            return None
+        source, target, defender = best
+        return {
+            "action": "move_army",
+            "from": source,
+            "to": self._step_toward(source, target),
+            "reason": f"raid {target} (defender {defender}) for corpses",
+        }
+
+    def _raise_army_from_corpses(self, game_state, corpses):
+        # Only raise when the fortress has at least 1 garrison to wrap the
+        # new unit around, so the fresh army is defensible.
+        cap_data = game_state.get(self.my_capital, {})
+        if cap_data.get('faction') != self.faction or cap_data.get('army', 0) < 1:
+            return None
+        if corpses < self.army_cost:
+            return None
+        return {
+            "action": "create_army",
+            "location": self.my_capital,
+            "count": 1,
+            "reason": f"raise undead ({corpses} corpses, cost {self.army_cost})",
+        }
+
+    def _passive_fallback(self):
+        # No-op for White Walkers: the passive corpse tick handles "idle".
+        return {
+            "action": "noop",
+            "reason": "passive: corpses accumulate at fortress",
+        }
+
+    # ── Utility ───────────────────────────────────────────────────────────────
+
+    def _walls(self):
+        types = get_location_types(self.map_id)
+        return [loc for loc, t in types.items() if t == "wall"]
+
+    def _nearest_source_with_army(self, game_state, target, needed):
+        """Return the (location_id, army) of the closest friendly node with
+        at least ``needed`` troops, or ``(None, 0)`` if nothing qualifies.
+        """
+        best = (None, 0)
+        best_dist = float("inf")
+        for loc, data in game_state.items():
+            if data.get('faction') != self.faction:
+                continue
+            if data.get('army', 0) < needed:
+                continue
+            dist = self.map.distance(loc, target)
+            if dist < best_dist:
+                best = (loc, data.get('army', 0))
+                best_dist = dist
+        return best
+
+
 # ─── AI State ──────────────────────────────────────────────────────────────────
 
 class AIState:
     def __init__(self):
         self.faction = None
+        self.map_id = "war_of_kingdoms"
         self.active = False
         self.last_action_time = None
         self.game_start_time = None
@@ -797,14 +1202,37 @@ ai_state = AIState()
 # ─── Preserved Helpers ─────────────────────────────────────────────────────────
 
 def get_location_url(location_id):
-    """Get the URL for a location's API"""
+    """Get the URL for a location's API.
+
+    Container hostnames in docker-compose are the stable WoK names
+    (``southern-capital``, ``village-1`` …). On WWA the *logical* location id
+    differs (``wall_west`` → still lives on container ``village-1``), so we
+    look up the container via ``CONTAINER_FOR_LOCATION_ID`` rather than
+    naively hyphenating the location id.
+    """
     if os.environ.get('IN_DOCKER'):
-        host = location_id.replace('_', '-')
+        host = CONTAINER_FOR_LOCATION_ID.get(location_id, location_id.replace('_', '-'))
     else:
         host = 'localhost'
 
     port = LOCATION_PORTS[location_id]
     return f"http://{host}:{port}"
+
+
+def fetch_faction_corpses(faction):
+    """Query any location service for the faction's corpse pool. Returns 0 on error."""
+    # Use slot_1 (southern-capital container); any container is fine since
+    # the DB is shared.
+    try:
+        if os.environ.get('IN_DOCKER'):
+            base = "http://southern-capital:5001"
+        else:
+            base = "http://localhost:5001"
+        resp = requests.get(f"{base}/faction_economy", params={"faction": faction}, timeout=2)
+        resp.raise_for_status()
+        return int(resp.json().get("corpses", 0))
+    except Exception:
+        return 0
 
 def make_api_request(location_id, endpoint, method='GET', data=None):
     """Make an API request to a location server with trace context"""
@@ -843,17 +1271,24 @@ def make_api_request(location_id, endpoint, method='GET', data=None):
             return {"error": str(e)}
 
 def get_game_state(parent_ctx):
-    """Get the current state of all locations"""
+    """Get the current state of every location on the currently active map."""
+    # Which set of location ids belongs to this AI's map? Fall back to
+    # WoK's 8 ids if AI isn't initialised yet.
+    if ai_state.strategic_ai is not None:
+        location_ids = list(get_map_graph(ai_state.strategic_ai.map_id).keys())
+    else:
+        location_ids = list(MAP_GRAPH.keys())
+
     with tracer.start_as_current_span(
         "get_game_state",
         kind=SpanKind.INTERNAL,
         context=parent_ctx,
-        attributes={"location_count": len(LOCATION_PORTS)}
+        attributes={"location_count": len(location_ids)}
     ) as span:
         game_state = {}
         error_count = 0
 
-        for location_id in LOCATION_PORTS.keys():
+        for location_id in location_ids:
             data = make_api_request(location_id, '')
             if 'error' not in data:
                 game_state[location_id] = data
@@ -951,6 +1386,14 @@ def execute_strategic_action(action, game_state, parent_ctx, decision_link=None)
                     result = make_api_request(loc, 'send_resources_to_capital', method='POST')
                     logger.info("AI transferred resources", extra={"from_location": loc})
                 span.set_attribute("transfers_count", len(locations))
+
+            elif action_type == "noop":
+                # WhiteWalkerAI uses ``noop`` as a quiet-tick fallback when
+                # corpses are accruing but no actionable move exists. Still
+                # emit a span so replay shows the AI was awake but chose not
+                # to act.
+                span.set_attribute("ai.cycle.idle", True)
+                logger.debug("AI idle cycle", extra={"reason": reason})
 
         except Exception as e:
             span.record_exception(e)
@@ -1059,21 +1502,45 @@ def ai_decision_loop():
 
 @app.route('/activate', methods=['POST'])
 def activate_ai():
-    """Activate the AI for a specific faction"""
-    data = request.get_json()
-    faction = data.get('faction')
+    """Activate the AI for a specific faction on a specific map.
 
-    if faction not in ['southern', 'northern']:
+    Accepts ``{"faction": ..., "map_id": ...}``. Defaults to
+    War of Kingdoms when ``map_id`` is omitted (backward compat).
+    Dispatches to ``WhiteWalkerAI`` when the requested faction is
+    ``white_walkers``; otherwise uses the classic ``StrategicAI``.
+    """
+    data = request.get_json() or {}
+    faction = data.get('faction')
+    map_id = data.get('map_id', 'war_of_kingdoms')
+
+    valid_factions = set()
+    for m in CAPITALS_BY_MAP.values():
+        valid_factions.update(m.keys())
+    if faction not in valid_factions:
         return jsonify({"success": False, "message": "Invalid faction"}), 400
+
+    if map_id not in MAP_GRAPHS_BY_MAP:
+        return jsonify({"success": False, "message": f"Unknown map_id: {map_id}"}), 400
+
+    if faction not in get_capitals(map_id):
+        return jsonify({
+            "success": False,
+            "message": f"Faction {faction} is not valid on map {map_id}"
+        }), 400
 
     if ai_state.active:
         return jsonify({"success": False, "message": "AI already active"}), 400
 
     ai_state.faction = faction
+    ai_state.map_id = map_id
     ai_state.active = True
     ai_state.game_start_time = datetime.now()
     ai_state.stop_flag.clear()
-    ai_state.strategic_ai = StrategicAI(faction)
+
+    if faction == "white_walkers":
+        ai_state.strategic_ai = WhiteWalkerAI(faction, map_id=map_id)
+    else:
+        ai_state.strategic_ai = StrategicAI(faction, map_id=map_id)
 
     # Register state callback for observable gauges
     telemetry.set_state_callback(lambda: {
@@ -1082,12 +1549,28 @@ def activate_ai():
         "faction": ai_state.faction or "unknown",
     } if ai_state.strategic_ai else None)
 
+    # Corpse-pool gauge: only meaningful for White Walkers. For other AIs
+    # the callback returns None so the gauge stays unobserved.
+    def _corpse_cb():
+        if ai_state.faction == "white_walkers":
+            return ("white_walkers", fetch_faction_corpses("white_walkers"))
+        return None
+    telemetry.set_corpse_callback(_corpse_cb)
+
     # Start AI decision thread
     ai_state.decision_thread = threading.Thread(target=ai_decision_loop, daemon=True)
     ai_state.decision_thread.start()
 
-    logger.info("AI activated", extra={"faction": faction})
-    return jsonify({"success": True, "message": f"AI activated for {faction} faction"})
+    logger.info(
+        "AI activated",
+        extra={"faction": faction, "map_id": map_id, "variant": type(ai_state.strategic_ai).__name__},
+    )
+    return jsonify({
+        "success": True,
+        "message": f"AI activated for {faction} faction on {map_id}",
+        "map_id": map_id,
+        "variant": type(ai_state.strategic_ai).__name__,
+    })
 
 @app.route('/deactivate', methods=['POST'])
 def deactivate_ai():

--- a/game-of-tracing/ai_opponent/ai_server.py
+++ b/game-of-tracing/ai_opponent/ai_server.py
@@ -598,9 +598,13 @@ class StrategicAI:
 
     def _step_toward(self, from_loc, toward_loc):
         """Return the neighbor of from_loc that is closest to toward_loc."""
+        # Must consult the *active map's* adjacency, not the global
+        # ``MAP_GRAPH`` (which is hard-coded to WoK). On WWA the from_loc is
+        # e.g. ``white_walker_fortress`` — absent from the WoK graph and
+        # raises ``KeyError`` mid-cascade, leaving the AI stuck.
         best = None
         best_dist = 99
-        for n in MAP_GRAPH[from_loc]:
+        for n in self.map.graph[from_loc]:
             d = self.map.distance(n, toward_loc)
             if d < best_dist:
                 best_dist = d
@@ -1092,16 +1096,44 @@ class WhiteWalkerAI(StrategicAI):
         ]
         if not mine:
             return None
-        weakest, _ = min(mine, key=lambda item: item[1])
-        # Look for a friendly neighbour with spare army to send.
+        weakest, weakest_army = min(mine, key=lambda item: item[1])
+
+        # Prefer non-capital neighbours so corpse-driven army production at
+        # the capital isn't drained on every tick. Capital is a fallback
+        # below — without it the AI gets stuck post-capture, since
+        # ``move_army`` moves *all* army, leaving walls at 0 and capital as
+        # the only source.
+        capital_neighbour = None
         for n in self.map.neighbors(weakest):
             n_data = game_state.get(n, {})
-            if n_data.get('faction') == self.faction and n_data.get('army', 0) > 1 and n != self.my_capital:
+            if n_data.get('faction') != self.faction:
+                continue
+            n_army = n_data.get('army', 0)
+            if n_army <= 1:
+                continue
+            if n == self.my_capital:
+                capital_neighbour = (n, n_army)
+                continue
+            return {
+                "action": "move_army",
+                "from": n,
+                "to": weakest,
+                "reason": f"reinforce {weakest} from {n}",
+            }
+
+        # Capital fallback. Only fire if (a) the capital has more than the
+        # weakest wall (otherwise it's not really reinforcing) and (b) the
+        # capital has enough to spare — leaving 0 garrison is fine because
+        # ``_raise_army_from_corpses`` no longer requires a non-zero
+        # garrison to wrap a fresh unit around.
+        if capital_neighbour is not None:
+            cap_loc, cap_army = capital_neighbour
+            if cap_army > weakest_army + 1:
                 return {
                     "action": "move_army",
-                    "from": n,
+                    "from": cap_loc,
                     "to": weakest,
-                    "reason": f"reinforce {weakest} from {n}",
+                    "reason": f"reinforce {weakest} from capital ({cap_army} → wall {weakest_army})",
                 }
         return None
 
@@ -1139,10 +1171,13 @@ class WhiteWalkerAI(StrategicAI):
         }
 
     def _raise_army_from_corpses(self, game_state, corpses):
-        # Only raise when the fortress has at least 1 garrison to wrap the
-        # new unit around, so the fresh army is defensible.
+        # Capital must still belong to us — if NW captured it the AI has
+        # soft-lost. The earlier `army >= 1` gate has been dropped: it
+        # blocked the AI's primary economic loop after every capital→wall
+        # reinforcement (move_army drains the source to 0), leaving the AI
+        # idle until corpses overflowed.
         cap_data = game_state.get(self.my_capital, {})
-        if cap_data.get('faction') != self.faction or cap_data.get('army', 0) < 1:
+        if cap_data.get('faction') != self.faction:
             return None
         if corpses < self.army_cost:
             return None

--- a/game-of-tracing/ai_opponent/telemetry.py
+++ b/game-of-tracing/ai_opponent/telemetry.py
@@ -157,6 +157,21 @@ class AITelemetry:
             unit="1"
         )
 
+        # White Walkers Attack metrics (additive; only populate when the
+        # relevant callback is wired).
+        self._walls_captured_counter = self.meter.create_counter(
+            name="ai.walls_captured",
+            description="Number of wall keeps captured by this AI variant",
+            unit="1",
+        )
+        self._corpse_callback = None
+        self.meter.create_observable_gauge(
+            name="ai.corpse_pool",
+            description="White Walker corpse pool (cost pool for raising armies)",
+            callbacks=[self._observe_corpse_pool],
+            unit="1",
+        )
+
     def _observe_territory_count(self, options: CallbackOptions) -> Iterable[Observation]:
         """Callback for territory count observable gauge"""
         if self._state_callback:
@@ -186,6 +201,31 @@ class AITelemetry:
     def set_state_callback(self, fn):
         """Register a callback that returns current AI state for observable gauges"""
         self._state_callback = fn
+
+    def set_corpse_callback(self, fn):
+        """Register a callback that returns ``(faction, corpses)`` for the
+        ``ai.corpse_pool`` gauge. ``fn`` should return ``None`` when the
+        current AI variant does not use the corpse economy.
+        """
+        self._corpse_callback = fn
+
+    def _observe_corpse_pool(self, options: CallbackOptions) -> Iterable[Observation]:
+        if not self._corpse_callback:
+            return
+        try:
+            result = self._corpse_callback()
+            if not result:
+                return
+            faction, corpses = result
+            yield Observation(value=int(corpses), attributes={"faction": faction})
+        except Exception:
+            pass
+
+    def record_wall_captured(self, wall_id, source):
+        """Increment the walls-captured counter. ``source`` is the AI variant name."""
+        self._walls_captured_counter.add(
+            1, {"wall_id": wall_id, "variant": source}
+        )
 
     def record_decision(self, action_type, phase):
         """Record an AI decision metric"""

--- a/game-of-tracing/app/CLAUDE.md
+++ b/game-of-tracing/app/CLAUDE.md
@@ -4,12 +4,13 @@
 
 ## Purpose
 
-All 8 locations (2 capitals + 6 villages) run the same codebase — they differ only by `LOCATION_ID` and port. Each location:
+All 8 locations run the same codebase. A container's **slot** (set via `SLOT_ID` env var, `slot_1` … `slot_8`) is fixed at build time; the **logical identity** it serves (`southern_capital`, `wall_west`, `barbarian_village_east`, …) is resolved at boot and on `/reload` from the active map in `game_state.db`. Each location:
 
 - Owns a row in the shared `game_state.db` (resources, army, faction).
 - Exposes an HTTP API for collecting resources, creating armies, moving armies, and launching attacks.
 - Instruments every route with OpenTelemetry traces, logs, and five custom game metrics.
 - Runs passive resource generation for villages (every 15 s) and handles cooldowns for capitals.
+- On the White Walkers Attack map, also runs: passive barbarian army growth (every 30 s at barbarian villages), passive corpse generation (every 15 s at the White Walker fortress), and the wall multiplier (defenders count 2× at `wall`-type locations).
 
 Ports 5001-5008:
 
@@ -50,6 +51,8 @@ Service names (hyphenated) match the `SERVICE_NAME` resource attribute used in t
 | `POST` | `/receive_resources` | `receive_resources` | Target of `_transfer_resources_along_path` |
 | `GET` | `/health` | — | Docker health check; returns `{"status":"ok"}` |
 | `POST` | `/send_resources_to_capital` | — | Village → friendly capital resource forwarding (used by AI) |
+| `POST` | `/reload` | — | Re-read `active_map_id` + rebind slot identity in place (war_map calls this after `/select_map`) |
+| `GET` | `/faction_economy?faction=...` | — | Read a faction's corpse pool (AI uses it) |
 
 ## Key algorithms
 
@@ -132,11 +135,26 @@ See `AGENTS.md` for the full cross-service metrics table. `app/`-specific:
 
 The gauge callbacks read from live server state via `_get_location_state()`, which the `LocationServer` registers on the telemetry instance at construction time.
 
+## New mechanics (White Walkers Attack)
+
+All defined in `app/game_config.py`'s `MAPS["white_walkers_attack"]["rules"]`. All behave as no-ops on `war_of_kingdoms`.
+
+- **Wall defender multiplier** — `_handle_battle` accepts a `location_type` argument and scales `defending_army` by `rules["wall_multiplier"]` (2.0 on WWA, 1.0 on WoK) when the location type is `wall`. Remaining defender count is converted back to physical units after the fight.
+- **Corpse economy** — when the battle winner is `white_walkers`, the post-battle hook in `receive_army` calls `self._add_corpses(attacking + defending - remaining, "white_walkers")`. `create_army` reads `get_army_currency(map_id, faction)` and, for `currency == "corpses"`, atomically decrements via `_spend_corpses` instead of touching `resources`. The corpse pool lives in `faction_economy` (persistent) so a `/reload` doesn't wipe it.
+- **Barbarian passive growth** — `_start_barbarian_growth(interval_s)` runs when `faction == "barbarian"`; adds +1 army every `rules["barbarian_army_growth_interval_s"]` (30 s). Guards each iteration against identity changes via `/reload`.
+- **White Walker passive corpses** — `_start_white_walker_corpse_tick(interval_s)` runs at the WW fortress, +1 corpse every `rules["white_walker_passive_corpse_interval_s"]` (15 s).
+
+## DB additions (live in `game_state.db`)
+
+- **`game_config`** — `(key, value)` key/value store. The `active_map_id` row is authoritative; containers re-read it on boot and on `/reload`.
+- **`faction_economy`** — `(faction, corpses)`. Updated by `_add_corpses` / `_spend_corpses`. Read by the AI via `/faction_economy?faction=white_walkers`.
+
 ## Environment
 
 | Var | Default | Purpose |
 |---|---|---|
-| `LOCATION_ID` | — (required) | Which row in `LOCATIONS` this service is |
+| `SLOT_ID` | — (required, `slot_1` … `slot_8`) | Fixed physical slot this container occupies |
+| `LOCATION_ID` | — (legacy; no longer authoritative) | Kept for backward-compat with `run_game.py` local dev |
 | `PORT` | derived from `LOCATION_ID` | HTTP listen port |
 | `IN_DOCKER` | unset | When set, location URLs resolve via container DNS (`village-2:5004`) instead of `localhost:5004` |
 | `DATABASE_FILE` | `/data/game_state.db` (Docker) / `./game_state.db` (local) | SQLite WAL-mode DB |

--- a/game-of-tracing/app/CLAUDE.md
+++ b/game-of-tracing/app/CLAUDE.md
@@ -10,7 +10,7 @@ All 8 locations run the same codebase. A container's **slot** (set via `SLOT_ID`
 - Exposes an HTTP API for collecting resources, creating armies, moving armies, and launching attacks.
 - Instruments every route with OpenTelemetry traces, logs, and five custom game metrics.
 - Runs passive resource generation for villages (every 15 s) and handles cooldowns for capitals.
-- On the White Walkers Attack map, also runs: passive barbarian army growth (every 30 s at barbarian villages), passive corpse generation (every 15 s at the White Walker fortress), and the wall multiplier (defenders count 2× at `wall`-type locations).
+- On the White Walkers Attack map, also runs: passive barbarian army growth (every 30 s at barbarian villages), passive corpse generation (every 15 s at the White Walker fortress), passive resource generation at the Night's Watch capital (+5 every 10 s — WWA has no friendly villages, so this replaces the click-only economy), and the wall multiplier (defenders count 2× at `wall`-type locations).
 
 Ports 5001-5008:
 
@@ -142,7 +142,9 @@ All defined in `app/game_config.py`'s `MAPS["white_walkers_attack"]["rules"]`. A
 - **Wall defender multiplier** — `_handle_battle` accepts a `location_type` argument and scales `defending_army` by `rules["wall_multiplier"]` (2.0 on WWA, 1.0 on WoK) when the location type is `wall`. Remaining defender count is converted back to physical units after the fight.
 - **Corpse economy** — when the battle winner is `white_walkers`, the post-battle hook in `receive_army` calls `self._add_corpses(attacking + defending - remaining, "white_walkers")`. `create_army` reads `get_army_currency(map_id, faction)` and, for `currency == "corpses"`, atomically decrements via `_spend_corpses` instead of touching `resources`. The corpse pool lives in `faction_economy` (persistent) so a `/reload` doesn't wipe it.
 - **Barbarian passive growth** — `_start_barbarian_growth(interval_s)` runs when `faction == "barbarian"`; adds +1 army every `rules["barbarian_army_growth_interval_s"]` (30 s). Guards each iteration against identity changes via `/reload`.
+- **Captured-camp resource generation** — `_start_passive_generation()` is launched for *every* `type == "village"` slot at boot (including barbarian Free Folk camps). The per-iteration `faction != "barbarian"` guard keeps it a no-op while the camp is still barbarian, then it starts producing the standard village amount the moment the player captures it. Without this fallthrough, captured camps stayed unproductive because the thread was never started on barbarian slots.
 - **White Walker passive corpses** — `_start_white_walker_corpse_tick(interval_s)` runs at the WW fortress, +1 corpse every `rules["white_walker_passive_corpse_interval_s"]` (15 s).
+- **Night's Watch passive resources** — `_start_nights_watch_capital_resource_tick(interval_s, amount)` runs at Castle Black on WWA (`faction == "nights_watch"`, `loc_type == "capital"`), adding `rules["nights_watch_capital_passive_amount"]` resources every `rules["nights_watch_capital_passive_interval_s"]` (5 per 10 s). Manual `/collect_resources` (+20, 5 s cooldown) still works alongside.
 
 ## DB additions (live in `game_state.db`)
 

--- a/game-of-tracing/app/game_config.py
+++ b/game-of-tracing/app/game_config.py
@@ -278,6 +278,13 @@ MAPS = {
             "wall_multiplier": 2.0,
             "barbarian_army_growth_interval_s": 30,
             "white_walker_passive_corpse_interval_s": 15,
+            # WWA gives the Night's Watch no friendly villages, so its only
+            # income source is /collect_resources at Castle Black. Add a slow
+            # passive trickle so the resource HUD ticks up without click-spam.
+            # Keep it well below the click rate (+20 per 5 s) — passive should
+            # supplement, not replace, active play.
+            "nights_watch_capital_passive_amount": 5,
+            "nights_watch_capital_passive_interval_s": 10,
             "tick_interval_s": 30,
             "win_hold_ticks": 5,
         },

--- a/game-of-tracing/app/game_config.py
+++ b/game-of-tracing/app/game_config.py
@@ -1,95 +1,334 @@
+"""Game configuration for all maps in the game-of-tracing scenario.
+
+Each entry in ``MAPS`` describes a playable map. A map has:
+
+- ``display_name`` / ``description`` — surfaced by the map picker UI.
+- ``single_player`` + ``player_faction`` / ``ai_faction`` — the map picker uses
+  these to skip faction selection and auto-activate the AI when appropriate.
+- ``factions`` — the valid faction strings for this map.
+- ``slot_assignments`` — maps the fixed container slot ids (``slot_1`` …
+  ``slot_8``) to the logical location id that slot serves on this map. The 8
+  location containers carry only their ``SLOT_ID`` — their in-game identity
+  is resolved at boot (and on ``/reload``) via this table.
+- ``locations`` — per-location config (name, type, faction, connections,
+  initial resources/army, port).
+- ``rules`` — map-wide game rules (army costs and currency per faction, wall
+  multiplier, tick interval, hold-to-win ticks, passive growth intervals).
+
+The active map id is stored at runtime in the shared ``game_state.db`` in the
+``game_config`` key-value table (written by ``war_map`` on ``/select_map``).
+Both ``location_server`` and ``war_map`` read it to resolve per-service state.
 """
-Game configuration for War of Kingdoms
 
-This file defines the game map, locations, and initial state
-"""
+from __future__ import annotations
 
-# Define locations
-LOCATIONS = {
-    "southern_capital": {
-        "name": "Southern Capital",
-        "type": "capital",
-        "faction": "southern",
-        "connections": ["village_1", "village_3"],
-        "initial_resources": 100,
-        "initial_army": 1,
-        "port": 5001
+DATABASE_FILE = "game_state.db"
+DEFAULT_MAP_ID = "war_of_kingdoms"
+
+# Each of the 8 location containers has a fixed SLOT_ID env var
+# (slot_1 .. slot_8). Its in-game identity is resolved through the active
+# map's slot_assignments table, so the same container can serve "village_1" on
+# War of Kingdoms and "wall_west" on White Walkers Attack.
+SLOT_IDS = tuple(f"slot_{i}" for i in range(1, 9))
+
+
+MAPS = {
+    "war_of_kingdoms": {
+        "display_name": "War of Kingdoms",
+        "description": (
+            "Northern and Southern kingdoms clash for dominance. "
+            "Capture the enemy capital to win."
+        ),
+        "single_player": False,
+        "factions": ["northern", "southern"],
+        "slot_assignments": {
+            "slot_1": "southern_capital",
+            "slot_2": "northern_capital",
+            "slot_3": "village_1",
+            "slot_4": "village_2",
+            "slot_5": "village_3",
+            "slot_6": "village_4",
+            "slot_7": "village_5",
+            "slot_8": "village_6",
+        },
+        "locations": {
+            "southern_capital": {
+                "name": "Southern Capital",
+                "type": "capital",
+                "faction": "southern",
+                "connections": ["village_1", "village_3"],
+                "initial_resources": 100,
+                "initial_army": 1,
+                "port": 5001,
+            },
+            "northern_capital": {
+                "name": "Northern Capital",
+                "type": "capital",
+                "faction": "northern",
+                "connections": ["village_2", "village_6"],
+                "initial_resources": 100,
+                "initial_army": 1,
+                "port": 5002,
+            },
+            "village_1": {
+                "name": "Village 1",
+                "type": "village",
+                "faction": "neutral",
+                "connections": ["southern_capital", "village_2", "village_4"],
+                "initial_resources": 50,
+                "initial_army": 2,
+                "port": 5003,
+            },
+            "village_2": {
+                "name": "Village 2",
+                "type": "village",
+                "faction": "neutral",
+                "connections": ["northern_capital", "village_1", "village_5"],
+                "initial_resources": 50,
+                "initial_army": 3,
+                "port": 5004,
+            },
+            "village_3": {
+                "name": "Village 3",
+                "type": "village",
+                "faction": "neutral",
+                "connections": ["southern_capital", "village_5", "village_6"],
+                "initial_resources": 50,
+                "initial_army": 2,
+                "port": 5005,
+            },
+            "village_4": {
+                "name": "Village 4",
+                "type": "village",
+                "faction": "neutral",
+                "connections": ["village_1", "village_5"],
+                "initial_resources": 50,
+                "initial_army": 1,
+                "port": 5006,
+            },
+            "village_5": {
+                "name": "Village 5",
+                "type": "village",
+                "faction": "neutral",
+                "connections": ["village_2", "village_3", "village_4", "village_6"],
+                "initial_resources": 50,
+                "initial_army": 4,
+                "port": 5007,
+            },
+            "village_6": {
+                "name": "Village 6",
+                "type": "village",
+                "faction": "neutral",
+                "connections": ["northern_capital", "village_3", "village_5"],
+                "initial_resources": 50,
+                "initial_army": 2,
+                "port": 5008,
+            },
+        },
+        "rules": {
+            "resource_generation": {"capital": 20, "village": 10},
+            "army_cost": {"default": 30},
+            "army_currency": {"default": "resources"},
+            "wall_multiplier": 1.0,
+            "barbarian_army_growth_interval_s": 0,
+            "white_walker_passive_corpse_interval_s": 0,
+            "tick_interval_s": 0,
+            "win_hold_ticks": 0,
+        },
     },
-    "northern_capital": {
-        "name": "Northern Capital",
-        "type": "capital",
-        "faction": "northern",
-        "connections": ["village_2", "village_6"],
-        "initial_resources": 100,
-        "initial_army": 1,
-        "port": 5002
+    "white_walkers_attack": {
+        "display_name": "White Walkers Attack",
+        "description": (
+            "The Long Night has come. As the Night's Watch, hold every Wall "
+            "keep for 5 ticks (150 s) before the White Walkers do. Single-player."
+        ),
+        "single_player": True,
+        "player_faction": "nights_watch",
+        "ai_faction": "white_walkers",
+        "factions": ["nights_watch", "white_walkers", "barbarian"],
+        "slot_assignments": {
+            "slot_1": "nights_watch_fortress",
+            "slot_2": "white_walker_fortress",
+            "slot_3": "wall_west",
+            "slot_4": "wall_center_west",
+            "slot_5": "wall_center_east",
+            "slot_6": "wall_east",
+            "slot_7": "barbarian_village_west",
+            "slot_8": "barbarian_village_east",
+        },
+        "locations": {
+            "nights_watch_fortress": {
+                "name": "Castle Black",
+                "type": "capital",
+                "faction": "nights_watch",
+                "connections": [
+                    "wall_west",
+                    "wall_center_west",
+                    "wall_center_east",
+                    "wall_east",
+                ],
+                "initial_resources": 150,
+                "initial_army": 3,
+                "port": 5001,
+            },
+            "white_walker_fortress": {
+                "name": "The Lands of Always Winter",
+                "type": "capital",
+                "faction": "white_walkers",
+                "connections": [
+                    "wall_west",
+                    "wall_center_west",
+                    "wall_center_east",
+                    "wall_east",
+                ],
+                # White Walkers spend corpses, not resources. Keep the column
+                # populated so the DB row shape stays uniform; the create_army
+                # handler reads currency from the map rules.
+                "initial_resources": 0,
+                "initial_army": 2,
+                "port": 5002,
+            },
+            "wall_west": {
+                "name": "Westwatch",
+                "type": "wall",
+                "faction": "neutral",
+                "connections": [
+                    "nights_watch_fortress",
+                    "white_walker_fortress",
+                    "wall_center_west",
+                    "barbarian_village_west",
+                ],
+                "initial_resources": 0,
+                "initial_army": 1,
+                "port": 5003,
+            },
+            "wall_center_west": {
+                "name": "Queensgate",
+                "type": "wall",
+                "faction": "neutral",
+                "connections": [
+                    "nights_watch_fortress",
+                    "white_walker_fortress",
+                    "wall_west",
+                    "wall_center_east",
+                ],
+                "initial_resources": 0,
+                "initial_army": 1,
+                "port": 5004,
+            },
+            "wall_center_east": {
+                "name": "Deep Lake",
+                "type": "wall",
+                "faction": "neutral",
+                "connections": [
+                    "nights_watch_fortress",
+                    "white_walker_fortress",
+                    "wall_center_west",
+                    "wall_east",
+                ],
+                "initial_resources": 0,
+                "initial_army": 1,
+                "port": 5005,
+            },
+            "wall_east": {
+                "name": "Eastwatch-by-the-Sea",
+                "type": "wall",
+                "faction": "neutral",
+                "connections": [
+                    "nights_watch_fortress",
+                    "white_walker_fortress",
+                    "wall_center_east",
+                    "barbarian_village_east",
+                ],
+                "initial_resources": 0,
+                "initial_army": 1,
+                "port": 5006,
+            },
+            "barbarian_village_west": {
+                "name": "Free Folk Camp (West)",
+                "type": "village",
+                "faction": "barbarian",
+                "connections": ["wall_west"],
+                "initial_resources": 0,
+                "initial_army": 2,
+                "port": 5007,
+            },
+            "barbarian_village_east": {
+                "name": "Free Folk Camp (East)",
+                "type": "village",
+                "faction": "barbarian",
+                "connections": ["wall_east"],
+                "initial_resources": 0,
+                "initial_army": 2,
+                "port": 5008,
+            },
+        },
+        "rules": {
+            # Night's Watch capital collects resources on the classic schedule.
+            # White Walker fortress ignores resource_generation (uses corpses).
+            "resource_generation": {"capital": 20, "village": 10},
+            "army_cost": {
+                "default": 30,
+                "white_walkers": 5,
+            },
+            "army_currency": {
+                "default": "resources",
+                "white_walkers": "corpses",
+            },
+            "wall_multiplier": 2.0,
+            "barbarian_army_growth_interval_s": 30,
+            "white_walker_passive_corpse_interval_s": 15,
+            "tick_interval_s": 30,
+            "win_hold_ticks": 5,
+        },
     },
-    "village_1": {
-        "name": "Village 1",
-        "type": "village",
-        "faction": "neutral",
-        "connections": ["southern_capital", "village_2", "village_4"],
-        "initial_resources": 50,
-        "initial_army": 2,
-        "port": 5003
-    },
-    "village_2": {
-        "name": "Village 2",
-        "type": "village",
-        "faction": "neutral",
-        "connections": ["northern_capital", "village_1", "village_5"],
-        "initial_resources": 50,
-        "initial_army": 3,
-        "port": 5004
-    },
-    "village_3": {
-        "name": "Village 3",
-        "type": "village",
-        "faction": "neutral",
-        "connections": ["southern_capital", "village_5", "village_6"],
-        "initial_resources": 50,
-        "initial_army": 2,
-        "port": 5005
-    },
-    "village_4": {
-        "name": "Village 4",
-        "type": "village",
-        "faction": "neutral",
-        "connections": ["village_1", "village_5"],
-        "initial_resources": 50,
-        "initial_army": 1,
-        "port": 5006
-    },
-    "village_5": {
-        "name": "Village 5",
-        "type": "village",
-        "faction": "neutral",
-        "connections": ["village_2", "village_3", "village_4", "village_6"],
-        "initial_resources": 50,
-        "initial_army": 4,
-        "port": 5007
-    },
-    "village_6": {
-        "name": "Village 6",
-        "type": "village",
-        "faction": "neutral",
-        "connections": ["northern_capital", "village_3", "village_5"],
-        "initial_resources": 50,
-        "initial_army": 2,
-        "port": 5008
-    }
 }
 
-# Resource generation per turn
-RESOURCE_GENERATION = {
-    "capital": 20,
-    "village": 10
-}
+# Backward-compat exports: unchanged shape for callers that don't know about
+# maps yet. These always reflect the War of Kingdoms defaults.
+LOCATIONS = MAPS[DEFAULT_MAP_ID]["locations"]
+RESOURCE_GENERATION = MAPS[DEFAULT_MAP_ID]["rules"]["resource_generation"]
+COSTS = {"create_army": MAPS[DEFAULT_MAP_ID]["rules"]["army_cost"]["default"]}
 
-# Costs
-COSTS = {
-    "create_army": 30
-}
 
-# Game state database
-DATABASE_FILE = "game_state.db" 
+def get_map(map_id):
+    """Return the full map-config dict for ``map_id``."""
+    if map_id not in MAPS:
+        raise KeyError(f"Unknown map_id: {map_id}")
+    return MAPS[map_id]
+
+
+def resolve_slot(map_id, slot_id):
+    """Return the location_id the given slot serves on the given map."""
+    return MAPS[map_id]["slot_assignments"][slot_id]
+
+
+def get_location_config(map_id, location_id):
+    """Return the per-location config dict for (map_id, location_id)."""
+    return MAPS[map_id]["locations"][location_id]
+
+
+def get_rules(map_id):
+    """Return the ``rules`` dict for ``map_id``."""
+    return MAPS[map_id]["rules"]
+
+
+def get_army_cost(map_id, faction):
+    """Return the army-creation cost for ``faction`` on ``map_id``."""
+    costs = MAPS[map_id]["rules"]["army_cost"]
+    return costs.get(faction, costs["default"])
+
+
+def get_army_currency(map_id, faction):
+    """Return ``"resources"`` or ``"corpses"`` for ``faction`` on ``map_id``."""
+    currencies = MAPS[map_id]["rules"]["army_currency"]
+    return currencies.get(faction, currencies["default"])
+
+
+def locations_by_type(map_id, type_name):
+    """Return the list of location_ids on ``map_id`` of the given ``type_name``."""
+    return [
+        lid
+        for lid, cfg in MAPS[map_id]["locations"].items()
+        if cfg["type"] == type_name
+    ]

--- a/game-of-tracing/app/location_server.py
+++ b/game-of-tracing/app/location_server.py
@@ -87,6 +87,7 @@ class LocationServer:
         self._passive_thread_started = False
         self._barbarian_thread_started = False
         self._corpse_thread_started = False
+        self._nw_capital_thread_started = False
 
         self._initialize_database()
         self._load_identity()
@@ -164,7 +165,13 @@ class LocationServer:
         faction = self.location_info["faction"]
         rules = self._current_rules()
 
-        if loc_type == "village" and faction != "barbarian" and not self._passive_thread_started:
+        # Launch the village resource thread for *every* village, including
+        # barbarian-faction slots (Free Folk camps). The thread guards each
+        # iteration on ``faction != "barbarian"``, so it stays a no-op while
+        # the camp is still barbarian and starts producing for the player
+        # the moment they capture it. Without this fallthrough, captured
+        # camps stay unproductive because the thread was never started.
+        if loc_type == "village" and not self._passive_thread_started:
             self._start_passive_generation()
             self._passive_thread_started = True
 
@@ -183,6 +190,17 @@ class LocationServer:
             if interval > 0:
                 self._start_white_walker_corpse_tick(interval)
                 self._corpse_thread_started = True
+
+        if (
+            loc_type == "capital"
+            and faction == "nights_watch"
+            and not self._nw_capital_thread_started
+        ):
+            interval = rules.get("nights_watch_capital_passive_interval_s", 0) or 0
+            amount = rules.get("nights_watch_capital_passive_amount", 0) or 0
+            if interval > 0 and amount > 0:
+                self._start_nights_watch_capital_resource_tick(interval, amount)
+                self._nw_capital_thread_started = True
 
     # ----------------------------------------------------------------
     # Corpse economy (faction-scoped; lives in faction_economy table)
@@ -241,9 +259,12 @@ class LocationServer:
         return None
 
     def _get_db_connection(self):
-        conn = sqlite3.connect(self.db_path)
-        conn.execute("PRAGMA journal_mode=WAL")
+        # ``timeout`` applies before the first PRAGMA runs, so concurrent
+        # boot of all 8 containers doesn't race on ``PRAGMA journal_mode=WAL``
+        # (which briefly acquires an exclusive lock to switch modes).
+        conn = sqlite3.connect(self.db_path, timeout=15)
         conn.execute("PRAGMA busy_timeout=5000")
+        conn.execute("PRAGMA journal_mode=WAL")
         conn.row_factory = sqlite3.Row
         return conn
 
@@ -660,9 +681,19 @@ class LocationServer:
         def generate_resources():
             while True:
                 time.sleep(15)
-                # Guard against identity changes: if /reload flipped this slot
-                # to a non-village identity, stop producing resources silently.
-                if self.location_info["type"] != "village" or self.location_info["faction"] == "barbarian":
+                # Static identity guards against /reload moving this slot off
+                # of a village type entirely.
+                if self.location_info["type"] != "village":
+                    continue
+                # Live-DB guard: gate on the *current* faction, not the
+                # boot-time identity, so a captured Free Folk camp starts
+                # producing for the new owner the moment its row flips. The
+                # static ``self.location_info["faction"]`` is set at boot
+                # from MAPS config and never updates on battle.
+                location_state = self._get_location_state(self.location_id)
+                if location_state is None:
+                    continue
+                if location_state["faction"] == "barbarian":
                     continue
                 amount = self._current_rules()["resource_generation"]["village"]
                 with self.tracer.start_as_current_span(
@@ -671,13 +702,10 @@ class LocationServer:
                         "location.id": self.location_id,
                         "resources_gained": amount,
                         "game.map.id": self.map_id,
+                        "owner.faction": location_state["faction"],
                     }
                 ):
-                    location_state = self._get_location_state(self.location_id)
-                    if location_state is None:
-                        continue
-                    current_resources = location_state["resources"]
-                    new_resources = current_resources + amount
+                    new_resources = location_state["resources"] + amount
                     self._update_location_state(self.location_id, resources=new_resources)
                     self.telemetry.collect_metrics()
 
@@ -714,6 +742,41 @@ class LocationServer:
                     self.telemetry.collect_metrics()
 
         Thread(target=grow, daemon=True).start()
+
+    def _start_nights_watch_capital_resource_tick(self, interval_s: int, amount: int):
+        """Passive resource generation at the Night's Watch capital (WWA only).
+
+        WWA gives the player no friendly villages, so /collect_resources at
+        Castle Black is the only income source — leading to click-spam UX. A
+        slow passive tick supplements that without removing the incentive to
+        actively collect (manual is +20 per 5 s; passive is +amount per
+        interval_s, configured well below that).
+        """
+        def tick():
+            while True:
+                time.sleep(interval_s)
+                if (self.location_info["faction"] != "nights_watch"
+                    or self.location_info["type"] != "capital"):
+                    continue
+                with self.tracer.start_as_current_span(
+                    "nights_watch_passive_resource",
+                    attributes={
+                        "location.id": self.location_id,
+                        "game.map.id": self.map_id,
+                        "resources_gained": amount,
+                    }
+                ):
+                    state = self._get_location_state(self.location_id)
+                    if state is None:
+                        continue
+                    if state["faction"] != "nights_watch":
+                        continue
+                    self._update_location_state(
+                        self.location_id, resources=state["resources"] + amount
+                    )
+                    self.telemetry.collect_metrics()
+
+        Thread(target=tick, daemon=True).start()
 
     def _start_white_walker_corpse_tick(self, interval_s: int):
         """Passive corpse generation at the White Walker fortress.

--- a/game-of-tracing/app/location_server.py
+++ b/game-of-tracing/app/location_server.py
@@ -1,9 +1,34 @@
-"""Location server implementation."""
+"""Location server implementation.
+
+Each of the 8 location containers has a constant ``SLOT_ID`` env var
+(``slot_1`` … ``slot_8``). The in-game identity a slot serves (e.g.
+``southern_capital`` in War of Kingdoms, ``wall_west`` in White Walkers
+Attack) is resolved at boot and on ``/reload`` via the active map stored
+in the shared ``game_config`` key-value table. See ``game_config.MAPS``.
+
+The per-container SERVICE_NAME (used by Grafana dashboards) stays stable
+regardless of map — it's derived from ``LOCATION_NAME`` env / slot id, not
+from the logical location id.
+"""
 import os, sqlite3, requests, random, time, threading, atexit
 from threading import Thread, Lock
 from datetime import datetime, timedelta
 from flask import Flask, jsonify, request
-from game_config import LOCATIONS, COSTS, RESOURCE_GENERATION, DATABASE_FILE
+from game_config import (
+    MAPS,
+    COSTS,
+    DATABASE_FILE,
+    DEFAULT_MAP_ID,
+    LOCATIONS,
+    RESOURCE_GENERATION,
+    SLOT_IDS,
+    get_army_cost,
+    get_army_currency,
+    get_location_config,
+    get_map,
+    get_rules,
+    resolve_slot,
+)
 from telemetry import GameTelemetry
 from opentelemetry.propagate import extract, inject
 from opentelemetry import trace
@@ -17,32 +42,203 @@ class PathType(Enum):
     ATTACK = 'attack'
 
 class LocationServer:
-    def __init__(self, location_id):
-        self.location_id = location_id
-        self.location_info = LOCATIONS[location_id]
+    def __init__(self, slot_or_location=None):
+        # Accept either a slot id (new, preferred) or a legacy location id
+        # (for backward compat with local dev scripts). Falls back to env.
+        raw = slot_or_location or os.environ.get('SLOT_ID')
+        if raw in SLOT_IDS:
+            self.slot_id = raw
+        elif raw in MAPS[DEFAULT_MAP_ID]["locations"]:
+            # Legacy: caller passed a War of Kingdoms location id; resolve to
+            # its slot via the reverse map.
+            inverse = {v: k for k, v in MAPS[DEFAULT_MAP_ID]["slot_assignments"].items()}
+            self.slot_id = inverse[raw]
+        else:
+            raise ValueError(
+                f"Cannot determine SLOT_ID from {raw!r}; expected one of {SLOT_IDS} "
+                f"or a War of Kingdoms location id."
+            )
+
         self.app = Flask(__name__)
         self.last_resource_collection = {}
         self.resource_cooldown = {}
         self.lock = Lock()
-        
-        # Initialize telemetry with consistent service name
-        # Always use hyphenated lowercase for service names
-        service_name = location_id.replace('_', '-')
+
+        # SERVICE_NAME must stay stable across map switches so Grafana
+        # dashboards keep their series. Prefer the explicit LOCATION_NAME env
+        # (matches container name in docker-compose); else synthesise from the
+        # slot id.
+        service_name = os.environ.get('LOCATION_NAME') or self.slot_id.replace('_', '-')
         self.telemetry = GameTelemetry(service_name=service_name)
         self.logger = self.telemetry.get_logger()
         self.tracer = self.telemetry.get_tracer()
-        
+
         # Give telemetry access to location state
         self.telemetry._get_location_state = self._get_location_state
-        
-        self.setup_routes()
+        # And access to faction-scoped economy (for the corpse gauge).
+        self.telemetry._get_corpse_count = self._get_corpses
+
         self.db_path = os.environ.get('DATABASE_FILE', DATABASE_FILE)
+
+        # Populated by _load_identity().
+        self.map_id = DEFAULT_MAP_ID
+        self.location_id = None
+        self.location_info = None
+        self._passive_thread_started = False
+        self._barbarian_thread_started = False
+        self._corpse_thread_started = False
+
         self._initialize_database()
-        
-        if self.location_info["type"] == "village":
-            self._start_passive_generation()
+        self._load_identity()
+        self.setup_routes()
 
         atexit.register(self.telemetry.shutdown)
+
+    # ----------------------------------------------------------------
+    # Map / slot identity resolution
+    # ----------------------------------------------------------------
+
+    def _current_locations(self) -> Dict:
+        """Return the active map's ``location_id → config`` dict."""
+        return MAPS[self.map_id]["locations"]
+
+    def _current_rules(self) -> Dict:
+        return MAPS[self.map_id]["rules"]
+
+    def _read_active_map_id(self) -> str:
+        conn = self._get_db_connection()
+        try:
+            row = conn.execute(
+                "SELECT value FROM game_config WHERE key = 'active_map_id'"
+            ).fetchone()
+        finally:
+            conn.close()
+        return row['value'] if row else DEFAULT_MAP_ID
+
+    def _load_identity(self):
+        """Resolve slot → (map, location_id, config); seed this slot's row."""
+        self.map_id = self._read_active_map_id()
+        self.location_id = resolve_slot(self.map_id, self.slot_id)
+        self.location_info = get_location_config(self.map_id, self.location_id)
+
+        # Publish live identity to the telemetry instance so the observable
+        # gauges report the currently-served id, not whatever id was derived
+        # from the container's SERVICE_NAME at boot.
+        self.telemetry._location_id = self.location_id
+        self.telemetry._location_type = self.location_info["type"]
+
+        # Seed this slot's row in the locations table if missing. Idempotent:
+        # INSERT OR IGNORE handles the case where war_map already re-seeded.
+        conn = self._get_db_connection()
+        try:
+            conn.execute(
+                "INSERT OR IGNORE INTO locations (id, resources, army, faction) VALUES (?, ?, ?, ?)",
+                (
+                    self.location_id,
+                    self.location_info["initial_resources"],
+                    self.location_info["initial_army"],
+                    self.location_info["faction"],
+                ),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        self._start_passive_threads_if_needed()
+
+        self.logger.info(
+            f"Identity loaded: slot={self.slot_id} map={self.map_id} "
+            f"location_id={self.location_id} type={self.location_info['type']} "
+            f"faction={self.location_info['faction']}"
+        )
+
+    def _start_passive_threads_if_needed(self):
+        """Kick off whichever passive loop matches this slot's identity.
+
+        Threads are started at most once per process lifetime. If a slot's
+        identity changes through ``/reload``, the *old* thread keeps running
+        but becomes a no-op because it guards each iteration against the
+        current location type/faction.
+        """
+        loc_type = self.location_info["type"]
+        faction = self.location_info["faction"]
+        rules = self._current_rules()
+
+        if loc_type == "village" and faction != "barbarian" and not self._passive_thread_started:
+            self._start_passive_generation()
+            self._passive_thread_started = True
+
+        if faction == "barbarian" and not self._barbarian_thread_started:
+            interval = rules.get("barbarian_army_growth_interval_s", 0) or 0
+            if interval > 0:
+                self._start_barbarian_growth(interval)
+                self._barbarian_thread_started = True
+
+        if (
+            loc_type == "capital"
+            and faction == "white_walkers"
+            and not self._corpse_thread_started
+        ):
+            interval = rules.get("white_walker_passive_corpse_interval_s", 0) or 0
+            if interval > 0:
+                self._start_white_walker_corpse_tick(interval)
+                self._corpse_thread_started = True
+
+    # ----------------------------------------------------------------
+    # Corpse economy (faction-scoped; lives in faction_economy table)
+    # ----------------------------------------------------------------
+
+    def _get_corpses(self, faction: str = "white_walkers") -> int:
+        conn = self._get_db_connection()
+        try:
+            row = conn.execute(
+                "SELECT corpses FROM faction_economy WHERE faction = ?", (faction,)
+            ).fetchone()
+        finally:
+            conn.close()
+        return int(row['corpses']) if row else 0
+
+    def _add_corpses(self, delta: int, faction: str = "white_walkers"):
+        if delta <= 0:
+            return
+        conn = self._get_db_connection()
+        try:
+            conn.execute(
+                "INSERT INTO faction_economy (faction, corpses) VALUES (?, ?) "
+                "ON CONFLICT(faction) DO UPDATE SET corpses = corpses + excluded.corpses",
+                (faction, delta),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+    def _spend_corpses(self, amount: int, faction: str = "white_walkers") -> bool:
+        """Atomically decrement ``faction``'s corpse pool. Returns True on success."""
+        conn = self._get_db_connection()
+        try:
+            cursor = conn.execute(
+                "UPDATE faction_economy SET corpses = corpses - ? "
+                "WHERE faction = ? AND corpses >= ?",
+                (amount, faction, amount),
+            )
+            conn.commit()
+            return cursor.rowcount > 0
+        finally:
+            conn.close()
+
+    def _find_capital(self, faction: str) -> Optional[str]:
+        """Return the location_id of the capital with the given faction in the active map, by static config."""
+        for loc_id, cfg in self._current_locations().items():
+            if cfg["type"] == "capital" and cfg["faction"] == faction:
+                return loc_id
+        return None
+
+    def _find_enemy_capital(self, faction: str) -> Optional[str]:
+        """Return the location_id of a capital not belonging to ``faction`` (and not barbarian), by static config."""
+        for loc_id, cfg in self._current_locations().items():
+            if cfg["type"] == "capital" and cfg["faction"] not in (faction, "barbarian"):
+                return loc_id
+        return None
 
     def _get_db_connection(self):
         conn = sqlite3.connect(self.db_path)
@@ -54,7 +250,8 @@ class LocationServer:
     def _initialize_database(self):
         conn = self._get_db_connection()
         cursor = conn.cursor()
-        
+
+        # Canonical per-location state.
         cursor.execute('''
         CREATE TABLE IF NOT EXISTS locations (
             id TEXT PRIMARY KEY,
@@ -63,15 +260,30 @@ class LocationServer:
             faction TEXT NOT NULL
         )
         ''')
-        
-        cursor.execute("SELECT COUNT(*) FROM locations")
-        if cursor.fetchone()[0] == 0:
-            for loc_id, loc_info in LOCATIONS.items():
-                cursor.execute(
-                    "INSERT INTO locations VALUES (?, ?, ?, ?)",
-                    (loc_id, loc_info["initial_resources"], loc_info["initial_army"], loc_info["faction"])
-                )
-            conn.commit()
+
+        # Key/value game-wide config; holds active_map_id (authoritative at
+        # runtime; overrides whatever the process started with).
+        cursor.execute('''
+        CREATE TABLE IF NOT EXISTS game_config (
+            key TEXT PRIMARY KEY,
+            value TEXT NOT NULL
+        )
+        ''')
+        cursor.execute(
+            "INSERT OR IGNORE INTO game_config (key, value) VALUES ('active_map_id', ?)",
+            (DEFAULT_MAP_ID,),
+        )
+
+        # Faction-scoped economy (White Walkers' corpse pool today; room for
+        # additional faction-level currencies later).
+        cursor.execute('''
+        CREATE TABLE IF NOT EXISTS faction_economy (
+            faction TEXT PRIMARY KEY,
+            corpses INTEGER NOT NULL DEFAULT 0
+        )
+        ''')
+
+        conn.commit()
         conn.close()
 
     def _get_location_state(self, location_id):
@@ -126,22 +338,26 @@ class LocationServer:
         return True
 
     def _find_path(self, target: str, path_type: PathType) -> Optional[List[str]]:
-        """Unified pathfinding for both resources and armies."""
+        """Unified pathfinding for both resources and armies on the active map."""
+        locations = self._current_locations()
         location_state = self._get_location_state(self.location_id)
         faction = location_state["faction"]
-        
-        if path_type == PathType.RESOURCE and faction not in ['southern', 'northern']:
+
+        # Resource routing only makes sense for factions that have a resource
+        # economy. ``barbarian`` and ``white_walkers`` don't send resources.
+        resource_factions = {"southern", "northern", "nights_watch"}
+        if path_type == PathType.RESOURCE and faction not in resource_factions:
             return None
-            
-        distances = {loc: float('infinity') for loc in LOCATIONS.keys()}
+
+        distances = {loc: float('infinity') for loc in locations.keys()}
         distances[self.location_id] = 0
-        previous = {loc: None for loc in LOCATIONS.keys()}
-        unvisited = set(LOCATIONS.keys())
-        
+        previous = {loc: None for loc in locations.keys()}
+        unvisited = set(locations.keys())
+
         def get_weight(loc_id: str) -> float:
             state = self._get_location_state(loc_id)
-            loc_faction = state["faction"]
-            
+            loc_faction = state["faction"] if state else "neutral"
+
             if path_type == PathType.RESOURCE:
                 if loc_faction == faction:
                     return 1
@@ -154,55 +370,78 @@ class LocationServer:
                 elif loc_faction == "neutral":
                     return 2
                 return 3
-        
+
         while unvisited:
             current = min(unvisited, key=lambda loc: distances[loc])
             if current == target:
                 break
-                
+
             unvisited.remove(current)
-            for neighbor in LOCATIONS[current]["connections"]:
+            for neighbor in locations[current]["connections"]:
                 if neighbor in unvisited:
                     weight = get_weight(neighbor)
                     distance = distances[current] + weight
-                    
+
                     if distance < distances[neighbor]:
                         distances[neighbor] = distance
                         previous[neighbor] = current
-        
+
         if previous[target] is None:
             return None
-            
+
         path = []
         current = target
         while current is not None:
             path.append(current)
             current = previous[current]
-        
+
         return list(reversed(path))
 
-    def _handle_battle(self, attacking_army: int, attacking_faction: str, 
-                      defending_army: int, defending_faction: str) -> tuple[str, int, str]:
-        """Handle battle between armies and return result."""
-        # Same faction = reinforcement
+    def _handle_battle(self, attacking_army: int, attacking_faction: str,
+                      defending_army: int, defending_faction: str,
+                      location_type: Optional[str] = None) -> tuple[str, int, str]:
+        """Handle battle between armies and return ``(result, remaining_army, new_faction)``.
+
+        ``location_type`` lets the active map's rules modify the fight. For
+        ``wall`` settlements on a map with ``wall_multiplier`` > 1 the defender's
+        effective strength is scaled up — the physical garrison plays harder to
+        dislodge, but the ``remaining_army`` reported back is converted back to
+        physical units so DB rows stay honest.
+        """
+        # Same faction = reinforcement. Multiplier never applies.
         if attacking_faction == defending_faction:
             self.logger.info(f"Reinforcement battle between {attacking_faction} armies")
             self.telemetry.record_battle(attacking_faction, defending_faction, "reinforcement")
             return "reinforcement", attacking_army + defending_army, attacking_faction
-        
-        # Actual combat
-        if attacking_army > defending_army:
-            self.logger.info(f"Attacker victory: {attacking_army} vs {defending_army}")
-            remaining = attacking_army - defending_army
+
+        multiplier = 1.0
+        if location_type == "wall":
+            multiplier = float(self._current_rules().get("wall_multiplier", 1.0) or 1.0)
+        effective_defender = int(defending_army * multiplier)
+
+        if attacking_army > effective_defender:
+            remaining = attacking_army - effective_defender
+            self.logger.info(
+                f"Attacker victory: {attacking_army} vs {defending_army} "
+                f"(effective {effective_defender}, mult {multiplier}) -> {remaining}"
+            )
             self.telemetry.record_battle(attacking_faction, defending_faction, "attacker_victory")
             return "attacker_victory", remaining, attacking_faction
-        elif defending_army > attacking_army:
-            remaining = defending_army - attacking_army
-            self.logger.info(f"Defender victory: {defending_army} vs {attacking_army}")
+        elif effective_defender > attacking_army:
+            # Convert defender's surviving *effective* strength back to physical.
+            effective_remaining = effective_defender - attacking_army
+            remaining = max(1, int(effective_remaining / multiplier)) if multiplier > 0 else effective_remaining
+            self.logger.info(
+                f"Defender victory: {defending_army} vs {attacking_army} "
+                f"(effective {effective_defender}, mult {multiplier}) -> {remaining}"
+            )
             self.telemetry.record_battle(attacking_faction, defending_faction, "defender_victory")
             return "defender_victory", remaining, defending_faction
         else:
-            self.logger.info(f"Stalemate: {attacking_army} vs {defending_army}")
+            self.logger.info(
+                f"Stalemate: {attacking_army} vs {defending_army} "
+                f"(effective {effective_defender}, mult {multiplier})"
+            )
             self.telemetry.record_battle(attacking_faction, defending_faction, "stalemate")
             return "stalemate", 0, defending_faction
 
@@ -384,53 +623,146 @@ class LocationServer:
             self.resource_cooldown[self.location_id] = datetime.now() + timedelta(seconds=5)
 
     def get_location_url(self, location_id):
-        port = LOCATIONS[location_id]["port"]
-        if os.environ.get('LOCATION_ID'):
-            docker_service_name = location_id.replace('_', '-')
+        """Return the HTTP base URL for reaching another location service.
+
+        Uses the active map's port assignment; falls back to WoK's port for a
+        legacy id if the location isn't on the current map (shouldn't happen
+        during a coherent game but guards against transition races).
+        """
+        locations = self._current_locations()
+        if location_id in locations:
+            port = locations[location_id]["port"]
+        else:
+            port = MAPS[DEFAULT_MAP_ID]["locations"][location_id]["port"]
+        if os.environ.get('IN_DOCKER') or os.environ.get('LOCATION_ID'):
+            docker_service_name = self._container_for(location_id)
             return f"http://{docker_service_name}:{port}"
         return f"http://localhost:{port}"
+
+    def _container_for(self, location_id: str) -> str:
+        """Return the stable container hostname for another location id.
+
+        Containers are named after their *slot* (slot_1 → southern-capital in
+        docker-compose, which is slot_1's stable identity). We reverse-look up
+        the slot that currently serves ``location_id`` on the active map, then
+        translate that slot back to its container hostname using the WoK
+        default slot assignments (which match docker-compose service names).
+        """
+        active = MAPS[self.map_id]["slot_assignments"]
+        wok = MAPS[DEFAULT_MAP_ID]["slot_assignments"]
+        for slot, active_loc in active.items():
+            if active_loc == location_id:
+                return wok[slot].replace('_', '-')
+        # Unknown id — best-effort: use the hyphenated form.
+        return location_id.replace('_', '-')
 
     def _start_passive_generation(self):
         def generate_resources():
             while True:
                 time.sleep(15)
+                # Guard against identity changes: if /reload flipped this slot
+                # to a non-village identity, stop producing resources silently.
+                if self.location_info["type"] != "village" or self.location_info["faction"] == "barbarian":
+                    continue
+                amount = self._current_rules()["resource_generation"]["village"]
                 with self.tracer.start_as_current_span(
                     "passive_resource_generation",
                     attributes={
                         "location.id": self.location_id,
-                        "resources_gained": RESOURCE_GENERATION["village"]
+                        "resources_gained": amount,
+                        "game.map.id": self.map_id,
                     }
                 ):
                     location_state = self._get_location_state(self.location_id)
+                    if location_state is None:
+                        continue
                     current_resources = location_state["resources"]
-                    new_resources = current_resources + RESOURCE_GENERATION["village"]
+                    new_resources = current_resources + amount
                     self._update_location_state(self.location_id, resources=new_resources)
-                    # Force metric collection after passive resource generation
                     self.telemetry.collect_metrics()
 
         Thread(target=generate_resources, daemon=True).start()
 
+    def _start_barbarian_growth(self, interval_s: int):
+        """Barbarian villages grow +1 army every ``interval_s`` seconds.
+
+        Barbarians never initiate combat; they exist to pressure the map and
+        feed the White Walker corpse economy. The thread self-gates against
+        identity changes so it becomes a no-op if /reload moves this slot off
+        a barbarian role.
+        """
+        def grow():
+            while True:
+                time.sleep(interval_s)
+                if self.location_info["faction"] != "barbarian":
+                    continue
+                with self.tracer.start_as_current_span(
+                    "barbarian_passive_growth",
+                    attributes={
+                        "location.id": self.location_id,
+                        "game.map.id": self.map_id,
+                        "army_gained": 1,
+                    }
+                ):
+                    state = self._get_location_state(self.location_id)
+                    if state is None:
+                        continue
+                    # Only grow while still barbarian-controlled.
+                    if state["faction"] != "barbarian":
+                        continue
+                    self._update_location_state(self.location_id, army=state["army"] + 1)
+                    self.telemetry.collect_metrics()
+
+        Thread(target=grow, daemon=True).start()
+
+    def _start_white_walker_corpse_tick(self, interval_s: int):
+        """Passive corpse generation at the White Walker fortress.
+
+        Simulates the undead slowly rising — keeps the WW economy nonzero even
+        when no battles are happening. Corpses accrue to the faction pool.
+        """
+        def tick():
+            while True:
+                time.sleep(interval_s)
+                if self.location_info["faction"] != "white_walkers" or self.location_info["type"] != "capital":
+                    continue
+                with self.tracer.start_as_current_span(
+                    "white_walker_corpse_tick",
+                    attributes={
+                        "location.id": self.location_id,
+                        "game.map.id": self.map_id,
+                        "game.corpses.harvested": 1,
+                        "corpse.source": "passive",
+                    }
+                ):
+                    self._add_corpses(1, "white_walkers")
+                    self.telemetry.collect_metrics()
+
+        Thread(target=tick, daemon=True).start()
+
     def reset_database(self):
-        """Reset the database to initial state."""
+        """Reset every location row + the corpse pool to the active map's initial state."""
         conn = self._get_db_connection()
         cursor = conn.cursor()
-        
+
         cursor.execute("DELETE FROM locations")
-        
-        for loc_id, loc_info in LOCATIONS.items():
+
+        for loc_id, loc_info in self._current_locations().items():
             cursor.execute(
                 "INSERT INTO locations VALUES (?, ?, ?, ?)",
                 (
                     loc_id,
                     loc_info["initial_resources"],
                     loc_info["initial_army"],
-                    loc_info["faction"]
-                )
+                    loc_info["faction"],
+                ),
             )
-        
+
+        cursor.execute("DELETE FROM faction_economy")
+
         conn.commit()
         conn.close()
-        self.logger.info("Database reset to initial state")
+        self.logger.info(f"Database reset to initial state for map {self.map_id}")
 
     def setup_routes(self):
         @self.app.route('/', methods=['GET'])
@@ -499,8 +831,8 @@ class LocationServer:
                     }), 200  # Return 200 for cooldown, as it's an expected state
                 
                 location_type = self.location_info["type"]
-                resources_gained = RESOURCE_GENERATION[location_type]
-                
+                resources_gained = self._current_rules()["resource_generation"].get(location_type, 0)
+
                 location_state = self._get_location_state(self.location_id)
                 new_resources = location_state["resources"] + resources_gained
                 self._update_location_state(self.location_id, resources=new_resources)
@@ -525,14 +857,15 @@ class LocationServer:
         def create_army():
             # Extract trace context from request headers
             context = extract(request.headers)
-            
+
             with self.tracer.start_as_current_span(
                 "create_army",
                 context=context,
                 kind=SpanKind.SERVER,
                 attributes={
                     "location_name": self.location_info["name"],
-                    "location_type": self.location_info["type"]
+                    "location_type": self.location_info["type"],
+                    "game.map.id": self.map_id,
                 }
             ) as span:
                 if self.location_info["type"] != "capital":
@@ -541,43 +874,63 @@ class LocationServer:
                         "success": False,
                         "message": "Only capitals can create armies"
                     }), 403
-                
+
                 location_state = self._get_location_state(self.location_id)
                 current_resources = location_state["resources"]
                 current_army = location_state["army"]
-                cost = COSTS["create_army"]
-                
+                faction = location_state["faction"]
+                currency = get_army_currency(self.map_id, faction)
+                cost = get_army_cost(self.map_id, faction)
+
                 span.set_attribute("current_resources", current_resources)
                 span.set_attribute("current_army", current_army)
                 span.set_attribute("army_cost", cost)
-                
-                if current_resources < cost:
-                    span.set_status(trace.StatusCode.ERROR, "Insufficient resources")
-                    return jsonify({
-                        "success": False,
-                        "message": f"Not enough resources. Need {cost}, have {current_resources}"
-                    }), 400
-                
-                new_resources = current_resources - cost
-                new_army = current_army + 1
-                
-                self._update_location_state(
-                    self.location_id,
-                    resources=new_resources,
-                    army=new_army
-                )
-                
+                span.set_attribute("army_currency", currency)
+                span.set_attribute("faction", faction)
+
+                if currency == "corpses":
+                    # White Walkers spend corpses from the faction pool, not
+                    # resources from the location.
+                    if not self._spend_corpses(cost, faction):
+                        available = self._get_corpses(faction)
+                        span.set_status(trace.StatusCode.ERROR, "Insufficient corpses")
+                        return jsonify({
+                            "success": False,
+                            "message": f"Not enough corpses. Need {cost}, have {available}"
+                        }), 400
+                    new_resources = current_resources
+                    new_army = current_army + 1
+                    self._update_location_state(self.location_id, army=new_army)
+                    span.set_attribute("game.corpses.spent", cost)
+                    span.set_attribute("corpses_remaining", self._get_corpses(faction))
+                else:
+                    if current_resources < cost:
+                        span.set_status(trace.StatusCode.ERROR, "Insufficient resources")
+                        return jsonify({
+                            "success": False,
+                            "message": f"Not enough resources. Need {cost}, have {current_resources}"
+                        }), 400
+
+                    new_resources = current_resources - cost
+                    new_army = current_army + 1
+
+                    self._update_location_state(
+                        self.location_id,
+                        resources=new_resources,
+                        army=new_army
+                    )
+
                 span.set_attribute("new_resources", new_resources)
                 span.set_attribute("new_army", new_army)
-                
-                # Force metric collection after army creation
+
                 self.telemetry.collect_metrics()
-                
+
                 return jsonify({
                     "success": True,
                     "message": "Army created",
                     "current_army": new_army,
-                    "current_resources": new_resources
+                    "current_resources": new_resources,
+                    "currency": currency,
                 })
         
         @self.app.route('/move_army', methods=['POST'])
@@ -688,8 +1041,14 @@ class LocationServer:
                             "message": "No army available for attack"
                         }), 400
                     
-                    # Determine enemy capital based on faction
-                    target_capital = "northern_capital" if faction == "southern" else "southern_capital"
+                    # Determine enemy capital based on the active map's config.
+                    target_capital = self._find_enemy_capital(faction)
+                    if not target_capital:
+                        attack_span.set_status(trace.StatusCode.ERROR, "No enemy capital on this map")
+                        return jsonify({
+                            "success": False,
+                            "message": "No enemy capital to attack on this map"
+                        }), 400
                     attack_span.set_attribute("target_capital", target_capital)
                     
                     attack_path = self._find_path(target_capital, PathType.ATTACK)
@@ -851,17 +1210,32 @@ class LocationServer:
                         attacking_army,
                         attacking_faction,
                         defending_army,
-                        defending_faction
+                        defending_faction,
+                        location_type=self.location_info["type"],
                     )
-                    
+
+                    # Corpse harvesting: the White Walkers reap from any battle
+                    # they win (either as attacker or defender). Corpses equal
+                    # the total physical units that died on both sides.
+                    if new_faction == "white_walkers":
+                        dead = max(0, attacking_army + defending_army - remaining_army)
+                        if dead > 0:
+                            self._add_corpses(dead, "white_walkers")
+                            battle_span.set_attribute("game.corpses.harvested", dead)
+                            battle_span.set_attribute("corpse.source", "battle")
+
                     self._update_location_state(
                         self.location_id,
                         army=remaining_army,
                         faction=new_faction
                     )
-                    
+
                     battle_span.set_attribute("result", battle_result)
                     battle_span.set_attribute("remaining_army", remaining_army)
+                    battle_span.set_attribute("game.map.id", self.map_id)
+                    if self.location_info["type"] == "wall":
+                        battle_span.set_attribute("game.wall.held", new_faction != "neutral")
+                        battle_span.set_attribute("span.wall.battle", True)
                     
                     if battle_result == "attacker_victory" and is_attack_move and remaining_path:
                         self.logger.info(f"Continuing army movement at {self.location_id}: {remaining_army}")
@@ -903,6 +1277,34 @@ class LocationServer:
         def reset():
             self.reset_database()
             return jsonify({"success": True, "message": "Game state reset to initial values"})
+
+        @self.app.route('/reload', methods=['POST'])
+        def reload_identity():
+            """Re-read the active map from the DB and rebind this slot's identity.
+
+            Called by ``war_map`` after ``/select_map``. The slot's port + the
+            telemetry service name do not change — only the logical
+            ``location_id``, ``name``, ``type``, ``faction``, connections, and
+            rules-scoped behaviour.
+            """
+            self._load_identity()
+            return jsonify({
+                "success": True,
+                "slot_id": self.slot_id,
+                "map_id": self.map_id,
+                "location_id": self.location_id,
+                "faction": self.location_info["faction"],
+                "type": self.location_info["type"],
+            })
+
+        @self.app.route('/faction_economy', methods=['GET'])
+        def faction_economy():
+            """Expose the corpse pool for a faction (used by the AI)."""
+            faction = request.args.get('faction', 'white_walkers')
+            return jsonify({
+                "faction": faction,
+                "corpses": self._get_corpses(faction),
+            })
         
         @self.app.route('/send_resources_to_capital', methods=['POST'])
         def send_resources_to_capital():
@@ -934,16 +1336,25 @@ class LocationServer:
                             "message": "Only villages can send resources to capital"
                         }), 403
                     
-                    if faction not in ['southern', 'northern']:
-                        span.set_status(trace.StatusCode.ERROR, "Village must belong to a faction")
-                        self.logger.error(f"Village must belong to a faction to send resources")
+                    resource_factions = {"southern", "northern", "nights_watch"}
+                    if faction not in resource_factions:
+                        span.set_status(trace.StatusCode.ERROR, "Faction has no resource economy")
+                        self.logger.error(
+                            f"Faction {faction!r} has no resource economy; cannot send to capital"
+                        )
                         return jsonify({
                             "success": False,
-                            "message": "Village must belong to a faction to send resources"
+                            "message": "This faction does not send resources",
                         }), 403
-                    
-                    # Determine target capital based on faction
-                    target_capital = "southern_capital" if faction == "southern" else "northern_capital"
+
+                    # Target this faction's capital on the active map.
+                    target_capital = self._find_capital(faction)
+                    if not target_capital:
+                        span.set_status(trace.StatusCode.ERROR, "No friendly capital on this map")
+                        return jsonify({
+                            "success": False,
+                            "message": "No friendly capital to send resources to"
+                        }), 400
                     path = self._find_path(target_capital, PathType.RESOURCE)
                     if not path:
                         span.set_status(trace.StatusCode.ERROR, "No valid path to capital")
@@ -1079,5 +1490,12 @@ class LocationServer:
     
     def run(self):
         port = self.location_info["port"]
-        self.app.run(host='0.0.0.0', port=port) 
+        self.app.run(host='0.0.0.0', port=port)
         self.logger.info(f"Location server running on port {port}")
+
+
+if __name__ == '__main__':
+    # Docker entrypoint: read SLOT_ID env var, resolve identity from the
+    # shared active_map_id, and serve. SERVICE_NAME comes from LOCATION_NAME
+    # (set per-container in docker-compose.yml) or is synthesised from slot.
+    LocationServer().run()

--- a/game-of-tracing/app/telemetry.py
+++ b/game-of-tracing/app/telemetry.py
@@ -173,11 +173,34 @@ class GameTelemetry:
         # Log that metrics have been set up
         self.logger.info("Game metrics initialized")
 
+    # Faction → numeric value for the ``game.location_control`` gauge.
+    # Existing WoK values (0/1/2) preserved for dashboard backward compat;
+    # new factions appended with fresh values.
+    _FACTION_VALUE = {
+        "neutral": 0,
+        "northern": 1,
+        "southern": 2,
+        "nights_watch": 3,
+        "white_walkers": 4,
+        "barbarian": 5,
+    }
+
+    def _active_location_id(self):
+        """Return the currently served logical location id.
+
+        ``LocationServer`` sets ``self._location_id`` on the telemetry instance
+        at boot and refreshes it on ``/reload``. Fall back to the legacy
+        ``service_name.replace('-', '_')`` pattern for non-slot deployments.
+        """
+        return getattr(self, "_location_id", None) or self.service_name.replace("-", "_")
+
+    def _active_location_type(self):
+        return getattr(self, "_location_type", None) or "village"
+
     def _observe_resources(self, options: CallbackOptions) -> Iterable[Observation]:
         """Callback to observe current resources"""
         try:
-            from game_config import LOCATIONS
-            location_id = self.service_name.replace("-", "_")
+            location_id = self._active_location_id()
             if hasattr(self, '_get_location_state'):
                 state = self._get_location_state(location_id)
                 if state:
@@ -186,7 +209,7 @@ class GameTelemetry:
                         value=state["resources"],
                         attributes={
                             "location": self.service_name,
-                            "location_type": LOCATIONS[location_id]["type"]
+                            "location_type": self._active_location_type(),
                         }
                     )
         except Exception as e:
@@ -195,8 +218,7 @@ class GameTelemetry:
     def _observe_army_size(self, options: CallbackOptions) -> Iterable[Observation]:
         """Callback to observe current army size"""
         try:
-            from game_config import LOCATIONS
-            location_id = self.service_name.replace("-", "_")
+            location_id = self._active_location_id()
             if hasattr(self, '_get_location_state'):
                 state = self._get_location_state(location_id)
                 if state:
@@ -205,8 +227,8 @@ class GameTelemetry:
                         value=state["army"],
                         attributes={
                             "location": self.service_name,
-                            "location_type": LOCATIONS[location_id]["type"],
-                            "faction": state["faction"]
+                            "location_type": self._active_location_type(),
+                            "faction": state["faction"],
                         }
                     )
         except Exception as e:
@@ -216,7 +238,7 @@ class GameTelemetry:
         """Callback to observe resource transfer cooldown"""
         try:
             from datetime import datetime
-            location_id = self.service_name.replace("-", "_")
+            location_id = self._active_location_id()
             if hasattr(self, 'resource_cooldown') and location_id in self.resource_cooldown:
                 cooldown = self.resource_cooldown[location_id]
                 now = datetime.now()
@@ -233,27 +255,22 @@ class GameTelemetry:
             self.logger.error(f"Error observing resource cooldown: {e}")
 
     def _observe_location_control(self, options: CallbackOptions) -> Iterable[Observation]:
-        """Callback to observe location control status"""
+        """Callback to observe location control status."""
         try:
-            from game_config import LOCATIONS
-            location_id = self.service_name.replace("-", "_")
+            location_id = self._active_location_id()
             if hasattr(self, '_get_location_state'):
                 state = self._get_location_state(location_id)
                 if state:
-                    # Convert faction to numeric value for the gauge
-                    faction_value = {
-                        "northern": 1,
-                        "southern": 2,
-                        "neutral": 0
-                    }.get(state["faction"], -1)
-                    
-                    self.logger.debug(f"Observing control for {location_id}: {state['faction']} ({faction_value})")
+                    faction_value = self._FACTION_VALUE.get(state["faction"], -1)
+                    self.logger.debug(
+                        f"Observing control for {location_id}: {state['faction']} ({faction_value})"
+                    )
                     yield Observation(
                         value=faction_value,
                         attributes={
                             "location": self.service_name,
-                            "location_type": LOCATIONS[location_id]["type"],
-                            "faction": state["faction"]
+                            "location_type": self._active_location_type(),
+                            "faction": state["faction"],
                         }
                     )
         except Exception as e:

--- a/game-of-tracing/docker-compose.yml
+++ b/game-of-tracing/docker-compose.yml
@@ -305,6 +305,7 @@ services:
       - "8080:8080"
     environment:
       - DATABASE_FILE=/data/game_state.db
+      - GAME_SESSIONS_DB=/data/game_sessions.db
       - LOCATION_NAME=war-map
       - SECRET_KEY=war_of_westeros_secret_key
       - IN_DOCKER=1

--- a/game-of-tracing/docker-compose.yml
+++ b/game-of-tracing/docker-compose.yml
@@ -88,14 +88,16 @@ services:
     ports:
       - "5001:5001"
     environment:
+      - SLOT_ID=slot_1
       - LOCATION_ID=southern_capital
       - FLASK_APP=location_server.py
       - LOCATION_NAME=southern-capital
       - DATABASE_FILE=/data/game_state.db
       - PYROSCOPE_SERVER_ADDRESS=http://alloy:9999
+      - IN_DOCKER=1
     volumes:
       - game-data:/data
-    command: ["python", "-c", "from location_server import LocationServer; server = LocationServer('southern_capital'); server.run()"]
+    command: ["python", "location_server.py"]
     healthcheck:
       test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:5001/health')"]
       interval: 5s
@@ -113,14 +115,16 @@ services:
     ports:
       - "5002:5002"
     environment:
+      - SLOT_ID=slot_2
       - LOCATION_ID=northern_capital
       - FLASK_APP=location_server.py
       - LOCATION_NAME=northern-capital
       - DATABASE_FILE=/data/game_state.db
       - PYROSCOPE_SERVER_ADDRESS=http://alloy:9999
+      - IN_DOCKER=1
     volumes:
       - game-data:/data
-    command: ["python", "-c", "from location_server import LocationServer; server = LocationServer('northern_capital'); server.run()"]
+    command: ["python", "location_server.py"]
     healthcheck:
       test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:5002/health')"]
       interval: 5s
@@ -138,14 +142,16 @@ services:
     ports:
       - "5003:5003"
     environment:
+      - SLOT_ID=slot_3
       - LOCATION_ID=village_1
       - FLASK_APP=location_server.py
       - LOCATION_NAME=village-1
       - DATABASE_FILE=/data/game_state.db
       - PYROSCOPE_SERVER_ADDRESS=http://alloy:9999
+      - IN_DOCKER=1
     volumes:
       - game-data:/data
-    command: ["python", "-c", "from location_server import LocationServer; server = LocationServer('village_1'); server.run()"]
+    command: ["python", "location_server.py"]
     healthcheck:
       test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:5003/health')"]
       interval: 5s
@@ -163,14 +169,16 @@ services:
     ports:
       - "5004:5004"
     environment:
+      - SLOT_ID=slot_4
       - LOCATION_ID=village_2
       - FLASK_APP=location_server.py
       - LOCATION_NAME=village-2
       - DATABASE_FILE=/data/game_state.db
       - PYROSCOPE_SERVER_ADDRESS=http://alloy:9999
+      - IN_DOCKER=1
     volumes:
       - game-data:/data
-    command: ["python", "-c", "from location_server import LocationServer; server = LocationServer('village_2'); server.run()"]
+    command: ["python", "location_server.py"]
     healthcheck:
       test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:5004/health')"]
       interval: 5s
@@ -188,14 +196,16 @@ services:
     ports:
       - "5005:5005"
     environment:
+      - SLOT_ID=slot_5
       - LOCATION_ID=village_3
       - FLASK_APP=location_server.py
       - LOCATION_NAME=village-3
       - DATABASE_FILE=/data/game_state.db
       - PYROSCOPE_SERVER_ADDRESS=http://alloy:9999
+      - IN_DOCKER=1
     volumes:
       - game-data:/data
-    command: ["python", "-c", "from location_server import LocationServer; server = LocationServer('village_3'); server.run()"]
+    command: ["python", "location_server.py"]
     healthcheck:
       test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:5005/health')"]
       interval: 5s
@@ -213,14 +223,16 @@ services:
     ports:
       - "5006:5006"
     environment:
+      - SLOT_ID=slot_6
       - LOCATION_ID=village_4
       - FLASK_APP=location_server.py
       - LOCATION_NAME=village-4
       - DATABASE_FILE=/data/game_state.db
       - PYROSCOPE_SERVER_ADDRESS=http://alloy:9999
+      - IN_DOCKER=1
     volumes:
       - game-data:/data
-    command: ["python", "-c", "from location_server import LocationServer; server = LocationServer('village_4'); server.run()"]
+    command: ["python", "location_server.py"]
     healthcheck:
       test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:5006/health')"]
       interval: 5s
@@ -238,14 +250,16 @@ services:
     ports:
       - "5007:5007"
     environment:
+      - SLOT_ID=slot_7
       - LOCATION_ID=village_5
       - FLASK_APP=location_server.py
       - LOCATION_NAME=village-5
       - DATABASE_FILE=/data/game_state.db
       - PYROSCOPE_SERVER_ADDRESS=http://alloy:9999
+      - IN_DOCKER=1
     volumes:
       - game-data:/data
-    command: ["python", "-c", "from location_server import LocationServer; server = LocationServer('village_5'); server.run()"]
+    command: ["python", "location_server.py"]
     healthcheck:
       test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:5007/health')"]
       interval: 5s
@@ -263,14 +277,16 @@ services:
     ports:
       - "5008:5008"
     environment:
+      - SLOT_ID=slot_8
       - LOCATION_ID=village_6
       - FLASK_APP=location_server.py
       - LOCATION_NAME=village-6
       - DATABASE_FILE=/data/game_state.db
       - PYROSCOPE_SERVER_ADDRESS=http://alloy:9999
+      - IN_DOCKER=1
     volumes:
       - game-data:/data
-    command: ["python", "-c", "from location_server import LocationServer; server = LocationServer('village_6'); server.run()"]
+    command: ["python", "location_server.py"]
     healthcheck:
       test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:5008/health')"]
       interval: 5s

--- a/game-of-tracing/war_map/CLAUDE.md
+++ b/game-of-tracing/war_map/CLAUDE.md
@@ -37,13 +37,17 @@
 | File | Owner | Purpose |
 |---|---|---|
 | `game_state.db` | All 8 location services (WAL mode, shared) | Canonical game state |
-| `game_sessions.db` | `war_map` **only** | `game_actions` table: `(game_session_id, action_sequence, action_type, player_name, faction, trace_id, span_id, location_id, target_location_id, timestamp, game_state_after)` |
+| `game_sessions.db` | `war_map` **only** | `game_actions` table: `(game_session_id, action_sequence, action_type, player_name, faction, trace_id, span_id, location_id, target_location_id, timestamp, game_state_after, map_id)` |
 
 `game_actions` schema is defined in `init_game_session_tracking()` at `app.py:60-96`. It carries a `UNIQUE(game_session_id, action_sequence)` constraint — the sequence is what lets "next action" look up "previous action" deterministically.
 
 ### Storing an action — `store_game_action()` at `app.py:101-128`
 
-Called at the tail of every action handler. Reads the current max `action_sequence` for the session, inserts a new row with `next_sequence = max + 1`, returns the sequence number.
+Called at the tail of every action handler. Reads the current max `action_sequence` for the session, inserts a new row with `next_sequence = max + 1`, returns the sequence number. Persists the active `map_id` (defaults to `get_active_map_id()` when callers don't pass one) so the replay UI can render the correct map layout for each session.
+
+### Resolving a session's map — `get_session_map_id()`
+
+Used by `replay_session_page` to pick the right layout. Reads the first non-NULL `map_id` from the session's actions (cheap — sessions don't switch maps mid-play), falls back to the active map, then to `DEFAULT_MAP_ID`. Without this, the replay template renders the WoK layout regardless of which map was actually played.
 
 ### Reconstructing a previous span context — `get_previous_action_context()` at `app.py:130-170`
 

--- a/game-of-tracing/war_map/CLAUDE.md
+++ b/game-of-tracing/war_map/CLAUDE.md
@@ -6,12 +6,14 @@
 
 `war-map` is the human-facing surface of the game and the coordination point for everything the player touches:
 
-- Renders the interactive SVG game map (territory ownership, army sizes, supply routes).
+- Hosts the **map picker** (`/map_picker` + `/select_map`) that lets the user choose between `war_of_kingdoms` and `white_walkers_attack`, then renders the faction selection (or single-player auto-start) for the chosen map.
+- Renders the interactive game map (territory ownership, army sizes, supply routes, wall-hold HUD for WWA).
 - Manages faction selection, sessions, and the human player's identity.
-- Is the **sole writer** of the `game_actions` SQLite table — the record of every action's trace/span IDs that makes span-link replay possible.
-- Activates / deactivates the AI opponent on behalf of the player.
+- Is the **sole writer** of the `game_actions` SQLite table — the record of every action's trace/span IDs that makes span-link replay possible (rows carry a `map_id` column).
+- Activates / deactivates the AI opponent on behalf of the player (auto-activates as `white_walkers` when the chosen map is WWA).
 - Proxies trace-replay queries to Tempo and falls back to local SQLite when Tempo is unavailable.
 - Instruments player actions as `SERVER` spans with `trace.Link`s chaining each action to the previous one in the session.
+- Runs the **wall-hold tick thread** (`_wall_tick_thread`, 30 s cadence) that increments `wall_hold` when one faction owns every wall keep, and declares the WWA winner at 5 consecutive ticks.
 
 ## File map
 

--- a/game-of-tracing/war_map/app.py
+++ b/game-of-tracing/war_map/app.py
@@ -2,6 +2,7 @@ import os
 import json
 import sqlite3
 import requests
+import threading
 import uuid
 import time
 import atexit
@@ -31,31 +32,134 @@ GAME_OVER = False
 WINNER = None
 VICTORY_MESSAGE = None
 
-# Location positions and connections for the map
-LOCATION_POSITIONS = {
-    "southern_capital": {"name": "Southern Capital", "x": 20, "y": 80, "type": "capital"},
-    "northern_capital": {"name": "Northern Capital", "x": 80, "y": 20, "type": "capital"},
-    "village_1": {"name": "Village 1", "x": 35, "y": 60, "type": "village"},
-    "village_2": {"name": "Village 2", "x": 65, "y": 40, "type": "village"},
-    "village_3": {"name": "Village 3", "x": 15, "y": 50, "type": "village"},
-    "village_4": {"name": "Village 4", "x": 50, "y": 70, "type": "village"},
-    "village_5": {"name": "Village 5", "x": 50, "y": 30, "type": "village"},
-    "village_6": {"name": "Village 6", "x": 85, "y": 50, "type": "village"}
+# ----------------------------------------------------------------
+# Maps — in-UI picker metadata.
+# Full per-location config lives in app/game_config.py. This is a compact
+# read-only duplicate of the fields war_map actually needs: layout for the
+# canvas, tick rules for the hold-to-win loop, faction/AI wiring for the
+# picker screen. Keep the map-id strings in sync with app/game_config.py.
+# ----------------------------------------------------------------
+DEFAULT_MAP_ID = "war_of_kingdoms"
+
+MAPS_META = {
+    "war_of_kingdoms": {
+        "display_name": "War of Kingdoms",
+        "description": (
+            "Northern and Southern kingdoms clash for dominance. "
+            "Capture the enemy capital to win."
+        ),
+        "single_player": False,
+        "player_faction": None,
+        "ai_faction": None,
+        "factions": ["northern", "southern"],
+        "tick_interval_s": 0,
+        "win_hold_ticks": 0,
+        "icon": "fa-chess-knight",
+    },
+    "white_walkers_attack": {
+        "display_name": "White Walkers Attack",
+        "description": (
+            "The Long Night has come. As the Night's Watch, hold every Wall "
+            "keep for 5 ticks before the White Walkers do. Single-player."
+        ),
+        "single_player": True,
+        "player_faction": "nights_watch",
+        "ai_faction": "white_walkers",
+        "factions": ["nights_watch", "white_walkers", "barbarian"],
+        "tick_interval_s": 30,
+        "win_hold_ticks": 5,
+        "icon": "fa-icicles",
+    },
 }
 
-LOCATION_CONNECTIONS = [
-    ["southern_capital", "village_1"],
-    ["southern_capital", "village_3"],
-    ["northern_capital", "village_2"],
-    ["northern_capital", "village_6"],
-    ["village_1", "village_2"],
-    ["village_1", "village_4"],
-    ["village_2", "village_5"],
-    ["village_3", "village_5"],
-    ["village_3", "village_6"],
-    ["village_4", "village_5"],
-    ["village_5", "village_6"]
-]
+# Map layout — canvas x/y percentages per location. Each map's keys must
+# match the location ids in app/game_config.py's MAPS[map_id]["locations"].
+LOCATION_POSITIONS_BY_MAP = {
+    "war_of_kingdoms": {
+        "southern_capital": {"x": 20, "y": 70, "type": "capital", "name": "Southern Capital"},
+        "northern_capital": {"x": 80, "y": 20, "type": "capital", "name": "Northern Capital"},
+        "village_1": {"x": 35, "y": 55, "type": "village", "name": "Village 1"},
+        "village_2": {"x": 65, "y": 35, "type": "village", "name": "Village 2"},
+        "village_3": {"x": 30, "y": 40, "type": "village", "name": "Village 3"},
+        "village_4": {"x": 45, "y": 65, "type": "village", "name": "Village 4"},
+        "village_5": {"x": 50, "y": 50, "type": "village", "name": "Village 5"},
+        "village_6": {"x": 70, "y": 45, "type": "village", "name": "Village 6"},
+    },
+    "white_walkers_attack": {
+        "nights_watch_fortress": {"x": 50, "y": 85, "type": "capital", "name": "Castle Black"},
+        "white_walker_fortress": {"x": 50, "y": 15, "type": "capital", "name": "The Lands of Always Winter"},
+        "wall_west": {"x": 20, "y": 50, "type": "wall", "name": "Westwatch"},
+        "wall_center_west": {"x": 40, "y": 50, "type": "wall", "name": "Queensgate"},
+        "wall_center_east": {"x": 60, "y": 50, "type": "wall", "name": "Deep Lake"},
+        "wall_east": {"x": 80, "y": 50, "type": "wall", "name": "Eastwatch-by-the-Sea"},
+        "barbarian_village_west": {"x": 10, "y": 72, "type": "village", "name": "Free Folk Camp (West)"},
+        "barbarian_village_east": {"x": 90, "y": 72, "type": "village", "name": "Free Folk Camp (East)"},
+    },
+}
+
+LOCATION_CONNECTIONS_BY_MAP = {
+    "war_of_kingdoms": [
+        ["southern_capital", "village_1"],
+        ["southern_capital", "village_3"],
+        ["northern_capital", "village_2"],
+        ["northern_capital", "village_6"],
+        ["village_1", "village_2"],
+        ["village_1", "village_4"],
+        ["village_2", "village_5"],
+        ["village_3", "village_5"],
+        ["village_3", "village_6"],
+        ["village_4", "village_5"],
+        ["village_5", "village_6"],
+    ],
+    "white_walkers_attack": [
+        ["nights_watch_fortress", "wall_west"],
+        ["nights_watch_fortress", "wall_center_west"],
+        ["nights_watch_fortress", "wall_center_east"],
+        ["nights_watch_fortress", "wall_east"],
+        ["white_walker_fortress", "wall_west"],
+        ["white_walker_fortress", "wall_center_west"],
+        ["white_walker_fortress", "wall_center_east"],
+        ["white_walker_fortress", "wall_east"],
+        ["wall_west", "wall_center_west"],
+        ["wall_center_west", "wall_center_east"],
+        ["wall_center_east", "wall_east"],
+        ["wall_west", "barbarian_village_west"],
+        ["wall_east", "barbarian_village_east"],
+    ],
+}
+
+# Per-map list of wall-type locations for the hold-to-win check.
+WALL_LOCATIONS_BY_MAP = {
+    map_id: [
+        loc_id for loc_id, meta in positions.items()
+        if meta.get("type") == "wall"
+    ]
+    for map_id, positions in LOCATION_POSITIONS_BY_MAP.items()
+}
+
+# Kept for legacy call sites that still reference the module-level names.
+# These stay pointing at the WoK defaults — call sites that need per-map
+# behaviour should call _current_positions() / _current_connections() instead.
+LOCATION_POSITIONS = LOCATION_POSITIONS_BY_MAP[DEFAULT_MAP_ID]
+LOCATION_CONNECTIONS = LOCATION_CONNECTIONS_BY_MAP[DEFAULT_MAP_ID]
+
+
+def _current_positions():
+    """Positions for the currently active map (reads active_map_id from DB)."""
+    return LOCATION_POSITIONS_BY_MAP.get(
+        get_active_map_id(), LOCATION_POSITIONS_BY_MAP[DEFAULT_MAP_ID]
+    )
+
+
+def _current_connections():
+    """Connections for the currently active map."""
+    return LOCATION_CONNECTIONS_BY_MAP.get(
+        get_active_map_id(), LOCATION_CONNECTIONS_BY_MAP[DEFAULT_MAP_ID]
+    )
+
+
+def _current_walls():
+    return WALL_LOCATIONS_BY_MAP.get(get_active_map_id(), [])
 
 def init_game_session_tracking():
     """Initialize the game session tracking database"""
@@ -82,10 +186,20 @@ def init_game_session_tracking():
             target_location_id TEXT,
             timestamp INTEGER NOT NULL,
             game_state_after TEXT,
+            map_id TEXT,
             UNIQUE(game_session_id, action_sequence)
         )
         ''')
-        
+
+        # Best-effort migration for existing game_sessions.db files created
+        # before the map_id column existed. SQLite's ALTER TABLE only adds
+        # missing columns; the IGNORE/OperationalError guard keeps a
+        # fresh-install run idempotent.
+        try:
+            cursor.execute("ALTER TABLE game_actions ADD COLUMN map_id TEXT")
+        except sqlite3.OperationalError:
+            pass
+
         conn.commit()
         conn.close()
         logger.info(f"Game session tracking database initialized: {GAME_SESSIONS_DB}")
@@ -97,6 +211,9 @@ def init_game_session_tracking():
 
 # Initialize the game session tracking database immediately
 init_game_session_tracking()
+# Tables in game_state.db (game_config, wall_hold, faction_economy) are
+# initialized lazily on first call to _ensure_game_config_tables() — see
+# the in-process startup path later in this module.
 
 def store_game_action(game_session_id, action_type, player_name, faction, 
                      trace_id, span_id, location_id=None, target_location_id=None, 
@@ -197,7 +314,9 @@ def remove_frame_options(response):
 DATABASE_FILE = os.environ.get('DATABASE_FILE', '../app/game_state.db')
 API_BASE_URL = os.environ.get('API_BASE_URL', 'http://localhost')  # Base URL for API calls
 
-# Location server ports (from game_config.py)
+# Location server ports (from game_config.py). These are keyed by the
+# *current-map* location id; when the active map changes, the keys here
+# follow along because both maps assign the same port to the same slot.
 LOCATION_PORTS = {
     "southern_capital": 5001,
     "northern_capital": 5002,
@@ -206,46 +325,219 @@ LOCATION_PORTS = {
     "village_3": 5005,
     "village_4": 5006,
     "village_5": 5007,
-    "village_6": 5008
+    "village_6": 5008,
+    # White Walkers Attack mappings (same ports — just aliased).
+    "nights_watch_fortress": 5001,
+    "white_walker_fortress": 5002,
+    "wall_west": 5003,
+    "wall_center_west": 5004,
+    "wall_center_east": 5005,
+    "wall_east": 5006,
+    "barbarian_village_west": 5007,
+    "barbarian_village_east": 5008,
 }
 
-# Location positions for the map (x, y coordinates as percentages)
-LOCATION_POSITIONS = {
-    "southern_capital": {"x": 20, "y": 70, "type": "capital", "name": "Southern Capital"},
-    "northern_capital": {"x": 80, "y": 20, "type": "capital", "name": "Northern Capital"},
-    "village_1": {"x": 35, "y": 55, "type": "village", "name": "Village 1"},
-    "village_2": {"x": 65, "y": 35, "type": "village", "name": "Village 2"},
-    "village_3": {"x": 30, "y": 40, "type": "village", "name": "Village 3"},
-    "village_4": {"x": 45, "y": 65, "type": "village", "name": "Village 4"},
-    "village_5": {"x": 50, "y": 50, "type": "village", "name": "Village 5"},
-    "village_6": {"x": 70, "y": 45, "type": "village", "name": "Village 6"}
+# Container hostname (in docker-compose) per slot. Stable across maps.
+SLOT_CONTAINER_NAMES = {
+    "slot_1": "southern-capital",
+    "slot_2": "northern-capital",
+    "slot_3": "village-1",
+    "slot_4": "village-2",
+    "slot_5": "village-3",
+    "slot_6": "village-4",
+    "slot_7": "village-5",
+    "slot_8": "village-6",
 }
 
-# Location connections for the map (to draw lines between connected locations)
-LOCATION_CONNECTIONS = [
-    ["southern_capital", "village_1"],
-    ["southern_capital", "village_3"],
-    ["northern_capital", "village_2"],
-    ["northern_capital", "village_6"],
-    ["village_1", "village_2"],
-    ["village_1", "village_4"],
-    ["village_2", "village_5"],
-    ["village_3", "village_5"],
-    ["village_3", "village_6"],
-    ["village_4", "village_5"],
-    ["village_5", "village_6"]
-]
+# Port per slot.
+SLOT_PORTS = {
+    "slot_1": 5001,
+    "slot_2": 5002,
+    "slot_3": 5003,
+    "slot_4": 5004,
+    "slot_5": 5005,
+    "slot_6": 5006,
+    "slot_7": 5007,
+    "slot_8": 5008,
+}
 
-# Game state - track victory conditions
-GAME_OVER = False
-WINNER = None
-VICTORY_MESSAGE = None
+
+def _container_for_slot(slot_id):
+    """Return the docker-compose service name hosting ``slot_id`` (stable)."""
+    return SLOT_CONTAINER_NAMES.get(slot_id, slot_id.replace('_', '-'))
+
+
+def _slot_port_pairs():
+    """Yield (slot_id, port) tuples for all 8 slots."""
+    return list(SLOT_PORTS.items())
+
+# LOCATION_POSITIONS and LOCATION_CONNECTIONS are defined earlier (as the
+# WoK default slices of the LOCATION_*_BY_MAP dicts). Legacy call sites that
+# still reference the unsuffixed names get the WoK layout; new code should
+# go through _current_positions() / _current_connections().
+
+# Game state - track victory conditions (local process cache; also read
+# from wall_hold on map WWA).
+# Note: GAME_OVER/WINNER/VICTORY_MESSAGE already declared near top of file.
 
 def get_db_connection():
     """Create a connection to the SQLite database"""
     conn = sqlite3.connect(DATABASE_FILE)
     conn.row_factory = sqlite3.Row
     return conn
+
+
+# ----------------------------------------------------------------
+# Active map + wall-hold state (lives in game_state.db so location
+# servers and war_map agree on the single source of truth).
+# ----------------------------------------------------------------
+
+def _ensure_game_config_tables():
+    """Create game_config, faction_economy, and wall_hold if missing, and
+    migrate the war_map table for single-player maps (adds map_id + drops the
+    faction UNIQUE constraint so nights_watch can be registered without
+    conflicting with the WoK two-faction model).
+    """
+    try:
+        conn = get_db_connection()
+        cursor = conn.cursor()
+        cursor.execute('''
+        CREATE TABLE IF NOT EXISTS game_config (
+            key TEXT PRIMARY KEY,
+            value TEXT NOT NULL
+        )
+        ''')
+        cursor.execute(
+            "INSERT OR IGNORE INTO game_config (key, value) VALUES ('active_map_id', ?)",
+            (DEFAULT_MAP_ID,),
+        )
+        cursor.execute('''
+        CREATE TABLE IF NOT EXISTS faction_economy (
+            faction TEXT PRIMARY KEY,
+            corpses INTEGER NOT NULL DEFAULT 0
+        )
+        ''')
+        cursor.execute('''
+        CREATE TABLE IF NOT EXISTS wall_hold (
+            map_id TEXT NOT NULL,
+            faction TEXT NOT NULL,
+            ticks INTEGER NOT NULL DEFAULT 0,
+            last_update INTEGER NOT NULL,
+            PRIMARY KEY (map_id, faction)
+        )
+        ''')
+        # war_map table: additive map_id column for session-level bookkeeping.
+        try:
+            cursor.execute("ALTER TABLE war_map ADD COLUMN map_id TEXT")
+        except sqlite3.OperationalError:
+            pass
+        conn.commit()
+        conn.close()
+    except sqlite3.Error as e:
+        logger.error(f"Failed to ensure game_config tables: {e}")
+
+
+def get_active_map_id():
+    """Return the currently active map id from game_state.db (cached row)."""
+    try:
+        conn = get_db_connection()
+        cursor = conn.cursor()
+        cursor.execute("SELECT value FROM game_config WHERE key = 'active_map_id'")
+        row = cursor.fetchone()
+        conn.close()
+        return row['value'] if row else DEFAULT_MAP_ID
+    except sqlite3.Error:
+        return DEFAULT_MAP_ID
+
+
+def set_active_map_id(map_id):
+    """Persist the active map id. Location services pick this up via /reload."""
+    try:
+        conn = get_db_connection()
+        cursor = conn.cursor()
+        cursor.execute(
+            "INSERT INTO game_config (key, value) VALUES ('active_map_id', ?) "
+            "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+            (map_id,),
+        )
+        conn.commit()
+        conn.close()
+        return True
+    except sqlite3.Error as e:
+        logger.error(f"Failed to set active map id: {e}")
+        return False
+
+
+def reset_wall_hold(map_id):
+    """Zero the wall-hold counter for every faction on ``map_id``."""
+    try:
+        conn = get_db_connection()
+        cursor = conn.cursor()
+        cursor.execute("DELETE FROM wall_hold WHERE map_id = ?", (map_id,))
+        conn.commit()
+        conn.close()
+    except sqlite3.Error as e:
+        logger.error(f"Failed to reset wall_hold for {map_id}: {e}")
+
+
+def bump_wall_hold(map_id, faction, reset_others=True):
+    """Increment ``faction``'s tick count on ``map_id``. Optionally reset
+    every other faction back to 0. Returns the new tick count.
+    """
+    try:
+        conn = get_db_connection()
+        cursor = conn.cursor()
+        now = int(time.time())
+        if reset_others:
+            cursor.execute(
+                "UPDATE wall_hold SET ticks = 0 WHERE map_id = ? AND faction != ?",
+                (map_id, faction),
+            )
+        cursor.execute(
+            "INSERT INTO wall_hold (map_id, faction, ticks, last_update) "
+            "VALUES (?, ?, 1, ?) "
+            "ON CONFLICT(map_id, faction) DO UPDATE SET "
+            "ticks = ticks + 1, last_update = excluded.last_update",
+            (map_id, faction, now),
+        )
+        cursor.execute(
+            "SELECT ticks FROM wall_hold WHERE map_id = ? AND faction = ?",
+            (map_id, faction),
+        )
+        row = cursor.fetchone()
+        conn.commit()
+        conn.close()
+        return int(row['ticks']) if row else 0
+    except sqlite3.Error as e:
+        logger.error(f"Failed to bump wall_hold: {e}")
+        return 0
+
+
+def get_wall_hold(map_id):
+    """Return {faction: ticks} for the given map."""
+    try:
+        conn = get_db_connection()
+        cursor = conn.cursor()
+        cursor.execute("SELECT faction, ticks FROM wall_hold WHERE map_id = ?", (map_id,))
+        rows = cursor.fetchall()
+        conn.close()
+        return {r['faction']: int(r['ticks']) for r in rows}
+    except sqlite3.Error:
+        return {}
+
+
+def get_faction_corpses(faction):
+    """Read a faction's corpse pool (0 when no row yet)."""
+    try:
+        conn = get_db_connection()
+        cursor = conn.cursor()
+        cursor.execute("SELECT corpses FROM faction_economy WHERE faction = ?", (faction,))
+        row = cursor.fetchone()
+        conn.close()
+        return int(row['corpses']) if row else 0
+    except sqlite3.Error:
+        return 0
+
 
 def check_faction_availability(faction):
     """Check if a faction is already claimed by another player"""
@@ -404,25 +696,66 @@ def make_api_request(location_id, endpoint, method='GET', data=None):
         except requests.RequestException as e:
             return {"error": str(e)}
 
-def check_game_over(locations_data):
-    """Check if the game is over by examining location ownership"""
+def check_game_over(locations_data, map_id=None):
+    """Dispatch to the right win-condition check based on the active map."""
+    if map_id is None:
+        map_id = get_active_map_id()
+    if map_id == "white_walkers_attack":
+        # WWA games end only via hold-the-walls. Capital captures do not end
+        # the game (the capital can change hands mid-match).
+        return check_wall_hold_win(locations_data, map_id)
+    return check_capital_capture_win(locations_data)
+
+
+def check_capital_capture_win(locations_data):
+    """Classic WoK win: take the enemy capital."""
     global GAME_OVER, WINNER, VICTORY_MESSAGE
-    
-    # Check if Southern Capital is owned by Northern
+
     if locations_data.get('southern_capital', {}).get('faction') == 'northern':
         GAME_OVER = True
         WINNER = 'northern'
         VICTORY_MESSAGE = "The Northern Kingdom has conquered the Southern Capital! Victory through unity!"
         return True
-    
-    # Check if Northern Capital is owned by Southern
+
     if locations_data.get('northern_capital', {}).get('faction') == 'southern':
         GAME_OVER = True
         WINNER = 'southern'
         VICTORY_MESSAGE = "The Southern Kingdom has conquered the Northern Capital! Glory to the South!"
         return True
-    
+
     logger.info("Game is not over")
+    return False
+
+
+def check_wall_hold_win(locations_data, map_id):
+    """White Walkers Attack win: one faction has held every wall for the
+    configured number of ticks. This is a passive check — the tick thread
+    owns incrementing the counter; here we just observe + declare.
+    """
+    global GAME_OVER, WINNER, VICTORY_MESSAGE
+
+    threshold = MAPS_META.get(map_id, {}).get("win_hold_ticks", 0)
+    if threshold <= 0:
+        return False
+
+    holds = get_wall_hold(map_id)
+    for faction, ticks in holds.items():
+        if ticks >= threshold:
+            GAME_OVER = True
+            WINNER = faction
+            if faction == "nights_watch":
+                VICTORY_MESSAGE = (
+                    "The Night's Watch held the Wall! The Long Night is broken."
+                )
+            elif faction == "white_walkers":
+                VICTORY_MESSAGE = (
+                    "The Wall has fallen. The Long Night has come for Westeros."
+                )
+            else:
+                VICTORY_MESSAGE = f"{faction.title()} held every Wall keep for {threshold} ticks."
+            return True
+
+    logger.debug(f"Wall hold check: {holds} (threshold {threshold})")
     return False
 
 def reset_game_state():
@@ -474,56 +807,218 @@ def health():
 
 @app.route('/')
 def index():
-    """Home page - faction selection"""
-    # Check if user already has a faction
+    """Home page. Routes through the map picker on first visit; once the
+    user has picked a map the faction-selection view (WoK) or auto-start
+    view (WWA single-player) is served instead.
+    """
+    _ensure_game_config_tables()
+
+    # Already in a game with a faction? Go straight to the map.
     if 'session_id' in session and get_player_faction(session['session_id']):
         return redirect(url_for('game_map'))
-    
-    # Check which factions are available
+
+    # No map chosen yet → map picker.
+    if 'map_id' not in session:
+        return redirect(url_for('map_picker'))
+
+    map_id = session['map_id']
+    meta = MAPS_META.get(map_id, MAPS_META[DEFAULT_MAP_ID])
+
+    if meta["single_player"]:
+        # Single-player maps skip the faction cards. A single CTA button posts
+        # back with faction=player_faction.
+        player_faction = meta["player_faction"]
+        player_available = check_faction_availability(player_faction)
+        return render_template(
+            'index.html',
+            map_id=map_id,
+            map_meta=meta,
+            single_player=True,
+            player_faction=player_faction,
+            player_available=player_available,
+            southern_available=False,
+            northern_available=False,
+        )
+
+    # Classic WoK two-faction flow.
     southern_available = check_faction_availability('southern')
     northern_available = check_faction_availability('northern')
     logger.info(f"Southern available: {southern_available}, Northern available: {northern_available}")
-    
-    return render_template('index.html', 
-                          southern_available=southern_available, 
-                          northern_available=northern_available)
+
+    return render_template(
+        'index.html',
+        map_id=map_id,
+        map_meta=meta,
+        single_player=False,
+        southern_available=southern_available,
+        northern_available=northern_available,
+    )
+
+
+@app.route('/map_picker')
+def map_picker():
+    """Map selection screen. Renders one card per entry in MAPS_META."""
+    _ensure_game_config_tables()
+    return render_template('map_picker.html', maps=MAPS_META)
+
+
+@app.route('/select_map', methods=['POST'])
+def select_map():
+    """Persist the chosen map as active + reload every location service.
+
+    Steps:
+      1. Write ``active_map_id`` to game_config.
+      2. Reset the locations table via one location's ``/reset`` (shared DB —
+         one call repopulates the 8 rows from the new map's config).
+      3. POST ``/reload`` to every slot so the in-memory ``location_info`` on
+         each service rebinds without a container restart.
+      4. For single-player maps, auto-register the preset player faction and
+         auto-activate the AI as the preset enemy faction.
+      5. Redirect to the entry UI (map-aware from the session).
+    """
+    map_id = request.form.get('map_id') or DEFAULT_MAP_ID
+    if map_id not in MAPS_META:
+        logger.error(f"Unknown map_id: {map_id}")
+        return redirect(url_for('map_picker'))
+
+    with tracer.start_as_current_span(
+        "select_map",
+        kind=SpanKind.SERVER,
+        attributes={"game.map.id": map_id},
+    ) as span:
+        # 1. Persist + wipe any previous wall-hold counters.
+        set_active_map_id(map_id)
+        reset_wall_hold(map_id)
+        # Clear all maps' old counters to avoid stale wins after switching.
+        for mid in MAPS_META:
+            reset_wall_hold(mid)
+
+        # 2. Reset locations rows to match the new map.
+        try:
+            # Any one container will do — the DB is shared. Use the first
+            # Docker service name (stable across maps).
+            reset_container = _container_for_slot("slot_1")
+            requests.post(
+                f"http://{reset_container}:5001/reset" if os.environ.get('IN_DOCKER')
+                else f"http://localhost:5001/reset",
+                timeout=5,
+            )
+        except Exception as e:
+            logger.warning(f"Failed to reset location rows during map switch: {e}")
+
+        # 3. Kick every slot to reload identity.
+        for slot_id, port in _slot_port_pairs():
+            try:
+                host = _container_for_slot(slot_id) if os.environ.get('IN_DOCKER') else "localhost"
+                requests.post(f"http://{host}:{port}/reload", timeout=5)
+            except Exception as e:
+                logger.warning(f"Failed to /reload {slot_id}: {e}")
+
+        # 4. Clear faction claims + session data so the new map starts clean.
+        release_all_factions()
+        session.pop('faction', None)
+        session.pop('player_name', None)
+        session.pop('game_session_id', None)
+        session.pop('action_sequence', None)
+        session.pop('session_id', None)
+        session['map_id'] = map_id
+
+        meta = MAPS_META[map_id]
+
+        # 5. Single-player: AI activation is deferred until the player clicks
+        # "Take the Black" on the index page (so the player always explicitly
+        # starts the game). But we do pre-reset the game-over flags.
+        reset_game_state()
+        span.set_attribute("single_player", meta["single_player"])
+
+    return redirect(url_for('index'))
+
 
 @app.route('/select_faction', methods=['POST'])
 def select_faction():
-    """Process faction selection"""
+    """Process faction selection (WoK two-player or single-player preset)."""
+    map_id = session.get('map_id', DEFAULT_MAP_ID)
+    meta = MAPS_META.get(map_id, MAPS_META[DEFAULT_MAP_ID])
+
     faction = request.form.get('faction')
     player_name = request.form.get('player_name', 'Unknown Player')
-    
-    if not faction or faction not in ['southern', 'northern']:
-        return render_template('index.html', error="Invalid faction selected")
-    
+
+    allowed = set(meta.get("factions", []))
+    if not faction or faction not in allowed:
+        return render_template(
+            'index.html',
+            map_id=map_id,
+            map_meta=meta,
+            single_player=meta["single_player"],
+            player_faction=meta.get("player_faction"),
+            southern_available=check_faction_availability('southern'),
+            northern_available=check_faction_availability('northern'),
+            player_available=(
+                check_faction_availability(meta.get("player_faction"))
+                if meta["single_player"] else False
+            ),
+            error="Invalid faction selected",
+        )
+
     # Check if faction is available
     if not check_faction_availability(faction):
         logger.info(f"Faction {faction} is already taken")
-        return render_template('index.html', 
-                              error=f"The {faction.capitalize()} faction is already taken")
-    
+        return render_template(
+            'index.html',
+            map_id=map_id,
+            map_meta=meta,
+            single_player=meta["single_player"],
+            player_faction=meta.get("player_faction"),
+            southern_available=check_faction_availability('southern'),
+            northern_available=check_faction_availability('northern'),
+            player_available=False,
+            error=f"The {faction.replace('_', ' ').title()} faction is already taken",
+        )
+
     # Generate a session ID if not present
     if 'session_id' not in session:
         session['session_id'] = str(uuid.uuid4())
-    
+
     # Generate a game session ID for span linking
     if 'game_session_id' not in session:
         session['game_session_id'] = str(uuid.uuid4())
         session['action_sequence'] = 0  # Initialize action sequence
         logger.info(f"Initialized game session: {session['game_session_id']}")
-    
+
     # Register the faction
     if register_faction(faction, player_name, session['session_id']):
         session['faction'] = faction
         session['player_name'] = player_name
         session['is_ai'] = False  # Human player by default
-        logger.info(f"Player {player_name} selected faction {faction}")
+        logger.info(f"Player {player_name} selected faction {faction} on map {map_id}")
+
+        # On single-player maps, auto-activate the AI as the preset enemy
+        # the moment the human commits to playing.
+        if meta["single_player"] and meta.get("ai_faction"):
+            try:
+                requests.post(
+                    f"{AI_SERVICE_URL}/activate",
+                    json={"faction": meta["ai_faction"], "map_id": map_id},
+                    timeout=5,
+                )
+                logger.info(f"Auto-activated AI as {meta['ai_faction']} for single-player map {map_id}")
+            except Exception as e:
+                logger.warning(f"Auto-activation of AI failed: {e}")
+
         return redirect(url_for('game_map'))
     else:
         logger.error(f"Failed to register faction {faction}")
-        return render_template('index.html', 
-                              error=f"Failed to register {faction.capitalize()} faction")
+        return render_template(
+            'index.html',
+            map_id=map_id,
+            map_meta=meta,
+            single_player=meta["single_player"],
+            player_faction=meta.get("player_faction"),
+            southern_available=check_faction_availability('southern'),
+            northern_available=check_faction_availability('northern'),
+            player_available=False,
+            error=f"Failed to register {faction.replace('_', ' ').title()} faction",
+        )
 
 @app.route('/logout')
 def logout():
@@ -564,38 +1059,56 @@ def restart_game():
 
 @app.route('/map')
 def game_map():
-    """Game map page"""
+    """Game map page — renders the canvas for the currently active map."""
     # Check if user has selected a faction
     if 'faction' not in session:
         return redirect(url_for('index'))
-    
+
+    map_id = session.get('map_id') or get_active_map_id()
+    positions = LOCATION_POSITIONS_BY_MAP.get(map_id, LOCATION_POSITIONS_BY_MAP[DEFAULT_MAP_ID])
+    connections = LOCATION_CONNECTIONS_BY_MAP.get(map_id, LOCATION_CONNECTIONS_BY_MAP[DEFAULT_MAP_ID])
+    meta = MAPS_META.get(map_id, MAPS_META[DEFAULT_MAP_ID])
+
     faction = session['faction']
     player_name = session.get('player_name', 'Unknown Player')
-    
-    # Get all location data for the map
+
+    # Get all location data for the map (only the ids relevant to this map).
     locations_data = {}
-    for loc_id in LOCATION_POSITIONS.keys():
+    for loc_id in positions.keys():
         data = make_api_request(loc_id, '')
         if 'error' not in data:
-            # Combine API data with position data
             locations_data[loc_id] = {
-                **LOCATION_POSITIONS[loc_id],
+                **positions[loc_id],
                 'faction': data['faction'],
                 'resources': data['resources'],
-                'army': data['army']
+                'army': data['army'],
             }
-    
-    # Check for game over condition
-    check_game_over(locations_data)
-    
-    return render_template('map.html', 
-                          player_name=player_name,
-                          faction=faction,
-                          locations=locations_data,
-                          connections=LOCATION_CONNECTIONS,
-                          game_over=GAME_OVER,
-                          winner=WINNER,
-                          victory_message=VICTORY_MESSAGE)
+
+    # Check for game over condition (map-aware).
+    check_game_over(locations_data, map_id=map_id)
+
+    # Wall-hold HUD payload for WWA.
+    wall_hold_state = None
+    if map_id == "white_walkers_attack":
+        wall_hold_state = {
+            "threshold": meta.get("win_hold_ticks", 0),
+            "holds": get_wall_hold(map_id),
+            "walls": WALL_LOCATIONS_BY_MAP.get(map_id, []),
+        }
+
+    return render_template(
+        'map.html',
+        player_name=player_name,
+        faction=faction,
+        map_id=map_id,
+        map_meta=meta,
+        locations=locations_data,
+        connections=connections,
+        wall_hold=wall_hold_state,
+        game_over=GAME_OVER,
+        winner=WINNER,
+        victory_message=VICTORY_MESSAGE,
+    )
 
 @app.route('/api/collect_resources', methods=['POST'])
 def collect_resources():
@@ -780,7 +1293,7 @@ def move_army():
         # Check if this move resulted in a victory condition
         if target_id in ['southern_capital', 'northern_capital'] and result.get('success'):
             locations_data = {}
-            for loc_id in LOCATION_POSITIONS.keys():
+            for loc_id in _current_positions().keys():
                 data = make_api_request(loc_id, '')
                 if 'error' not in data:
                     locations_data[loc_id] = {
@@ -817,7 +1330,7 @@ def move_army():
 @app.route('/api/location_info/<location_id>', methods=['GET'])
 def location_info(location_id):
     """API endpoint to get information about a location"""
-    if location_id not in LOCATION_POSITIONS:
+    if location_id not in _current_positions():
         return jsonify({"error": "Invalid location ID"}), 400
     
     result = make_api_request(location_id, '')
@@ -827,37 +1340,47 @@ def location_info(location_id):
 @app.route('/api/map_data', methods=['GET'])
 def map_data():
     """API endpoint to get all map data for updating the UI"""
-    # Get all location data for the map
+    map_id = get_active_map_id()
+    meta = MAPS_META.get(map_id, MAPS_META[DEFAULT_MAP_ID])
     locations_data = {}
-    for loc_id in LOCATION_POSITIONS.keys():
+    for loc_id in _current_positions().keys():
         data = make_api_request(loc_id, '')
         if 'error' not in data:
-            # Combine API data with position data and location type
             locations_data[loc_id] = {
-                **LOCATION_POSITIONS[loc_id],
+                **_current_positions()[loc_id],
                 'faction': data['faction'],
                 'resources': data['resources'],
                 'army': data['army'],
-                'type': LOCATION_POSITIONS[loc_id]['type']  # Add location type
+                'type': _current_positions()[loc_id]['type']
             }
-    
-    # Check for game over condition
-    check_game_over(locations_data)
-    
-    return jsonify({
+
+    check_game_over(locations_data, map_id=map_id)
+
+    response = {
         "locations": locations_data,
-        "connections": LOCATION_CONNECTIONS,
+        "connections": _current_connections(),
         "game_over": GAME_OVER,
         "winner": WINNER,
-        "victory_message": VICTORY_MESSAGE
-    })
+        "victory_message": VICTORY_MESSAGE,
+        "map_id": map_id,
+    }
+
+    # Include wall-hold state when the active map uses the tick mechanic.
+    if meta.get("win_hold_ticks", 0) > 0:
+        response["wall_hold"] = {
+            "threshold": meta["win_hold_ticks"],
+            "holds": get_wall_hold(map_id),
+            "walls": WALL_LOCATIONS_BY_MAP.get(map_id, []),
+        }
+
+    return jsonify(response)
 
 @app.route('/api/game_status', methods=['GET'])
 def game_status():
     """API endpoint to get the current game status"""
     # Always check the current state to catch AI victories
     locations_data = {}
-    for loc_id in LOCATION_POSITIONS.keys():
+    for loc_id in _current_positions().keys():
         data = make_api_request(loc_id, '')
         if 'error' not in data:
             locations_data[loc_id] = {
@@ -946,7 +1469,7 @@ def all_out_attack():
             # Check if this attack resulted in game over
             if result.get('success'):
                 locations_data = {}
-                for loc_id in LOCATION_POSITIONS.keys():
+                for loc_id in _current_positions().keys():
                     data = make_api_request(loc_id, '')
                     if 'error' not in data:
                         locations_data[loc_id] = {
@@ -1203,7 +1726,7 @@ def replay_session_page(session_id):
         # Check if location database reset to initial state
         try:
             locations_data = {}
-            for loc_id in LOCATION_POSITIONS.keys():
+            for loc_id in _current_positions().keys():
                 data = make_api_request(loc_id, '')
                 if 'error' not in data:
                     locations_data[loc_id] = data
@@ -1601,6 +2124,85 @@ def verify_action_links(actions):
         chain_verification.append(verification)
     
     return chain_verification
+
+# ----------------------------------------------------------------
+# Wall-hold tick thread — WWA win condition.
+# Runs every tick_interval_s, reads every wall-type location's faction from
+# game_state.db, increments the hold counter for whoever owns them all, and
+# resets the counter otherwise. When a faction's count reaches win_hold_ticks
+# the global game-over flags flip and the map.html poll picks up the winner.
+# ----------------------------------------------------------------
+
+def _wall_tick_thread():
+    _ensure_game_config_tables()
+    logger.info("Wall-hold tick thread started")
+    while True:
+        try:
+            map_id = get_active_map_id()
+            meta = MAPS_META.get(map_id)
+            interval = meta.get("tick_interval_s", 0) if meta else 0
+            if not meta or interval <= 0:
+                # WoK or any map that doesn't use the hold-to-win mechanic:
+                # sleep in short slices so a map switch to WWA picks up
+                # within 5 s rather than waiting out a long interval.
+                time.sleep(5)
+                continue
+
+            # Measure wall ownership from game_state.db directly (faster and
+            # more consistent than round-tripping through the HTTP API, and
+            # avoids producing tracing noise every 30 s).
+            wall_ids = WALL_LOCATIONS_BY_MAP.get(map_id, [])
+            if not wall_ids:
+                time.sleep(interval)
+                continue
+
+            conn = get_db_connection()
+            cursor = conn.cursor()
+            placeholders = ",".join("?" for _ in wall_ids)
+            cursor.execute(
+                f"SELECT id, faction FROM locations WHERE id IN ({placeholders})",
+                wall_ids,
+            )
+            rows = cursor.fetchall()
+            conn.close()
+
+            factions = {r['faction'] for r in rows}
+            playable = factions - {"neutral"}
+            threshold = meta.get("win_hold_ticks", 0)
+
+            with tracer.start_as_current_span(
+                "wall_tick",
+                kind=SpanKind.INTERNAL,
+                attributes={
+                    "game.map.id": map_id,
+                    "wall.count": len(wall_ids),
+                    "wall.factions": ",".join(sorted(factions)),
+                },
+            ) as tick_span:
+                if len(rows) == len(wall_ids) and len(playable) == 1 and "neutral" not in factions:
+                    holder = playable.pop()
+                    ticks = bump_wall_hold(map_id, holder, reset_others=True)
+                    tick_span.set_attribute("wall.holder", holder)
+                    tick_span.set_attribute("game.wall.hold_counter", ticks)
+                    if threshold > 0 and ticks >= threshold:
+                        tick_span.add_event(
+                            "game.wall.hold_win",
+                            attributes={"faction": holder, "ticks": ticks},
+                        )
+                        logger.info(f"Wall-hold win detected for {holder} on {map_id}")
+                else:
+                    reset_wall_hold(map_id)
+                    tick_span.set_attribute("wall.holder", "contested")
+
+            time.sleep(interval)
+        except Exception as e:
+            logger.error(f"Wall-tick thread error: {e}")
+            time.sleep(5)
+
+
+# Kick off the wall-tick thread once per process.
+threading.Thread(target=_wall_tick_thread, daemon=True, name="wall-tick").start()
+
 
 if __name__ == '__main__':
     port = int(os.environ.get('PORT', 8080))

--- a/game-of-tracing/war_map/app.py
+++ b/game-of-tracing/war_map/app.py
@@ -215,34 +215,78 @@ init_game_session_tracking()
 # initialized lazily on first call to _ensure_game_config_tables() — see
 # the in-process startup path later in this module.
 
-def store_game_action(game_session_id, action_type, player_name, faction, 
-                     trace_id, span_id, location_id=None, target_location_id=None, 
-                     game_state=None):
-    """Store a game action with its trace information"""
+def store_game_action(game_session_id, action_type, player_name, faction,
+                     trace_id, span_id, location_id=None, target_location_id=None,
+                     game_state=None, map_id=None):
+    """Store a game action with its trace information.
+
+    ``map_id`` is recorded so the replay page can render the correct map
+    layout (positions/connections) for sessions played on non-default maps.
+    Defaults to the currently active map when not supplied.
+    """
+    if map_id is None:
+        try:
+            map_id = get_active_map_id()
+        except Exception:
+            map_id = DEFAULT_MAP_ID
+
     conn = sqlite3.connect(GAME_SESSIONS_DB)
     cursor = conn.cursor()
-    
+
     # Get next sequence number
-    cursor.execute("SELECT MAX(action_sequence) FROM game_actions WHERE game_session_id = ?", 
+    cursor.execute("SELECT MAX(action_sequence) FROM game_actions WHERE game_session_id = ?",
                    (game_session_id,))
     result = cursor.fetchone()
     next_sequence = (result[0] or 0) + 1
-    
+
     # Debug logging
-    logger.info(f"Storing action: session={game_session_id}, sequence={next_sequence}, action={action_type}, trace_id={trace_id}, span_id={span_id}")
-    
+    logger.info(f"Storing action: session={game_session_id}, sequence={next_sequence}, action={action_type}, trace_id={trace_id}, span_id={span_id}, map_id={map_id}")
+
     cursor.execute('''
-    INSERT INTO game_actions 
-    (game_session_id, action_sequence, action_type, player_name, faction, 
-     trace_id, span_id, location_id, target_location_id, timestamp, game_state_after)
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    INSERT INTO game_actions
+    (game_session_id, action_sequence, action_type, player_name, faction,
+     trace_id, span_id, location_id, target_location_id, timestamp, game_state_after, map_id)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     ''', (game_session_id, next_sequence, action_type, player_name, faction,
-          trace_id, span_id, location_id, target_location_id, 
-          int(time.time()), json.dumps(game_state) if game_state else None))
-    
+          trace_id, span_id, location_id, target_location_id,
+          int(time.time()), json.dumps(game_state) if game_state else None, map_id))
+
     conn.commit()
     conn.close()
     return next_sequence
+
+
+def get_session_map_id(session_id):
+    """Resolve the map a session was played on.
+
+    Looks at any non-NULL ``map_id`` in the session's actions; falls back to
+    the currently active map for sessions stored before the column was
+    populated. Returns ``DEFAULT_MAP_ID`` as a last resort so the replay
+    template always has a layout to render.
+    """
+    try:
+        conn = sqlite3.connect(GAME_SESSIONS_DB)
+        try:
+            row = conn.execute(
+                "SELECT map_id FROM game_actions "
+                "WHERE game_session_id = ? AND map_id IS NOT NULL "
+                "ORDER BY action_sequence LIMIT 1",
+                (session_id,),
+            ).fetchone()
+            if row and row[0] in LOCATION_POSITIONS_BY_MAP:
+                return row[0]
+        finally:
+            conn.close()
+    except Exception as e:
+        logger.warning(f"get_session_map_id failed for {session_id}: {e}")
+
+    try:
+        active = get_active_map_id()
+        if active in LOCATION_POSITIONS_BY_MAP:
+            return active
+    except Exception:
+        pass
+    return DEFAULT_MAP_ID
 
 def get_previous_action_context(game_session_id, target_sequence):
     """Get the action's span context for linking by target sequence number"""
@@ -335,6 +379,30 @@ LOCATION_PORTS = {
     "wall_east": 5006,
     "barbarian_village_west": 5007,
     "barbarian_village_east": 5008,
+}
+
+# Container hostname per logical location id. WWA reuses the same 8 slot
+# containers, so its location ids resolve to the WoK container names. Without
+# this aliasing, ``location_id.replace('_', '-')`` produces hostnames like
+# ``nights-watch-fortress`` that don't exist in the docker network and the
+# /map render returns an empty locations dict (blank map).
+CONTAINER_FOR_LOCATION_ID = {
+    "southern_capital": "southern-capital",
+    "northern_capital": "northern-capital",
+    "village_1": "village-1",
+    "village_2": "village-2",
+    "village_3": "village-3",
+    "village_4": "village-4",
+    "village_5": "village-5",
+    "village_6": "village-6",
+    "nights_watch_fortress": "southern-capital",
+    "white_walker_fortress": "northern-capital",
+    "wall_west": "village-1",
+    "wall_center_west": "village-2",
+    "wall_center_east": "village-3",
+    "wall_east": "village-4",
+    "barbarian_village_west": "village-5",
+    "barbarian_village_east": "village-6",
 }
 
 # Container hostname (in docker-compose) per slot. Stable across maps.
@@ -637,12 +705,15 @@ def release_all_factions():
 
 def get_location_url(location_id):
     """Get the URL for a location's API"""
-    # In Docker, use container names instead of localhost
+    # In Docker, use container names instead of localhost. WWA location ids
+    # alias the WoK slot containers — see CONTAINER_FOR_LOCATION_ID.
     if os.environ.get('IN_DOCKER'):
-        host = location_id.replace('_', '-')
+        host = CONTAINER_FOR_LOCATION_ID.get(
+            location_id, location_id.replace('_', '-')
+        )
     else:
         host = 'localhost'
-    
+
     port = LOCATION_PORTS[location_id]
     return f"http://{host}:{port}"
 
@@ -1675,8 +1746,16 @@ def replay_page():
 
 @app.route('/replay/<session_id>')
 def replay_session_page(session_id):
-    """Page to replay a specific game session"""
-    return render_template('replay_session.html', session_id=session_id)
+    """Page to replay a specific game session — renders with the layout of
+    whichever map the session was played on (not the active map)."""
+    map_id = get_session_map_id(session_id)
+    return render_template(
+        'replay_session.html',
+        session_id=session_id,
+        map_id=map_id,
+        location_positions=LOCATION_POSITIONS_BY_MAP[map_id],
+        location_connections=LOCATION_CONNECTIONS_BY_MAP[map_id],
+    )
     """Debug endpoint to verify restart cleared all data properly"""
     verification_results = {
         'game_state_reset': False,

--- a/game-of-tracing/war_map/static/css/style.css
+++ b/game-of-tracing/war_map/static/css/style.css
@@ -27,6 +27,28 @@
     --neutral-silver: #78909C;
     --neutral-glow: rgba(120, 144, 156, 0.3);
 
+    /* White Walkers Attack — Night's Watch (player on WWA) */
+    --nights-watch-black: #141824;
+    --nights-watch-accent: #d7e4f1;
+    --nights-watch-glow: rgba(215, 228, 241, 0.45);
+    --nights-watch-bg: linear-gradient(135deg, #0a0f1d, #2a3246);
+
+    /* White Walkers (AI on WWA) */
+    --white-walkers-blue: #88c4e6;
+    --white-walkers-ice: #d6f1ff;
+    --white-walkers-glow: rgba(136, 196, 230, 0.55);
+    --white-walkers-bg: linear-gradient(135deg, #0f2d3f, #88c4e6);
+
+    /* Barbarians (passive NPCs on WWA) */
+    --barbarian-orange: #c1442e;
+    --barbarian-glow: rgba(193, 68, 46, 0.4);
+    --barbarian-bg: linear-gradient(135deg, #5a1a0d, #c1442e);
+
+    /* Wall keeps (new settlement type) */
+    --wall-stone: #8a8a95;
+    --wall-stone-light: #b9b9c2;
+    --wall-rune: rgba(200, 225, 255, 0.5);
+
     /* Text */
     --text-primary: #e6edf3;
     --text-secondary: #8b949e;
@@ -449,6 +471,50 @@ code {
     border-color: var(--neutral-silver);
 }
 
+/* --- White Walkers Attack faction markers --- */
+.location-marker.nights_watch {
+    background: var(--nights-watch-bg);
+    box-shadow: 0 0 12px var(--nights-watch-glow), 0 0 24px rgba(215, 228, 241, 0.2);
+    border-color: var(--nights-watch-accent);
+}
+.location-marker.nights_watch.selected {
+    box-shadow: 0 0 20px var(--nights-watch-accent), 0 0 40px rgba(215, 228, 241, 0.35);
+}
+
+.location-marker.white_walkers {
+    background: var(--white-walkers-bg);
+    box-shadow: 0 0 14px var(--white-walkers-glow), 0 0 30px rgba(136, 196, 230, 0.25);
+    border-color: var(--white-walkers-ice);
+}
+.location-marker.white_walkers.selected {
+    box-shadow: 0 0 22px var(--white-walkers-ice), 0 0 44px rgba(214, 241, 255, 0.45);
+}
+
+.location-marker.barbarian {
+    background: var(--barbarian-bg);
+    box-shadow: 0 0 12px var(--barbarian-glow), 0 0 24px rgba(193, 68, 46, 0.22);
+    border-color: var(--barbarian-orange);
+}
+.location-marker.barbarian.selected {
+    box-shadow: 0 0 18px var(--barbarian-orange), 0 0 36px rgba(193, 68, 46, 0.35);
+}
+
+/* --- Wall settlement type: rounded rectangle, stonework styling --- */
+.location-marker.wall {
+    border-radius: 6px !important;
+    background: linear-gradient(135deg, #4a4a55, var(--wall-stone));
+    box-shadow: 0 0 10px rgba(138, 138, 149, 0.35);
+    border-color: var(--wall-stone-light);
+}
+.location-marker.wall.nights_watch {
+    background: linear-gradient(135deg, var(--nights-watch-black), #3a4055);
+    box-shadow: 0 0 16px var(--nights-watch-glow);
+}
+.location-marker.wall.white_walkers {
+    background: linear-gradient(135deg, #0f2d3f, var(--white-walkers-blue));
+    box-shadow: 0 0 16px var(--white-walkers-glow);
+}
+
 /* Capital crown effect */
 .location-marker.capital::before {
     content: '';
@@ -470,6 +536,13 @@ code {
 
 .location-marker.capital.neutral::before {
     border-bottom-color: var(--neutral-silver);
+}
+
+.location-marker.capital.nights_watch::before {
+    border-bottom-color: var(--nights-watch-accent);
+}
+.location-marker.capital.white_walkers::before {
+    border-bottom-color: var(--white-walkers-ice);
 }
 
 /* Location label */
@@ -559,6 +632,26 @@ code {
     box-shadow: 0 0 30px var(--northern-glow), 0 0 60px rgba(79, 195, 247, 0.15);
 }
 
+.faction-card.faction-selected.faction-nights-watch {
+    border-color: var(--nights-watch-accent);
+    box-shadow: 0 0 30px var(--nights-watch-glow), 0 0 60px rgba(215, 228, 241, 0.2);
+}
+
+.faction-card.faction-selected.faction-white-walkers {
+    border-color: var(--white-walkers-ice);
+    box-shadow: 0 0 30px var(--white-walkers-glow), 0 0 60px rgba(214, 241, 255, 0.2);
+}
+
+.faction-card.faction-selected.faction-barbarian {
+    border-color: var(--barbarian-orange);
+    box-shadow: 0 0 30px var(--barbarian-glow), 0 0 60px rgba(193, 68, 46, 0.18);
+}
+
+.faction-card.faction-selected.map-card {
+    border-color: var(--northern-blue);
+    box-shadow: 0 0 30px var(--northern-glow), 0 0 60px rgba(79, 195, 247, 0.15);
+}
+
 .faction-unavailable {
     opacity: 0.4;
     cursor: not-allowed;
@@ -599,6 +692,69 @@ code {
     box-shadow: 0 0 30px var(--northern-glow);
     border-color: var(--northern-blue);
 }
+
+/* --- WWA faction icons --- */
+.nights-watch-icon {
+    background: radial-gradient(circle, rgba(215, 228, 241, 0.18), transparent 70%);
+    color: var(--nights-watch-accent);
+    border: 2px solid rgba(215, 228, 241, 0.3);
+}
+.faction-card:hover .nights-watch-icon,
+.faction-card.faction-selected .nights-watch-icon {
+    box-shadow: 0 0 30px var(--nights-watch-glow);
+    border-color: var(--nights-watch-accent);
+}
+
+.white-walkers-icon {
+    background: radial-gradient(circle, rgba(136, 196, 230, 0.22), transparent 70%);
+    color: var(--white-walkers-ice);
+    border: 2px solid rgba(136, 196, 230, 0.35);
+}
+.faction-card:hover .white-walkers-icon,
+.faction-card.faction-selected .white-walkers-icon {
+    box-shadow: 0 0 30px var(--white-walkers-glow);
+    border-color: var(--white-walkers-ice);
+}
+
+.barbarian-icon {
+    background: radial-gradient(circle, rgba(193, 68, 46, 0.2), transparent 70%);
+    color: var(--barbarian-orange);
+    border: 2px solid rgba(193, 68, 46, 0.32);
+}
+
+/* --- Wall-hold HUD overlay for WWA --- */
+.wall-hold-hud {
+    position: absolute;
+    top: 20px;
+    right: 20px;
+    z-index: 10;
+    background: var(--bg-glass);
+    backdrop-filter: blur(var(--glass-blur));
+    border: 1px solid var(--border-subtle);
+    border-radius: 10px;
+    padding: 0.75rem 1rem;
+    color: var(--text-primary);
+    min-width: 220px;
+    font-size: 0.9rem;
+}
+.wall-hold-hud h6 {
+    margin: 0 0 0.35rem 0;
+    color: var(--nights-watch-accent);
+    font-size: 0.85rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+}
+.wall-hold-hud .hold-row {
+    display: flex;
+    justify-content: space-between;
+    margin: 0.1rem 0;
+}
+.wall-hold-hud .hold-row .ticks {
+    font-family: monospace;
+    font-weight: 600;
+}
+.wall-hold-hud .hold-row.nights_watch .ticks { color: var(--nights-watch-accent); }
+.wall-hold-hud .hold-row.white_walkers .ticks { color: var(--white-walkers-ice); }
 
 @keyframes iconFloat {
     0%, 100% { transform: translateY(0); }

--- a/game-of-tracing/war_map/templates/index.html
+++ b/game-of-tracing/war_map/templates/index.html
@@ -1,13 +1,26 @@
 {% extends "layout.html" %}
 
-{% block title %}Choose Your Faction{% endblock %}
+{% block title %}
+    {% if single_player %}Take the Black — {{ map_meta.display_name }}{% else %}Choose Your Faction{% endif %}
+{% endblock %}
 
 {% block content %}
 <div class="faction-hero">
     <div class="col-lg-8 col-xl-7">
         <div class="text-center mb-5">
-            <h1 class="faction-hero-title">A Game of Traces</h1>
-            <p class="faction-hero-subtitle">Choose your kingdom. Command your armies. Master distributed tracing.</p>
+            <h1 class="faction-hero-title">
+                {% if single_player %}{{ map_meta.display_name }}{% else %}A Game of Traces{% endif %}
+            </h1>
+            <p class="faction-hero-subtitle">
+                {% if single_player %}{{ map_meta.description }}
+                {% else %}Choose your kingdom. Command your armies. Master distributed tracing.
+                {% endif %}
+            </p>
+            <p class="small">
+                <a href="{{ url_for('map_picker') }}" class="text-decoration-none">
+                    <i class="fas fa-map me-1"></i>Pick a different map
+                </a>
+            </p>
         </div>
 
         <!-- Show reset status if coming from restart -->
@@ -24,13 +37,48 @@
 
         <form method="POST" action="{{ url_for('select_faction') }}" id="factionForm">
             <div class="mb-4">
-                <label for="player_name" class="form-label">Commander Name</label>
+                <label for="player_name" class="form-label">
+                    {% if single_player %}Your name, brother of the Watch{% else %}Commander Name{% endif %}
+                </label>
                 <input type="text" class="form-control form-control-lg" id="player_name" name="player_name"
                        placeholder="Enter your name..." required
                        style="max-width: 400px; margin: 0 auto; text-align: center;">
             </div>
-            <input type="hidden" name="faction" id="factionInput" value="" required>
+            <input type="hidden" name="faction" id="factionInput" value="{% if single_player %}{{ player_faction }}{% endif %}" required>
 
+            {% if single_player %}
+            <!-- Single-player: one preset faction card, auto-selected. -->
+            <div class="row g-4 faction-selection justify-content-center mb-4">
+                <div class="col-md-6">
+                    <div class="card faction-card faction-nights-watch faction-selected {% if not player_available %}faction-unavailable{% endif %}"
+                         data-faction="{{ player_faction }}">
+                        <div class="card-body">
+                            <span class="faction-icon nights-watch-icon">
+                                <i class="fas fa-shield-halved"></i>
+                            </span>
+                            <h4>The Night's Watch</h4>
+                            <p class="faction-motto">"Night gathers, and now my watch begins."</p>
+                            <p class="faction-start">
+                                <i class="fas fa-map-marker-alt me-1"></i>Castle Black
+                            </p>
+                            {% if not player_available %}
+                            <div class="mt-2">
+                                <span class="badge bg-danger"><i class="fas fa-ban me-1"></i>Already taken — reset the game</span>
+                            </div>
+                            {% endif %}
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <div class="text-center">
+                <button type="submit" id="enterGameBtn" class="btn btn-primary btn-lg px-5 py-2"
+                        {% if not player_available %}disabled{% endif %}>
+                    <i class="fas fa-chess-knight me-2"></i>Take the Black
+                </button>
+            </div>
+            {% else %}
+            <!-- Two-faction WoK selection -->
             <div class="row g-4 faction-selection justify-content-center mb-4">
                 <div class="col-md-5">
                     <div class="card faction-card faction-southern {% if not southern_available %}faction-unavailable{% endif %}"
@@ -81,6 +129,7 @@
                     <i class="fas fa-dungeon me-2"></i>Enter The Game
                 </button>
             </div>
+            {% endif %}
         </form>
 
         <!-- Reset & Replay links -->

--- a/game-of-tracing/war_map/templates/map.html
+++ b/game-of-tracing/war_map/templates/map.html
@@ -814,7 +814,10 @@
 
         document.getElementById('refreshMapBtn').addEventListener('click', refreshMapData);
 
-        setInterval(refreshMapData, 30000);
+        // Poll every 5 s so the wall-hold counter and resource HUD reflect
+        // the wall-tick thread (30 s cadence) and AI moves within seconds
+        // rather than up to a minute later.
+        setInterval(refreshMapData, 5000);
         setInterval(checkGameStatus, 5000);
 
         document.getElementById('sendResourcesBtn').addEventListener('click', () => {

--- a/game-of-tracing/war_map/templates/map.html
+++ b/game-of-tracing/war_map/templates/map.html
@@ -60,6 +60,26 @@
             <!-- Location Markers (added dynamically) -->
             <div id="mapMarkers"></div>
 
+            {% if wall_hold %}
+            <!-- Wall-hold HUD (WWA win-condition tracker) -->
+            <div class="wall-hold-hud" id="wallHoldHud">
+                <h6><i class="fas fa-gavel me-1"></i>Wall Hold</h6>
+                <div class="small mb-1">Hold every keep for {{ wall_hold.threshold }} ticks to win.</div>
+                <div class="hold-row nights_watch">
+                    <span>Night's Watch</span>
+                    <span class="ticks" id="hudHoldNightsWatch">
+                        {{ wall_hold.holds.get('nights_watch', 0) }}/{{ wall_hold.threshold }}
+                    </span>
+                </div>
+                <div class="hold-row white_walkers">
+                    <span>White Walkers</span>
+                    <span class="ticks" id="hudHoldWhiteWalkers">
+                        {{ wall_hold.holds.get('white_walkers', 0) }}/{{ wall_hold.threshold }}
+                    </span>
+                </div>
+            </div>
+            {% endif %}
+
             <!-- Alert messages -->
             <div id="mapAlert" class="position-absolute top-0 start-0 end-0 alert alert-danger m-3 d-none">
                 An error occurred
@@ -382,20 +402,21 @@
                 const f1 = loc1.faction;
                 const f2 = loc2.faction;
 
+                const factionLineColors = {
+                    southern: 'rgba(255, 215, 0, 0.35)',
+                    northern: 'rgba(79, 195, 247, 0.35)',
+                    nights_watch: 'rgba(215, 228, 241, 0.45)',
+                    white_walkers: 'rgba(136, 196, 230, 0.45)',
+                    barbarian: 'rgba(193, 68, 46, 0.35)'
+                };
                 if (f1 !== 'neutral' && f1 === f2) {
-                    // Both same faction — faction color
-                    if (f1 === 'southern') {
-                        ctx.strokeStyle = 'rgba(255, 215, 0, 0.35)';
-                    } else {
-                        ctx.strokeStyle = 'rgba(79, 195, 247, 0.35)';
-                    }
+                    ctx.strokeStyle = factionLineColors[f1] || 'rgba(120, 144, 156, 0.2)';
                     ctx.setLineDash([]);
                 } else if (f1 !== 'neutral' && f2 !== 'neutral' && f1 !== f2) {
-                    // Enemy territories — red dashed
+                    // Any two non-neutral, non-identical factions = contested.
                     ctx.strokeStyle = 'rgba(239, 68, 68, 0.3)';
                     ctx.setLineDash([8, 6]);
                 } else {
-                    // Neutral connections
                     ctx.strokeStyle = 'rgba(120, 144, 156, 0.2)';
                     ctx.setLineDash([]);
                 }
@@ -419,12 +440,24 @@
             marker.style.left = `${locationData.x}%`;
             marker.style.top = `${locationData.y}%`;
 
-            // Icon
+            // Icon — chosen by (type, faction).
             let icon = document.createElement('i');
-            if (locationData.type === 'capital') {
-                icon.className = locationData.faction === 'southern' ? 'fas fa-sun' :
-                                 locationData.faction === 'northern' ? 'fas fa-snowflake' :
-                                 'fas fa-chess-rook';
+            const factionIcons = {
+                southern: 'fas fa-sun',
+                northern: 'fas fa-snowflake',
+                nights_watch: 'fas fa-shield-halved',
+                white_walkers: 'fas fa-icicles',
+                barbarian: 'fas fa-campground',
+                neutral: 'fas fa-chess-rook'
+            };
+            if (locationData.type === 'wall') {
+                // Wall keeps always render as a gate/tower regardless of holder;
+                // the colour on the marker conveys the faction.
+                icon.className = 'fas fa-tower-cell';
+            } else if (locationData.type === 'capital') {
+                icon.className = factionIcons[locationData.faction] || 'fas fa-chess-rook';
+            } else if (locationData.faction === 'barbarian') {
+                icon.className = 'fas fa-campground';
             } else {
                 icon.className = 'fas fa-map-marker-alt';
             }
@@ -723,6 +756,16 @@
             gameState.gameOver = data.game_over;
             gameState.winner = data.winner;
             gameState.victoryMessage = data.victory_message;
+
+            // Update the Wall Hold HUD if present (White Walkers Attack).
+            if (data.wall_hold) {
+                const nw = document.getElementById('hudHoldNightsWatch');
+                const ww = document.getElementById('hudHoldWhiteWalkers');
+                const threshold = data.wall_hold.threshold || 5;
+                const holds = data.wall_hold.holds || {};
+                if (nw) nw.textContent = `${holds.nights_watch || 0}/${threshold}`;
+                if (ww) ww.textContent = `${holds.white_walkers || 0}/${threshold}`;
+            }
 
             // Defer visual rebuild while animations are playing
             if (activeAnimations > 0) {

--- a/game-of-tracing/war_map/templates/map_picker.html
+++ b/game-of-tracing/war_map/templates/map_picker.html
@@ -1,0 +1,74 @@
+{% extends "layout.html" %}
+
+{% block title %}Pick a Map{% endblock %}
+
+{% block content %}
+<div class="faction-hero">
+    <div class="col-lg-9 col-xl-8">
+        <div class="text-center mb-5">
+            <h1 class="faction-hero-title">A Game of Traces</h1>
+            <p class="faction-hero-subtitle">Pick a battlefield. Each map has its own factions, economy, and win conditions.</p>
+        </div>
+
+        <form method="POST" action="{{ url_for('select_map') }}" id="mapPickerForm">
+            <input type="hidden" name="map_id" id="mapIdInput" value="" required>
+
+            <div class="row g-4 justify-content-center mb-4">
+                {% for map_id, meta in maps.items() %}
+                <div class="col-md-6">
+                    <div class="card faction-card map-card" data-map-id="{{ map_id }}">
+                        <div class="card-body">
+                            <span class="faction-icon">
+                                <i class="fas {{ meta.icon }}"></i>
+                            </span>
+                            <h4>{{ meta.display_name }}</h4>
+                            <p class="faction-motto">
+                                {% if meta.single_player %}Single-player · Hold to win
+                                {% else %}Two-player · Capture to win
+                                {% endif %}
+                            </p>
+                            <p class="faction-start">{{ meta.description }}</p>
+                            <p class="small mt-2 mb-0">
+                                <strong>Factions:</strong>
+                                {{ meta.factions | join(', ') | replace('_', ' ') | title }}
+                            </p>
+                        </div>
+                    </div>
+                </div>
+                {% endfor %}
+            </div>
+
+            <div class="text-center">
+                <button type="submit" id="enterMapBtn" class="btn btn-primary btn-lg px-5 py-2" disabled>
+                    <i class="fas fa-play me-2"></i>Enter The Realm
+                </button>
+            </div>
+        </form>
+    </div>
+</div>
+{% endblock %}
+
+{% block scripts %}
+<script>
+    $(document).ready(function() {
+        const mapInput = $('#mapIdInput');
+        const enterBtn = $('#enterMapBtn');
+
+        $('.map-card').click(function() {
+            const mapId = $(this).data('map-id');
+            mapInput.val(mapId);
+            $('.map-card').removeClass('faction-selected');
+            $(this).addClass('faction-selected');
+            enterBtn.prop('disabled', false);
+        });
+
+        $('#mapPickerForm').on('submit', function(e) {
+            if (!mapInput.val()) {
+                e.preventDefault();
+                $('.map-card').addClass('border-warning');
+                setTimeout(() => $('.map-card').removeClass('border-warning'), 900);
+            }
+        });
+    });
+</script>
+{% endblock %}

--- a/game-of-tracing/war_map/templates/replay_session.html
+++ b/game-of-tracing/war_map/templates/replay_session.html
@@ -177,30 +177,12 @@ let replayInterval = null;
 let gameLocations = {};
 let replaySpeed = 2000;
 
-const LOCATION_POSITIONS = {
-    "southern_capital": {"x": 20, "y": 70, "type": "capital", "name": "Southern Capital"},
-    "northern_capital": {"x": 80, "y": 20, "type": "capital", "name": "Northern Capital"},
-    "village_1": {"x": 35, "y": 55, "type": "village", "name": "Village 1"},
-    "village_2": {"x": 65, "y": 35, "type": "village", "name": "Village 2"},
-    "village_3": {"x": 30, "y": 40, "type": "village", "name": "Village 3"},
-    "village_4": {"x": 45, "y": 65, "type": "village", "name": "Village 4"},
-    "village_5": {"x": 50, "y": 50, "type": "village", "name": "Village 5"},
-    "village_6": {"x": 70, "y": 45, "type": "village", "name": "Village 6"}
-};
-
-const LOCATION_CONNECTIONS = [
-    ["southern_capital", "village_1"],
-    ["southern_capital", "village_3"],
-    ["northern_capital", "village_2"],
-    ["northern_capital", "village_6"],
-    ["village_1", "village_2"],
-    ["village_1", "village_4"],
-    ["village_2", "village_5"],
-    ["village_3", "village_5"],
-    ["village_3", "village_6"],
-    ["village_4", "village_5"],
-    ["village_5", "village_6"]
-];
+// Layout for the map this session was played on — provided server-side
+// from ``LOCATION_POSITIONS_BY_MAP[map_id]`` so the replay matches WWA or
+// any future map, not just the WoK default.
+const REPLAY_MAP_ID = {{ map_id | tojson }};
+const LOCATION_POSITIONS = {{ location_positions | tojson }};
+const LOCATION_CONNECTIONS = {{ location_connections | tojson }};
 
 document.addEventListener('DOMContentLoaded', function() {
     loadSessionData();


### PR DESCRIPTION
## Summary
- Adds a second playable map — **White Walkers Attack** — selected via a new in-UI picker at game start. Night's Watch (player) vs White Walkers (AI), with Barbarians as a passive third faction. Both maps reuse the existing 8 location containers via a new slot-identity system (`SLOT_ID` env + `/reload` endpoint + `active_map_id` row in `game_state.db`).
- New settlement type `wall` with a **2× defender multiplier** in battles; new **corpse economy** for the White Walkers (5 corpses per army unit, earned from battle kills + passive fortress tick); passive **barbarian army growth** (+1 army per 30 s). Stored in new `faction_economy` and `wall_hold` tables.
- New win condition for WWA: hold every wall keep continuously for **5 × 30 s ticks**. A new `_wall_tick_thread` in `war_map` drives the counter; HUD overlay on the map renders live hold progress.
- New **`WhiteWalkerAI`** subclass of `StrategicAI` with a WWA-tailored priority cascade (defend fortress → capture unowned wall → reinforce wall → raid barbarian → raise army from corpses → idle). Dispatches off the `faction` field on `/activate`.
- Map picker + single-player index variant + new CSS variables/classes for Night's Watch / White Walkers / Barbarian / wall markers (FontAwesome icons, no new image assets — matches repo precedent).
- All existing War of Kingdoms behaviour is preserved. Existing metric and span attribute names are **not renamed**; new attributes (`game.map.id`, `game.wall.held`, `game.corpses.harvested`, `game.corpses.spent`) and metrics (`ai.corpse_pool`, `ai.walls_captured`) are additive.

**Change footprint:** 17 files, +2,633 / −414.

## Architecture
- **`app/game_config.py`** — refactored into a `MAPS` dict (`war_of_kingdoms`, `white_walkers_attack`), each carrying `slot_assignments`, `locations`, and `rules`. Legacy `LOCATIONS` / `RESOURCE_GENERATION` / `COSTS` remain importable as WoK defaults.
- **`app/location_server.py`** — reads `SLOT_ID` env; resolves identity from `active_map_id` stored in the new `game_config` table; `/reload` rebinds in place; `_handle_battle` accepts `location_type` and applies `rules["wall_multiplier"]` to wall defenders; new passive threads for barbarian army growth and WW fortress corpse generation; corpse bookkeeping in `faction_economy`.
- **`ai_opponent/ai_server.py`** — `MapAnalyzer` takes a graph argument (no longer hardcodes WoK); `StrategicAI` takes `map_id` and computes capitals from the map config; new `WhiteWalkerAI` subclass. `/activate` accepts `{faction, map_id}`.
- **`war_map/app.py`** — `/map_picker` + `/select_map` routes; session-level `map_id`; `check_game_over` dispatches to `check_capital_capture_win` (WoK) or `check_wall_hold_win` (WWA); `_wall_tick_thread` runs every 30 s when WWA is active; `/api/map_data` now returns `wall_hold` state so the HUD updates on the existing poll loop.
- **`docker-compose.yml`** — all 8 location services now run `python location_server.py` with a `SLOT_ID` env var; container names stay stable so Grafana dashboards don't lose series when the active map changes.

## Test plan
- [ ] `cd game-of-tracing && docker compose down -v && docker compose up -d` boots a clean stack and lands on `/map_picker`
- [ ] **WoK regression:** pick War of Kingdoms → existing faction selection → play a few actions → traces in Tempo, flamegraphs in Pyroscope, panels in Grafana all populate unchanged
- [ ] **WWA happy path:** pick White Walkers Attack → lands on the Night's Watch single-player start → AI auto-activates as White Walkers
- [ ] Attacking an empty wall with 3 NW army captures it
- [ ] Attacking a wall with 3 defending WW army using 5 NW army fails (5 vs 6 effective) — span attribute `game.wall.held=true` appears
- [ ] WW raid on a barbarian village bumps the corpse pool (`ai.corpse_pool` gauge climbs; `/faction_economy?faction=white_walkers` reflects the new total)
- [ ] WW fortress accrues +1 corpse every 15 s
- [ ] Capturing every wall as NW makes the HUD show `Wall held: 1/5` within 30 s; 5/5 within 150 s triggers the winner banner
- [ ] Losing a wall mid-hold resets the HUD to `0/5`
- [ ] Switching back to WoK from the picker wipes state and re-seeds WoK rows via `/reset` + `/reload` on all 8 slots
- [ ] `python3 -m py_compile` (already passing) on every touched Python file
- [ ] `grep -rn map_id game-of-tracing/` returns hits in game_config, location_server, war_map, ai_opponent, templates, and CLAUDE.md files

## Known follow-ups
- Line-number anchors in several submodule CLAUDE.md sections haven't been refreshed after this PR's large line-count shifts. File-map rows, mechanics descriptions, env tables, routes tables, and new-section additions are up-to-date; specific `file.py:NNN-NNN` anchors for unchanged symbols still point to their pre-PR positions and should be swept in a follow-up (scenario policy treats stale anchors as regressions).
- WWA-specific Grafana dashboard panels (corpse pool over time, wall control stripchart, hold-counter vs threshold) are not added in this PR — the raw metrics ship, but the panels themselves are deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)