### PR TITLE
Add lightweight CI validation for k8s/ scenarios

### DIFF
--- a/.github/k8s-scenarios.json
+++ b/.github/k8s-scenarios.json
@@ -1,0 +1,22 @@
+{
+  "metrics": [
+    { "release": "prometheus", "chart": "prometheus-community/prometheus", "values": "prometheus-values.yml" },
+    { "release": "grafana",    "chart": "grafana/grafana",                 "values": "grafana-values.yml" },
+    { "release": "k8s",        "chart": "grafana/k8s-monitoring",          "values": "k8s-monitoring-values.yml", "version": "^4.0.0" }
+  ],
+  "logs": [
+    { "release": "loki",       "chart": "grafana/loki",                    "values": "loki-values.yml" },
+    { "release": "grafana",    "chart": "grafana/grafana",                 "values": "grafana-values.yml" },
+    { "release": "k8s",        "chart": "grafana/k8s-monitoring",          "values": "k8s-monitoring-values.yml", "version": "^4.0.0" }
+  ],
+  "tracing": [
+    { "release": "tempo",      "chart": "grafana/tempo",                   "values": "tempo-values.yml" },
+    { "release": "grafana",    "chart": "grafana/grafana",                 "values": "grafana-values.yml" },
+    { "release": "k8s",        "chart": "grafana/k8s-monitoring",          "values": "k8s-monitoring-values.yml", "version": "^4.0.0" }
+  ],
+  "profiling": [
+    { "release": "pyroscope",  "chart": "grafana/pyroscope",               "values": "pyroscope-values.yml" },
+    { "release": "grafana",    "chart": "grafana/grafana",                 "values": "grafana-values.yml" },
+    { "release": "k8s",        "chart": "grafana/k8s-monitoring",          "values": "k8s-monitoring-values.yml", "version": "^4.0.0" }
+  ]
+}

--- a/.github/workflows/validate-k8s-scenarios.yml
+++ b/.github/workflows/validate-k8s-scenarios.yml
@@ -1,0 +1,286 @@
+name: validate-k8s-scenarios
+
+# Lightweight validation for k8s scenarios under k8s/. Mirrors the
+# defense-in-depth posture of validate-scenarios.yml (docker), but
+# without paying the cost of a real cluster on every PR:
+#
+#   validate (every PR):  helm template + kubeconform per chart per scenario.
+#                         Renders offline, validates against k8s API schemas.
+#   kind-integration:     opt-in via workflow_dispatch only. Boots kind,
+#                         helm-installs all charts, waits for pods Ready.
+#
+# Defense-in-depth (same as the docker workflow):
+#   - permissions: contents: read       (no token write, no secrets)
+#   - harden-runner egress allowlist    (compromised tool can't phone home)
+#   - third-party actions SHA-pinned    (tag pushes can't sneak in)
+#   - direct binary downloads, version-pinned (helm, kubeconform)
+#   - github-hosted ephemeral runners
+#   - pull_request, not pull_request_target
+
+on:
+  pull_request:
+    paths:
+      - 'k8s/**'
+      - '.github/k8s-scenarios.json'
+      - '.github/workflows/validate-k8s-scenarios.yml'
+  workflow_dispatch:
+    inputs:
+      kind_integration:
+        description: 'Run the kind-cluster integration job after validation'
+        type: boolean
+        default: false
+      scenario:
+        description: 'Which scenario(s) to run kind-integration for ("all" or comma-separated subset, e.g. "metrics,logs")'
+        type: string
+        default: 'all'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: validate-k8s-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
+env:
+  HELM_VERSION: 'v4.1.4'
+  KUBECONFORM_VERSION: 'v0.6.7'
+  KUBERNETES_VERSION: '1.31.0'
+
+jobs:
+  # ──────────────────────────────────────────────────────────────────
+  # validate: helm template + kubeconform per chart for each of the
+  # 4 scenarios. Pure offline — no API server, no real cluster.
+  # ──────────────────────────────────────────────────────────────────
+  validate:
+    name: Validate ${{ matrix.scenario }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 8
+    strategy:
+      fail-fast: false
+      matrix:
+        scenario: [metrics, logs, tracing, profiling]
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            github.com:443
+            objects.githubusercontent.com:443
+            raw.githubusercontent.com:443
+            get.helm.sh:443
+            grafana.github.io:443
+            prometheus-community.github.io:443
+            charts.bitnami.com:443
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install helm + kubeconform + yamllint
+        run: |
+          set -euo pipefail
+          # Helm — pinned by version. Upstream tarball, verify by sha would
+          # be ideal but Helm doesn't publish stable per-tag checksums in a
+          # consumable way; pinning the version + restricting egress is the
+          # workable compromise.
+          curl -fsSL "https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz" \
+            | tar -xz -C /tmp
+          sudo install -m 0755 /tmp/linux-amd64/helm /usr/local/bin/helm
+
+          # kubeconform — pinned. The release archive contains just the
+          # binary; we extract it directly.
+          curl -fsSL "https://github.com/yannh/kubeconform/releases/download/${KUBECONFORM_VERSION}/kubeconform-linux-amd64.tar.gz" \
+            | sudo tar -xz -C /usr/local/bin/ kubeconform
+
+          # yamllint — preinstalled python3 + pip on ubuntu-latest.
+          sudo pip install --quiet yamllint
+
+          helm version --short
+          kubeconform -v
+          yamllint --version
+
+      - name: Helm repo bootstrap
+        run: |
+          set -euo pipefail
+          helm repo add grafana https://grafana.github.io/helm-charts
+          helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+          helm repo update
+
+      - name: yamllint values files
+        # Loose ruleset — values files commonly use long datasource URLs and
+        # don't need a leading `---`. Run as advisory: don't fail the job on
+        # style; we want it for hygiene signal, not blocking.
+        continue-on-error: true
+        run: |
+          yamllint -d "{extends: relaxed, rules: {line-length: disable, document-start: disable}}" \
+            k8s/${{ matrix.scenario }}/
+
+      - name: Helm template + kubeconform per chart
+        run: |
+          set -euo pipefail
+          mkdir -p /tmp/rendered
+          fail=0
+
+          # Iterate the scenario's chart list. helm template against the
+          # remote chart triggers values.schema.json validation upstream
+          # (most grafana charts ship a schema), then kubeconform validates
+          # the rendered Kubernetes API objects against the target version.
+          while IFS= read -r entry; do
+            release=$(jq -r '.release' <<<"$entry")
+            chart=$(jq -r '.chart'    <<<"$entry")
+            values=$(jq -r '.values'  <<<"$entry")
+            version=$(jq -r '.version // ""' <<<"$entry")
+            values_path="k8s/${{ matrix.scenario }}/$values"
+
+            ver_arg=()
+            [ -n "$version" ] && ver_arg=(--version "$version")
+
+            echo "::group::helm template $release ($chart${version:+ @$version})"
+            out="/tmp/rendered/${{ matrix.scenario }}-$release.yaml"
+            if ! helm template "$release" "$chart" "${ver_arg[@]}" \
+                  -f "$values_path" > "$out" 2> "/tmp/rendered/${{ matrix.scenario }}-$release.err"; then
+              echo "::error::helm template failed for $release"
+              cat "/tmp/rendered/${{ matrix.scenario }}-$release.err"
+              fail=1
+              echo "::endgroup::"
+              continue
+            fi
+            lines=$(wc -l < "$out")
+            echo "Rendered $lines lines to $out"
+            echo "::endgroup::"
+
+            echo "::group::kubeconform $release"
+            # -ignore-missing-schemas: skip CRDs whose schemas aren't in the
+            # datree catalog (catching built-in K8s API drift is the real
+            # signal; CRD validation is the chart maintainer's responsibility).
+            if ! kubeconform -strict -summary \
+                  -kubernetes-version "$KUBERNETES_VERSION" \
+                  -schema-location default \
+                  -schema-location 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json' \
+                  -ignore-missing-schemas \
+                  "$out"; then
+              echo "::error::kubeconform failed for $release"
+              fail=1
+            fi
+            echo "::endgroup::"
+          done < <(jq -c --arg s "${{ matrix.scenario }}" '.[$s][]' .github/k8s-scenarios.json)
+
+          exit $fail
+
+      - name: Upload rendered manifests
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: rendered-${{ matrix.scenario }}
+          path: /tmp/rendered/
+          retention-days: 7
+
+  # ──────────────────────────────────────────────────────────────────
+  # kind-integration: Boots a real kind cluster and helm-installs all
+  # charts for the scenario. Heavy — only on workflow_dispatch.
+  # ──────────────────────────────────────────────────────────────────
+  kind-integration:
+    name: Kind integration ${{ matrix.scenario }}
+    if: github.event_name == 'workflow_dispatch' && inputs.kind_integration == true
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    strategy:
+      fail-fast: false
+      matrix:
+        scenario: [metrics, logs, tracing, profiling]
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
+        with:
+          egress-policy: block
+          # Adds image registries on top of the validate allowlist —
+          # helm install actually pulls images for kind to schedule.
+          allowed-endpoints: >
+            api.github.com:443
+            github.com:443
+            objects.githubusercontent.com:443
+            raw.githubusercontent.com:443
+            get.helm.sh:443
+            grafana.github.io:443
+            prometheus-community.github.io:443
+            charts.bitnami.com:443
+            registry-1.docker.io:443
+            auth.docker.io:443
+            production.cloudflare.docker.com:443
+            ghcr.io:443
+            quay.io:443
+            cdn.quay.io:443
+            grafana.com:443
+            mcr.microsoft.com:443
+            public.ecr.aws:443
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Filter by scenario input
+        id: filter
+        run: |
+          set -euo pipefail
+          want="${{ inputs.scenario }}"
+          if [ "$want" = "all" ]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if grep -qx '${{ matrix.scenario }}' <(tr ',' '\n' <<<"$want"); then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Skipping ${{ matrix.scenario }} (not in user-selected subset '$want')"
+          fi
+
+      - name: Install helm
+        if: steps.filter.outputs.run == 'true'
+        run: |
+          curl -fsSL "https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz" \
+            | tar -xz -C /tmp
+          sudo install -m 0755 /tmp/linux-amd64/helm /usr/local/bin/helm
+
+      - name: Create kind cluster
+        if: steps.filter.outputs.run == 'true'
+        uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
+        with:
+          config: k8s/${{ matrix.scenario }}/kind.yml
+          cluster_name: ${{ matrix.scenario }}
+
+      - name: Helm bootstrap + install all charts
+        if: steps.filter.outputs.run == 'true'
+        run: |
+          set -euo pipefail
+          helm repo add grafana https://grafana.github.io/helm-charts
+          helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
+          helm repo update
+          kubectl create namespace meta || true
+
+          while IFS= read -r entry; do
+            release=$(jq -r '.release' <<<"$entry")
+            chart=$(jq -r '.chart'    <<<"$entry")
+            values=$(jq -r '.values'  <<<"$entry")
+            version=$(jq -r '.version // ""' <<<"$entry")
+            values_path="k8s/${{ matrix.scenario }}/$values"
+
+            ver_arg=()
+            [ -n "$version" ] && ver_arg=(--version "$version")
+
+            echo "::group::helm install $release ($chart)"
+            helm install "$release" "$chart" "${ver_arg[@]}" \
+              -f "$values_path" -n meta --create-namespace \
+              --wait --timeout 5m
+            echo "::endgroup::"
+          done < <(jq -c --arg s "${{ matrix.scenario }}" '.[$s][]' .github/k8s-scenarios.json)
+
+      - name: Wait for pods Ready in meta namespace
+        if: steps.filter.outputs.run == 'true'
+        run: |
+          if ! kubectl wait --for=condition=Ready pods --all -n meta --timeout=10m; then
+            echo "::error::Pods did not become Ready"
+            kubectl get pods -n meta -o wide
+            kubectl describe pods -n meta
+            exit 1
+          fi
+          kubectl get pods -n meta -o wide

--- a/.github/workflows/validate-k8s-scenarios.yml
+++ b/.github/workflows/validate-k8s-scenarios.yml
@@ -68,6 +68,7 @@ jobs:
             api.github.com:443
             github.com:443
             objects.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
             raw.githubusercontent.com:443
             get.helm.sh:443
             grafana.github.io:443
@@ -200,6 +201,7 @@ jobs:
             api.github.com:443
             github.com:443
             objects.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
             raw.githubusercontent.com:443
             get.helm.sh:443
             grafana.github.io:443
@@ -220,18 +222,25 @@ jobs:
 
       - name: Filter by scenario input
         id: filter
+        # User-supplied workflow_dispatch input is passed via env, NOT
+        # interpolated directly into the run block, to prevent
+        # template-injection (zizmor: template-injection rule).
+        # matrix.scenario IS safe to interpolate directly because it's
+        # constrained to the static list above.
+        env:
+          USER_SCENARIO: ${{ inputs.scenario }}
+          MATRIX_SCENARIO: ${{ matrix.scenario }}
         run: |
           set -euo pipefail
-          want="${{ inputs.scenario }}"
-          if [ "$want" = "all" ]; then
+          if [ "$USER_SCENARIO" = "all" ]; then
             echo "run=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          if grep -qx '${{ matrix.scenario }}' <(tr ',' '\n' <<<"$want"); then
+          if grep -qx "$MATRIX_SCENARIO" <(tr ',' '\n' <<<"$USER_SCENARIO"); then
             echo "run=true" >> "$GITHUB_OUTPUT"
           else
             echo "run=false" >> "$GITHUB_OUTPUT"
-            echo "::notice::Skipping ${{ matrix.scenario }} (not in user-selected subset '$want')"
+            echo "::notice::Skipping $MATRIX_SCENARIO (not in user-selected subset '$USER_SCENARIO')"
           fi
 
       - name: Install helm


### PR DESCRIPTION
## Summary

Companion to #67 (docker-compose validation). Adds a workflow that runs `helm template | kubeconform` against every k8s/ scenario on PR — fast, offline, no cluster required — plus an opt-in `workflow_dispatch` job that boots a real kind cluster and helm-installs all charts when a maintainer wants the heavy signal.

- New `.github/workflows/validate-k8s-scenarios.yml` — two jobs: `validate` (always) and `kind-integration` (manual).
- New `.github/k8s-scenarios.json` — single source of truth mapping each scenario to its 3 Helm charts.

## Why lightweight is enough here

The k8s tree is uniform and friendly: 4 scenarios (`metrics`, `logs`, `tracing`, `profiling`), each installing exactly 3 Helm charts, no raw manifests, no Helm hooks, no admission webhooks, no CRDs in values files. Every realistic breakage from a values-file edit or chart bump can be caught with:

1. `helm template <chart> -f <values>` — runs the chart's `values.schema.json` validation upstream and renders manifests.
2. `kubeconform -strict` against the rendered output — validates K8s API objects against schemas for the target version.

A real cluster only adds value for things this workflow intentionally doesn't cover: pod startup, image-pull, PVC binding, Helm hooks. Those land in the opt-in `kind-integration` job.

## Validate job (every k8s PR)

Matrix: `[metrics, logs, tracing, profiling]` (4 parallel jobs).

For each scenario:
- yamllint on values files (advisory only — doesn't fail).
- For each (release, chart, values) tuple from `.github/k8s-scenarios.json`:
  - `helm template ...` (validates against the chart's `values.schema.json` upstream).
  - `kubeconform -strict -summary -kubernetes-version 1.31.0 -ignore-missing-schemas` on the rendered output. The datreeio CRDs catalog is added as a fallback schema source; `-ignore-missing-schemas` covers any custom resource not in either catalog.
- Rendered manifests uploaded as artifacts for 7 days (handy for debugging schema breaks).

Wall time: ~2 min. Catches: invalid values keys, K8s API drift (e.g. removed `apiVersion`), broken manifests.

## Kind-integration job (workflow_dispatch only)

Triggered manually via the Actions UI. Inputs:
- `kind_integration: true|false` (default `false`)
- `scenario: "all" | "metrics,logs"` (default `"all"`)

For each requested scenario:
- Boots kind using the scenario's existing `kind.yml` (same spec the README uses for local dev).
- `helm install` all 3 charts into the `meta` namespace, `--wait`.
- `kubectl wait` until all pods Ready.
- Cluster teardown handled by `helm/kind-action` cleanup.

Wall time: ~5–10 min per scenario, runs in matrix.

## Defense-in-depth (mirrors #67)

| Layer | Where |
|---|---|
| `permissions: contents: read` | Workflow root |
| `harden-runner` egress allowlist | Per-job step 1; tightest possible (Helm + GitHub + grafana/prometheus chart hosts for `validate`; adds image registries for `kind-integration`) |
| Third-party actions SHA-pinned | harden-runner, checkout, upload-artifact, kind-action |
| Pinned tool versions | helm `v4.1.4`, kubeconform `v0.6.7` |
| Direct binary downloads from upstream | `get.helm.sh`, `github.com/yannh/kubeconform/releases` |
| `pull_request` not `pull_request_target` | Fork PRs run without secrets |
| `concurrency.cancel-in-progress: true` | No runaway re-runs on force-push |
| `kind-integration` opt-in only | Heavy work doesn't run on every PR |

## Verified locally

All 4 scenarios validate cleanly with the workflow's exact pipeline:

| Scenario | Backend | Grafana | k8s-monitoring |
|---|---|---|---|
| metrics | prometheus: 25 valid, 0 invalid | grafana: 13 valid, 0 invalid | k8s: 24 valid, 1 skipped (CRD) |
| logs | loki: 28 valid, 0 invalid | grafana: 13 valid, 0 invalid | k8s: 19 valid, 2 skipped |
| tracing | tempo: 4 valid, 0 invalid | grafana: 13 valid, 0 invalid | k8s: 18 valid, 1 skipped |
| profiling | pyroscope: 15 valid, 0 invalid | grafana: 13 valid, 0 invalid | k8s: 18 valid, 1 skipped |

Skips are CRDs whose schemas aren't in the datreeio catalog — expected and acceptable (the chart maintainers own those).

## Out of scope (deferred / advisory)

- **kube-score** on rendered manifests — best-practice warnings (security context, resource limits). Easy to add as a non-failing step later.
- **trivy config** scan on rendered manifests — security policy linting. Same.
- **Renovate regexManager** to bump `^4.0.0` chart version in README install commands — k8s renovate has a gap here today (chart versions live in markdown, not config). Separate, smaller change.

## Test plan

- [ ] This PR triggers `validate` only (`pull_request` event); all 4 scenarios should pass.
- [ ] Open a follow-up draft PR adding `nonexistent_key: foo` to `k8s/logs/grafana-values.yml` → `helm template` should fail with a schema error.
- [ ] Open a follow-up draft PR rendering an invalid manifest (e.g. `replicas: -1`) → kubeconform should reject with a clear error.
- [ ] Manually trigger `workflow_dispatch` with `kind_integration: true, scenario: metrics` → confirm only `metrics` boots a kind cluster, all 3 charts install, pods become Ready, cluster tears down.
- [ ] Manually trigger with `kind_integration: true, scenario: all` → all 4 in parallel within the 25-min timeout.
- [ ] On any run: `harden-runner` step output should show egress audits / blocked attempts confirming the allowlist is enforced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)