### PR TITLE
Track grafana/k8s-monitoring chart version via renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,6 +9,17 @@
       "matchStrings": [
         "# renovate: datasource=(?<datasource>.+?) depName=(?<depName>.+?)\\s+\\w+_VERSION=(?<currentValue>.+)"
       ]
+    },
+    {
+      "customType": "regex",
+      "description": "Bump grafana/k8s-monitoring chart version pinned in k8s/*/README.md install commands. The other two charts in each scenario (backend + grafana) are intentionally unpinned (`helm install` resolves latest at run time), so only k8s-monitoring needs tracking.",
+      "fileMatch": ["^k8s/.+/README\\.md$"],
+      "matchStrings": [
+        "grafana/k8s-monitoring --version \"(?<currentValue>[^\"]+)\""
+      ],
+      "datasourceTemplate": "helm",
+      "depNameTemplate": "k8s-monitoring",
+      "registryUrlTemplate": "https://grafana.github.io/helm-charts"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Builds on #69. Adds a customManager that bumps the `grafana/k8s-monitoring` Helm chart version pinned in each k8s scenario's README install command.

## Why a customManager

The 4 k8s scenarios install three Helm charts each. Two are intentionally unpinned (`helm install grafana grafana/grafana` resolves latest at run time — fine for demo scenarios). The third, `grafana/k8s-monitoring`, is pinned via `--version "^4.0.0"` in the README install command. That pin lives in markdown, not in a config file renovate manages by default, so nothing has been bumping it.

This customManager fixes that:
- `fileMatch: ["^k8s/.+/README\\.md$"]`
- `matchStrings: grafana/k8s-monitoring --version "(?<currentValue>[^"]+)"`
- `datasourceTemplate: "helm"`, `depNameTemplate: "k8s-monitoring"`, `registryUrlTemplate: "https://grafana.github.io/helm-charts"`

## Behaviour

Renovate's default `rangeStrategy: "replace"` only proposes a bump when the upstream major moves outside the current range. `^4.0.0` already accepts any 4.x at install time, so in-range minors don't generate noise. When upstream ships v5, renovate opens **one PR** that updates all 4 README files (grouped by depName).

## Companion to #68

When renovate proposes the chart bump, the validate-k8s-scenarios workflow (#68) helm-templates all 4 scenarios at the new version and validates rendered manifests with kubeconform. Automated gate before merge.

## Verified locally

```
k8s/logs/README.md      → currentValue=^4.0.0
k8s/metrics/README.md   → currentValue=^4.0.0
k8s/profiling/README.md → currentValue=^4.0.0
k8s/tracing/README.md   → currentValue=^4.0.0
```

All 4 scenarios match. Renovate will treat them as one logical dep across 4 files.

## Merge order

This PR's base is `chore/renovate-lgmt-versions` (PR #69). Merge #69 first, then this rebase to main automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)