### PR TITLE
Fix validate-scenarios egress allowlist (trivy DB + GitHub releases)

### DIFF
--- a/.github/workflows/validate-scenarios.yml
+++ b/.github/workflows/validate-scenarios.yml
@@ -127,16 +127,21 @@ jobs:
         uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
           egress-policy: block
+          # mirror.gcr.io is where trivy v0.50+ fetches its vulnerability
+          # DB by default (TRIVY_DB_REPOSITORY). Without it, every scan
+          # fails with "connect: connection refused".
           allowed-endpoints: >
             api.github.com:443
             github.com:443
             objects.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
             ghcr.io:443
             registry-1.docker.io:443
             auth.docker.io:443
             production.cloudflare.docker.com:443
             quay.io:443
             cdn.quay.io:443
+            mirror.gcr.io:443
             grafana.com:443
             mcr.microsoft.com:443
             public.ecr.aws:443
@@ -227,6 +232,7 @@ jobs:
             api.github.com:443
             github.com:443
             objects.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
             ghcr.io:443
             registry-1.docker.io:443
             auth.docker.io:443


### PR DESCRIPTION
## Summary

PR #69 surfaced two missing endpoints in the harden-runner egress allowlists in #67's workflow. Single-file fix.

## Failures it addresses

**Scan images (every scenario)** failed with:
```
2026-04-27T11:41:31Z FATAL Fatal error	run error: init error: DB error:
  failed to download vulnerability DB:
  failed to download artifact from mirror.gcr.io/aquasec/trivy-db:2:
  Get "https://mirror.gcr.io/v2/": dial tcp 54.185.253.63:443: connect: connection refused
```

Trivy v0.50+ moved its default DB repo to `mirror.gcr.io/aquasec/trivy-db:2`. The allowlist didn't include `mirror.gcr.io`, so harden-runner blocked the connection.

## Changes

1. **scan job** — add `mirror.gcr.io:443` so trivy can fetch its vulnerability DB.
2. **scan + smoke jobs** — add `release-assets.githubusercontent.com:443` defensively. GitHub release downloads (`github.com/<...>/releases/download/...`) redirect to this host; not currently used by validate-scenarios but a frequent gotcha in future scenarios that fetch GitHub-hosted tooling.

No behavioral change otherwise. Once this lands, PR #69's scan matrix should go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)