### PR TITLE
Fix trivy "connection refused" on Docker Hub images

### DIFF
--- a/.github/workflows/validate-scenarios.yml
+++ b/.github/workflows/validate-scenarios.yml
@@ -203,15 +203,21 @@ jobs:
         uses: step-security/harden-runner@8d3c67de8e2fe68ef647c8db1e6a09f647780f40 # v2.19.0
         with:
           egress-policy: block
+          # Docker Hub endpoint set: trivy in remote-mode (no docker.sock
+          # mount) hits index.docker.io for the manifest (legacy registry
+          # name; HTTP-redirects to registry-1.docker.io). The initial
+          # connection has to land at index.docker.io for the redirect to
+          # even happen, so allowlisting registry-1.docker.io alone is
+          # not enough — trivy fails with "connection refused".
           # mirror.gcr.io is where trivy v0.50+ fetches its vulnerability
-          # DB by default (TRIVY_DB_REPOSITORY). Without it, every scan
-          # fails with "connect: connection refused".
+          # DB (TRIVY_DB_REPOSITORY default).
           allowed-endpoints: >
             api.github.com:443
             github.com:443
             objects.githubusercontent.com:443
             release-assets.githubusercontent.com:443
             ghcr.io:443
+            index.docker.io:443
             registry-1.docker.io:443
             auth.docker.io:443
             production.cloudflare.docker.com:443


### PR DESCRIPTION
## Summary

PR #58's first run with the new validate-scenarios workflow exposed a missing endpoint in the harden-runner egress allowlist. One-line fix.

## What broke

```
unable to find the specified image "grafana/loki:3.6.10" in
  ["docker" "containerd" "podman" "remote"]:
* docker error: Cannot connect to the Docker daemon at unix:///var/run/docker.sock
* remote error: Get "https://index.docker.io/v2/":
    dial tcp 54.185.253.63:443: connect: connection refused
```

Trivy runs in its own container without `docker.sock` mounted (defense-in-depth — keeps trivy from getting root-equivalent access on the runner). So it falls back to remote-mode, which means pulling the image from the registry itself.

For Docker Hub images, trivy's go-containerregistry library targets `index.docker.io/v2/...` first — that's the legacy registry alias which HTTP-redirects to `registry-1.docker.io`. The redirect needs the *initial* TCP connection to `index.docker.io` to succeed; harden-runner blocking it kills the whole chain.

We had `registry-1.docker.io` allowlisted but not `index.docker.io`. Adding it.

## Why one and not the other was enough before

Existing CI runs scanning `aquasec/trivy:0.66.0@sha256:...` (the trivy container itself) worked because `docker pull` uses the runner's docker daemon, not the trivy library, and the daemon is configured to skip `index.docker.io` and go straight to `registry-1.docker.io`. The trivy library inside the container has its own resolution logic.

## Test plan

- [ ] After this lands, retry the failed scan job on PR #58 — `Scan images (game-of-tracing)` should pass.
- [ ] Verify smoke job runs after scan succeeds.
- [ ] Confirm zizmor still passes (no template-injection or other findings introduced).

## Out of scope

The k8s validate workflow doesn't pull images during validation (just `helm template | kubeconform`), so no equivalent fix needed there. If we later expand the kind-integration job to actually `helm install`, it'll need the same allowlist update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)