### PR TITLE
Skip locally-built images in trivy scan

### DIFF
--- a/.github/workflows/validate-scenarios.yml
+++ b/.github/workflows/validate-scenarios.yml
@@ -263,11 +263,27 @@ jobs:
             echo "No docker-compose found for ${{ matrix.scenario }}" >&2
             exit 1
           fi
+
+          # `docker compose config --images` returns service-name defaults
+          # like `game-of-tracing-ai-opponent` for `build:`-only services
+          # — those don't exist in any registry, so trivy fails with
+          # UNAUTHORIZED. Filter to services with an explicit `image:`
+          # field (third-party registry artifacts only). Locally-built
+          # images aren't directly scanned; their FROM base image (e.g.
+          # python:3.11-slim) lives in the Dockerfile and is tracked
+          # separately by renovate's docker manager.
           docker compose -f "$compose_file" \
             --env-file image-versions.env \
-            config --images | sort -u > /tmp/images.txt
+            config --format json \
+            | jq -r '.services | to_entries[]
+                     | select(.value.image != null)
+                     | .value.image' \
+            | sort -u > /tmp/images.txt
           echo "Images to scan:"
           cat /tmp/images.txt
+          if [ ! -s /tmp/images.txt ]; then
+            echo "::notice::No third-party images to scan in this scenario (all services build locally)."
+          fi
 
       - name: Trivy scan each image
         # Run trivy via its own docker image (digest-pinned). No


### PR DESCRIPTION
## Summary

PR #58's first run after #73 surfaced the next problem: scenarios with `build:`-only services have their service-name defaults emitted by `docker compose config --images` (e.g. `game-of-tracing-ai-opponent`). Trivy then tries to pull those non-existent images from Docker Hub and fails with `UNAUTHORIZED`.

Fix: filter the image list to services with an explicit `image:` field. Locally-built images aren't directly scanned; their FROM base images (e.g. `python:3.11-slim`) are tracked separately by renovate's docker manager via Dockerfile parsing.

## Failure this addresses

```
unable to find the specified image "game-of-tracing-ai-opponent" in
  ["docker" "containerd" "podman" "remote"]:
* docker error: Cannot connect to the Docker daemon
* remote error:
    GET https://index.docker.io/v2/library/game-of-tracing-ai-opponent/manifests/latest:
    UNAUTHORIZED: authentication required
```

The image `game-of-tracing-ai-opponent` is a docker-compose-derived service-name tag for a `build:` service. It only exists locally after `docker compose up --build`. There's nothing in any registry to scan.

## Before/after on game-of-tracing

| | Output |
|---|---|
| `docker compose config --images` | 16 entries (10 build-only + 6 third-party) |
| `docker compose config --format json \| jq '.services[].image'` | 6 entries (third-party only) |

The 6 are exactly: `grafana/alloy`, `grafana/grafana`, `grafana/loki`, `grafana/pyroscope`, `grafana/tempo`, `prom/prometheus`. The 10 dropped are `game-of-tracing-{ai-opponent,northern-capital,southern-capital,village-1..6,war-map}`.

## What's still scanned vs not

| Path | Scanned? |
|---|---|
| Third-party `image:` references in compose | ✅ Yes — scanned every PR run |
| Base image declared in a custom `Dockerfile` (e.g. `FROM python:3.11-slim`) | ❌ Not directly by this workflow, but bumped by renovate's docker manager (which inspects Dockerfiles) → next renovate PR validates the bump |
| Application code in a custom `Dockerfile` | ❌ Out of scope |

If we want CVE coverage on locally-built images, the next step would be `docker compose build` then `trivy image` on each resulting tag. Heavier; defer until needed.

## Test plan

- [ ] After this lands, retrigger PR #58 — `Scan images (game-of-tracing)` should pass with the 6 third-party images scanned cleanly.
- [ ] Smoke job runs after scan succeeds.
- [ ] On a hypothetical scenario with zero third-party images, the workflow emits a clean notice rather than failing.

## Out of scope

- **PR #63 (`app-instrumentation/.../csharp/LoggingExample.csproj`)** — separately blocked by path filter depth + scenario-list scope. Documented as a follow-up; not addressed here.
- **CVE scanning of locally-built images** — could be added by `docker compose build` first, then scanning the resulting tags. Approx 5–10 min added per scenario; defer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)