### PR TITLE
Sync compose ${VAR:-default} fallbacks alongside image-versions.env

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -24,6 +24,91 @@
       "datasourceTemplate": "helm",
       "depNameTemplate": "k8s-monitoring",
       "registryUrlTemplate": "https://grafana.github.io/helm-charts"
+    },
+
+    {
+      "customType": "regex",
+      "description": "Sync ${GRAFANA_VERSION:-default} fallbacks in compose files alongside image-versions.env updates. Renovate's docker-compose manager treats `${VAR}` substitution as a templated reference and won't update inline fallback defaults — without this customManager, the env file moves but the fallbacks drift, breaking `docker compose up` for users who don't pass --env-file.",
+      "managerFilePatterns": [
+        "/docker-compose(\\.coda)?\\.ya?ml$/"
+      ],
+      "matchStrings": [
+        "\\$\\{GRAFANA_VERSION:-(?<currentValue>[^}]+)\\}"
+      ],
+      "datasourceTemplate": "docker",
+      "depNameTemplate": "grafana/grafana"
+    },
+    {
+      "customType": "regex",
+      "description": "Sync ${GRAFANA_LOKI_VERSION:-default} fallbacks in compose files (see GRAFANA_VERSION rule).",
+      "managerFilePatterns": [
+        "/docker-compose(\\.coda)?\\.ya?ml$/"
+      ],
+      "matchStrings": [
+        "\\$\\{GRAFANA_LOKI_VERSION:-(?<currentValue>[^}]+)\\}"
+      ],
+      "datasourceTemplate": "docker",
+      "depNameTemplate": "grafana/loki"
+    },
+    {
+      "customType": "regex",
+      "description": "Sync ${GRAFANA_ALLOY_VERSION:-default} fallbacks in compose files (see GRAFANA_VERSION rule).",
+      "managerFilePatterns": [
+        "/docker-compose(\\.coda)?\\.ya?ml$/"
+      ],
+      "matchStrings": [
+        "\\$\\{GRAFANA_ALLOY_VERSION:-(?<currentValue>[^}]+)\\}"
+      ],
+      "datasourceTemplate": "docker",
+      "depNameTemplate": "grafana/alloy"
+    },
+    {
+      "customType": "regex",
+      "description": "Sync ${GRAFANA_TEMPO_VERSION:-default} fallbacks in compose files (see GRAFANA_VERSION rule).",
+      "managerFilePatterns": [
+        "/docker-compose(\\.coda)?\\.ya?ml$/"
+      ],
+      "matchStrings": [
+        "\\$\\{GRAFANA_TEMPO_VERSION:-(?<currentValue>[^}]+)\\}"
+      ],
+      "datasourceTemplate": "docker",
+      "depNameTemplate": "grafana/tempo"
+    },
+    {
+      "customType": "regex",
+      "description": "Sync ${GRAFANA_PYROSCOPE_VERSION:-default} fallbacks in compose files (see GRAFANA_VERSION rule).",
+      "managerFilePatterns": [
+        "/docker-compose(\\.coda)?\\.ya?ml$/"
+      ],
+      "matchStrings": [
+        "\\$\\{GRAFANA_PYROSCOPE_VERSION:-(?<currentValue>[^}]+)\\}"
+      ],
+      "datasourceTemplate": "docker",
+      "depNameTemplate": "grafana/pyroscope"
+    },
+    {
+      "customType": "regex",
+      "description": "Sync ${PROMETHEUS_VERSION:-default} fallbacks in compose files (see GRAFANA_VERSION rule).",
+      "managerFilePatterns": [
+        "/docker-compose(\\.coda)?\\.ya?ml$/"
+      ],
+      "matchStrings": [
+        "\\$\\{PROMETHEUS_VERSION:-(?<currentValue>[^}]+)\\}"
+      ],
+      "datasourceTemplate": "docker",
+      "depNameTemplate": "prom/prometheus"
+    },
+    {
+      "customType": "regex",
+      "description": "Sync ${PYTHON_VERSION:-default} fallbacks in compose files (see GRAFANA_VERSION rule).",
+      "managerFilePatterns": [
+        "/docker-compose(\\.coda)?\\.ya?ml$/"
+      ],
+      "matchStrings": [
+        "\\$\\{PYTHON_VERSION:-(?<currentValue>[^}]+)\\}"
+      ],
+      "datasourceTemplate": "docker",
+      "depNameTemplate": "python"
     }
   ]
 }


### PR DESCRIPTION
## Summary

PR #77 (renovate: python `3.11-slim → 3.14-slim`) blocked `check-image-versions` because renovate updated `image-versions.env` and Dockerfile FROM lines, but left the `${PYTHON_VERSION:-3.11-slim}` fallbacks in 15 compose files alone — so the env file said 3.14 while every fallback still said 3.11.

This is renovate behaviour, not a bug: its docker-compose manager treats `image: foo:${VAR:-...}` as a templated reference and intentionally doesn't touch the inline fallback default. We need a customManager to do that work.

This adds seven customManagers, one per tracked variable, that match `${VAR_NAME:-...}` across every compose file and bump it via the same `docker` datasource the env-file manager uses. Renovate groups updates by `depName`, so each LGMT release will now ship **one PR that touches both the env file and every matching fallback in lockstep**.

## Variables added

| Variable | `depName` | Fallback count (current) |
|---|---|---|
| `GRAFANA_VERSION` | `grafana/grafana` | 38 |
| `GRAFANA_LOKI_VERSION` | `grafana/loki` | 22 |
| `GRAFANA_ALLOY_VERSION` | `grafana/alloy` | 38 |
| `GRAFANA_TEMPO_VERSION` | `grafana/tempo` | 15 |
| `GRAFANA_PYROSCOPE_VERSION` | `grafana/pyroscope` | 1 |
| `PROMETHEUS_VERSION` | `prom/prometheus` | 22 |
| `PYTHON_VERSION` | `python` | 58 |

194 fallbacks total — renovate will now keep all of them current automatically.

## What this does to the existing workflow

- **`check-image-versions`** stays as a hard gate. After this lands it should be a no-op for renovate PRs (everything moves together) but still catches hand-edits and any future renovate gap. Defense-in-depth, not redundancy.
- **`validate-scenarios`** unaffected.
- **Existing customManagers** (`image-versions.env` and `k8s/*/README.md`) untouched.

## Test plan

- [ ] After this lands, retrigger PR #77 — the bot should rebase and the second push should include all 15 PYTHON_VERSION fallback updates. `check-image-versions` should pass.
- [ ] Future renovate PR for any LGMT bump (e.g. `GRAFANA_VERSION` patch) should produce one PR that touches both `image-versions.env` and every matching `${GRAFANA_VERSION:-...}` fallback.
- [ ] Hand-editing a fallback to a wrong value on a draft PR should still trip `check-image-versions` (gate stays useful).

🤖 Generated with [Claude Code](https://claude.com/claude-code)