### PR TITLE
test: explicit 30s scrape interval for elasticsearch-monitoring

### DIFF
--- a/elasticsearch-monitoring/README.md
+++ b/elasticsearch-monitoring/README.md
@@ -36,6 +36,9 @@ Once running, you can query Elasticsearch metrics in Grafana or Prometheus. Some
 - `elasticsearch_indices_store_size_bytes` - Total store size
 - `elasticsearch_jvm_memory_used_bytes` - JVM memory usage
 - `elasticsearch_process_cpu_percent` - CPU usage
+- `elasticsearch_breakers_tripped` - Circuit breaker trip count
+
+Metrics are scraped every 30s by default — adjust `scrape_interval` in `config.alloy` if you need finer or coarser resolution.
 
 ## Stopping
 

--- a/elasticsearch-monitoring/config.alloy
+++ b/elasticsearch-monitoring/config.alloy
@@ -11,8 +11,9 @@ prometheus.exporter.elasticsearch "default" {
 }
 
 prometheus.scrape "elasticsearch" {
-	targets    = prometheus.exporter.elasticsearch.default.targets
-	forward_to = [prometheus.remote_write.default.receiver]
+	targets         = prometheus.exporter.elasticsearch.default.targets
+	forward_to      = [prometheus.remote_write.default.receiver]
+	scrape_interval = "30s"
 }
 
 prometheus.remote_write "default" {


### PR DESCRIPTION
## Summary
- Set an explicit `scrape_interval = \"30s\"` on the Elasticsearch `prometheus.scrape` block in `config.alloy`
- Documented the cadence in the README and added `elasticsearch_breakers_tripped` to the key-metrics list

This is a small, intentional change to exercise the repo's CI / review workflows on the `elasticsearch-monitoring` scenario.

## Test plan
- [ ] CI workflows run successfully on the PR
- [ ] `cd elasticsearch-monitoring && docker compose up -d` still brings the stack up cleanly
- [ ] Alloy UI at http://localhost:12345 shows the `prometheus.scrape \"elasticsearch\"` component healthy
- [ ] Prometheus shows Elasticsearch metrics being scraped at the new 30s cadence

🤖 Generated with [Claude Code](https://claude.com/claude-code)