### PR TITLE
Add nginx-monitoring scenario

### DIFF
--- a/.github/scenario-list.txt
+++ b/.github/scenario-list.txt
@@ -14,6 +14,7 @@ logs-tcp
 mail-house
 memcached-monitoring
 mysql-monitoring
+nginx-monitoring
 otel-basic-tracing
 otel-metrics-pipeline
 otel-span-metrics

--- a/image-versions.env
+++ b/image-versions.env
@@ -26,3 +26,11 @@ PROMETHEUS_VERSION=v3.11.2
 # Other images
 # renovate: datasource=docker depName=python
 PYTHON_VERSION=3.11-slim
+
+# nginx-monitoring scenario
+# renovate: datasource=docker depName=nginx
+NGINX_VERSION=1.27-alpine
+# renovate: datasource=docker depName=nginx/nginx-prometheus-exporter
+NGINX_EXPORTER_VERSION=1.4.2
+# renovate: datasource=docker depName=curlimages/curl
+CURL_VERSION=8.10.1

--- a/nginx-monitoring/README.md
+++ b/nginx-monitoring/README.md
@@ -1,0 +1,77 @@
+# NGINX Monitoring with Grafana Alloy
+
+End-to-end NGINX observability with a single Alloy pipeline:
+
+- **Logs** — `loki.source.file` tails NGINX access and error logs; `loki.process` parses the combined log format and promotes `method` and `status` to labels.
+- **Metrics** — `prometheus.scrape` scrapes `nginx-prometheus-exporter` (which itself reads NGINX's built-in `stub_status`) and remote-writes to Prometheus.
+
+## Architecture
+
+- **NGINX** — the monitored web server (`/nginx_status` enabled, access/error logs written to a shared volume)
+- **nginx-prometheus-exporter** — translates `stub_status` into Prometheus metrics on `:9113`
+- **loadgen** — small `curl` loop that hits NGINX once per second so the demo has visible activity (200s and 404s)
+- **Grafana Alloy** — the pipeline above, exposed at `:12345`
+- **Loki / Prometheus / Grafana** — backends and visualization, with Loki and Prometheus datasources auto-provisioned
+
+## Running
+
+```bash
+# From this directory
+docker compose up -d
+
+# Or from the repo root using centralized image versions
+./run-example.sh nginx-monitoring
+```
+
+## Accessing
+
+- **Grafana**: http://localhost:3000 (no login required)
+- **Alloy UI**: http://localhost:12345 — verify components are healthy and inspect the live data flow
+- **Prometheus**: http://localhost:9090
+- **NGINX**: http://localhost:8080 — `/` returns "ok", `/nginx_status` returns connection counters
+
+## Trying it out
+
+The `loadgen` container hits NGINX once per second (alternating a 200 response and a 404). Within ~30 seconds you should see:
+
+### Logs (Loki)
+
+```logql
+# All access logs
+{job="nginx", log_type="access"}
+
+# Just 4xx
+{job="nginx", log_type="access", status=~"4.."}
+
+# Error log
+{job="nginx", log_type="error"}
+```
+
+The combined-log regex extracts `remote_addr`, `time_local`, `method`, `path`, `status`, and `bytes_sent`. Of those, `method` and `status` are promoted to Loki labels for fast filtering; the rest stay in the line text.
+
+### Metrics (Prometheus)
+
+```promql
+# Active connections
+nginx_connections_active
+
+# Accepted-since-start counter (per second)
+rate(nginx_connections_accepted[1m])
+
+# Total HTTP requests
+nginx_http_requests_total
+```
+
+## Customization
+
+- **Different log format**: edit the regex in `config.alloy` under `loki.process.nginx`. The default expects NGINX's built-in `combined` format.
+- **Different exporter target**: change the `--nginx.scrape-uri` flag on `nginx-exporter` in `docker-compose.yml`.
+- **More log sources**: add entries to `local.file_match.nginx.path_targets`.
+
+## Stopping
+
+```bash
+docker compose down -v
+```
+
+The `-v` removes the shared `nginx-logs` volume so the next run starts with a clean log file.

--- a/nginx-monitoring/config.alloy
+++ b/nginx-monitoring/config.alloy
@@ -1,0 +1,76 @@
+// NGINX Monitoring with Grafana Alloy.
+// Logs: tail access.log + error.log via loki.source.file, parse the access log
+// with a combined-format regex, and ship to Loki with method/status labels.
+// Metrics: scrape nginx-prometheus-exporter and remote_write to Prometheus.
+
+livedebugging {
+	enabled = true
+}
+
+// --- logs pipeline ---
+
+local.file_match "nginx" {
+	path_targets = [
+		{
+			__path__ = "/var/log/nginx-data/access.log",
+			job      = "nginx",
+			log_type = "access",
+		},
+		{
+			__path__ = "/var/log/nginx-data/error.log",
+			job      = "nginx",
+			log_type = "error",
+		},
+	]
+	sync_period = "5s"
+}
+
+loki.source.file "nginx" {
+	targets       = local.file_match.nginx.targets
+	forward_to    = [loki.process.nginx.receiver]
+	tail_from_end = true
+}
+
+loki.process "nginx" {
+	// Extract `method` and `status` from access logs (combined format).
+	// Error logs pass through unchanged.
+	stage.match {
+		selector = "{log_type=\"access\"}"
+
+		stage.regex {
+			expression = `^(?P<remote_addr>\S+) - (?P<remote_user>\S+) \[(?P<time_local>[^\]]+)\] "(?P<method>\S+) (?P<path>\S+) [^"]+" (?P<status>\d+) (?P<bytes_sent>\d+)`
+		}
+
+		stage.labels {
+			values = {
+				method = "",
+				status = "",
+			}
+		}
+	}
+
+	forward_to = [loki.write.local.receiver]
+}
+
+loki.write "local" {
+	endpoint {
+		url = "http://loki:3100/loki/api/v1/push"
+	}
+}
+
+// --- metrics pipeline ---
+
+prometheus.scrape "nginx" {
+	targets = [{
+		__address__ = "nginx-exporter:9113",
+		job         = "nginx",
+	}]
+	forward_to      = [prometheus.remote_write.local.receiver]
+	scrape_interval = "15s"
+}
+
+prometheus.remote_write "local" {
+	endpoint {
+		url = "http://prometheus:9090/api/v1/write"
+	}
+}

--- a/nginx-monitoring/docker-compose.yml
+++ b/nginx-monitoring/docker-compose.yml
@@ -1,0 +1,112 @@
+services:
+  nginx:
+    image: nginx:${NGINX_VERSION:-1.27-alpine}
+    container_name: nginx-monitoring-nginx
+    ports:
+      - "8080:80"
+    volumes:
+      - ./nginx.conf:/etc/nginx/nginx.conf:ro
+      - nginx-logs:/var/log/nginx-data
+
+  nginx-exporter:
+    image: nginx/nginx-prometheus-exporter:${NGINX_EXPORTER_VERSION:-1.4.2}
+    container_name: nginx-monitoring-exporter
+    command:
+      - --nginx.scrape-uri=http://nginx:80/nginx_status
+    ports:
+      - "9113:9113"
+    depends_on:
+      - nginx
+
+  loadgen:
+    image: curlimages/curl:${CURL_VERSION:-8.10.1}
+    container_name: nginx-monitoring-loadgen
+    entrypoint:
+      - sh
+      - -c
+      - |
+        until curl -s -o /dev/null --max-time 2 http://nginx/; do sleep 1; done
+        while true; do
+          curl -s -o /dev/null http://nginx/
+          curl -s -o /dev/null http://nginx/missing-page
+          sleep 1
+        done
+    depends_on:
+      - nginx
+    restart: unless-stopped
+
+  alloy:
+    image: grafana/alloy:${GRAFANA_ALLOY_VERSION:-v1.16.0}
+    container_name: nginx-monitoring-alloy
+    ports:
+      - "12345:12345"
+    volumes:
+      - ./config.alloy:/etc/alloy/config.alloy
+      - nginx-logs:/var/log/nginx-data:ro
+    command: run --server.http.listen-addr=0.0.0.0:12345 --storage.path=/var/lib/alloy/data /etc/alloy/config.alloy
+    depends_on:
+      - nginx
+      - nginx-exporter
+      - loki
+      - prometheus
+
+  loki:
+    image: grafana/loki:${GRAFANA_LOKI_VERSION:-3.6.10}
+    container_name: nginx-monitoring-loki
+    ports:
+      - "3100:3100"
+    volumes:
+      - ./loki-config.yaml:/etc/loki/local-config.yaml
+    command: -config.file=/etc/loki/local-config.yaml
+
+  prometheus:
+    image: prom/prometheus:${PROMETHEUS_VERSION:-v3.11.2}
+    container_name: nginx-monitoring-prometheus
+    command:
+      - --web.enable-remote-write-receiver
+      - --config.file=/etc/prometheus/prometheus.yml
+    volumes:
+      - ./prom-config.yaml:/etc/prometheus/prometheus.yml
+    ports:
+      - "9090:9090"
+
+  grafana:
+    image: grafana/grafana:${GRAFANA_VERSION:-13.0.1}
+    container_name: nginx-monitoring-grafana
+    environment:
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_BASIC_ENABLED=false
+    ports:
+      - "3000:3000/tcp"
+    entrypoint:
+      - sh
+      - -euc
+      - |
+        mkdir -p /etc/grafana/provisioning/datasources
+        cat <<EOF > /etc/grafana/provisioning/datasources/ds.yaml
+        apiVersion: 1
+        datasources:
+        - name: Loki
+          type: loki
+          access: proxy
+          orgId: 1
+          url: http://loki:3100
+          basicAuth: false
+          isDefault: false
+          version: 1
+          editable: false
+        - name: Prometheus
+          type: prometheus
+          access: proxy
+          orgId: 1
+          url: http://prometheus:9090
+          basicAuth: false
+          isDefault: true
+          version: 1
+          editable: false
+        EOF
+        /run.sh
+
+volumes:
+  nginx-logs:

--- a/nginx-monitoring/loki-config.yaml
+++ b/nginx-monitoring/loki-config.yaml
@@ -1,0 +1,39 @@
+auth_enabled: false
+
+limits_config:
+  allow_structured_metadata: true
+  volume_enabled: true
+
+server:
+  http_listen_port: 3100
+
+common:
+  ring:
+    instance_addr: 0.0.0.0
+    kvstore:
+      store: inmemory
+  replication_factor: 1
+  path_prefix: /tmp/loki
+
+schema_config:
+  configs:
+    - from: 2020-05-15
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
+storage_config:
+  tsdb_shipper:
+    active_index_directory: /tmp/loki/index
+    cache_location: /tmp/loki/index_cache
+  filesystem:
+    directory: /tmp/loki/chunks
+
+pattern_ingester:
+  enabled: true
+
+ingester:
+  max_chunk_age: 5m

--- a/nginx-monitoring/nginx.conf
+++ b/nginx-monitoring/nginx.conf
@@ -1,0 +1,35 @@
+worker_processes 1;
+events {
+    worker_connections 1024;
+}
+
+http {
+    # Use the nginx built-in "combined" log format:
+    # '$remote_addr - $remote_user [$time_local] "$request" '
+    # '$status $body_bytes_sent "$http_referer" "$http_user_agent"'
+    #
+    # Write to a fresh path outside /var/log/nginx — that directory
+    # has access.log/error.log pre-symlinked to /dev/stdout in the
+    # nginx image, which Alloy's tailer cannot follow across containers.
+    access_log /var/log/nginx-data/access.log combined;
+    error_log  /var/log/nginx-data/error.log warn;
+
+    server {
+        listen 80;
+        server_name _;
+
+        location = / {
+            add_header Content-Type text/plain;
+            return 200 "ok\n";
+        }
+
+        location = /missing-page {
+            return 404;
+        }
+
+        location /nginx_status {
+            stub_status on;
+            access_log off;
+        }
+    }
+}

--- a/nginx-monitoring/prom-config.yaml
+++ b/nginx-monitoring/prom-config.yaml
@@ -1,0 +1,3 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s


### PR DESCRIPTION
## Summary

Adds a new top-level scenario `nginx-monitoring/` demonstrating end-to-end NGINX observability with Grafana Alloy: access/error logs into Loki and metrics into Prometheus, in a single ~70-line `config.alloy`.

Closes #91.

## What's in the box

- `nginx` (1.27-alpine) configured with a custom `nginx.conf` that:
  - exposes `/nginx_status` for the exporter
  - returns `200` on `/` and `404` on `/missing-page` so the demo has label variety
  - writes access/error logs to `/var/log/nginx-data/` (a fresh path — `/var/log/nginx/` has pre-existing symlinks to `/dev/stdout` that Alloy's tailer can't follow across containers)
- `nginx-prometheus-exporter` scrapes `stub_status`
- `loadgen` (`curlimages/curl`) alternates `/` and `/missing-page` once per second
- `alloy` mounts the shared `nginx-logs` volume read-only and runs the pipeline
- Loki / Prometheus / Grafana with both datasources auto-provisioned

## Alloy pipeline

- **Logs**: `local.file_match` → `loki.source.file` → `loki.process` (regex stage parsing combined-log format, `stage.labels` promoting `method` and `status`) → `loki.write`
- **Metrics**: `prometheus.scrape` (nginx-exporter:9113) → `prometheus.remote_write`

## Test plan

Verified locally before pushing:

- [x] `docker compose up -d` brings up cleanly, all 7 containers running
- [x] `nginx-exporter` exposes `nginx_connections_active` etc on `:9113/metrics`
- [x] Prometheus query `nginx_connections_active` returns a non-zero value
- [x] Loki query `{job="nginx", log_type="access"}` returns two streams: `status=200` and `status=404`, with `method=GET` extracted as a label
- [x] Grafana auto-provisions both Loki and Prometheus datasources
- [x] `docker compose down -v` cleans up the named volume

CI to verify on this PR:

- [ ] `validate-scenarios` detect step picks up `nginx-monitoring/`
- [ ] `Scan images (nginx-monitoring)` passes (all images on Docker Hub)
- [ ] `Smoke test (nginx-monitoring)` passes (Grafana :3000 healthy, no exited containers)

## Renovate

Three new image-version pins added to `image-versions.env` with `# renovate:` annotations: `NGINX_VERSION`, `NGINX_EXPORTER_VERSION`, `CURL_VERSION`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)