### PR TITLE
Add windows-events scenario (Security channel focus)

### DIFF
--- a/.github/scenario-list.txt
+++ b/.github/scenario-list.txt
@@ -27,3 +27,4 @@ snmp
 syslog
 trace-delivery
 windows
+windows-events

--- a/windows-events/README.md
+++ b/windows-events/README.md
@@ -1,0 +1,98 @@
+# Windows Security Event Logs with Grafana Alloy
+
+A focused logs-only scenario for shipping the **Windows Security event channel** to Loki, with filtering and field-extraction tuned for SOC-style queries (logon attempts, privilege escalation, account changes).
+
+## How this differs from the [`windows/`](../windows/) scenario
+
+| Aspect | `windows/` (broad) | `windows-events/` (this) |
+|---|---|---|
+| Channels | Application + System + Performance metrics | **Security** only |
+| Processing | Pass-through with basic JSON parsing | **Drops noise event IDs** + extracts security-specific fields as labels |
+| Backend | Loki + Prometheus + Grafana | **Loki + Grafana** (no metrics) |
+| Demo intent | "ship Windows logs to Loki" | "make Security events queryable for SOC use cases" |
+
+If you want general-purpose Windows monitoring, use `windows/`. If you specifically care about Security audit events, use this one.
+
+## Prerequisites
+
+- A Windows host (Server or Desktop) with admin access — `loki.source.windowsevent` reads from the Windows Event Log API and only runs on Windows.
+- Docker Desktop for Windows (or any Linux machine you can reach over the network) for the Loki/Grafana backend.
+- Git, to clone the repo.
+
+## Step 1 — Backend (Loki + Grafana)
+
+On the machine that will host the backend (the Windows host itself, or any Linux machine):
+
+```bash
+git clone https://github.com/grafana/alloy-scenarios.git
+cd alloy-scenarios/windows-events
+docker compose up -d
+```
+
+Grafana is on `http://<backend-host>:3000` with the Loki datasource already provisioned.
+
+## Step 2 — Install Alloy on the Windows host
+
+Follow the [Windows install guide](https://grafana.com/docs/alloy/latest/set-up/install/windows/). Recommended: Windows Installer + Windows Service.
+
+If your backend is on a different machine than the Windows host, edit the `loki.write` URL in `config.alloy` from `http://localhost:3100` to `http://<backend-host>:3100`.
+
+## Step 3 — Replace the Alloy config
+
+1. Stop the `Grafana Alloy` Windows service.
+2. Replace `C:\Program Files\GrafanaLabs\Alloy\config.alloy` with the [`config.alloy`](./config.alloy) from this directory.
+3. Start the service.
+4. Open `http://localhost:12345` to confirm the components load without error.
+
+## Step 4 — Generate Security events
+
+To see traffic, trigger some auditable actions on the Windows host:
+
+- **Failed logon (4625)**: try to log in with a wrong password from a remote machine, or run `runas /user:fakeuser cmd` and enter a wrong password.
+- **Successful logon (4624)**: log out and back in, or open a new RDP session.
+- **User created (4720)**: `net user testuser P@ssw0rd /add` from an admin shell.
+- **Privilege use (4672)**: any action requiring Administrator elevation.
+
+Some of these only generate events if the corresponding **audit policy** is enabled. Check `auditpol /get /category:*` on the Windows host; enable additional audit policies via `auditpol /set /subcategory:"<name>" /success:enable /failure:enable` if needed.
+
+## Step 5 — Query in Grafana
+
+```logql
+# All Security events
+{eventlog_name="Security"}
+
+# Failed logons
+{eventlog_name="Security", event_id="4625"}
+
+# Successful logons by a specific user
+{eventlog_name="Security", event_id="4624", target_user_name="alice"}
+
+# All events affecting a specific user account
+{eventlog_name="Security", target_user_name="alice"}
+
+# Recent privileged-operation events
+{eventlog_name="Security", event_id=~"4672|4673"}
+```
+
+The promoted labels are `event_id`, `subject_user_name`, `target_user_name`, and `logon_type`. Other event fields (computer, eventRecordID, channel) are kept as **structured metadata** — searchable via Loki's `| json` filter without inflating the label index.
+
+## What's filtered out
+
+The pipeline drops these event IDs at the Alloy side:
+
+| Event ID | Description | Why dropped |
+|---|---|---|
+| 4658 | Handle to an object was closed | Pairs with 4656/4663; on its own rarely actionable |
+| 4690 | Attempt to duplicate a handle to an object | Audit noise |
+| 4674 | Operation attempted on a privileged object | Fires for routine privileged ops |
+| 5379 | Credential Manager credentials were read | Frequent false-positive in normal use |
+
+If you want one of these back, edit `stage.match` in `config.alloy` to remove the corresponding ID from the `event_id=~"…"` regex.
+
+## Stopping
+
+```bash
+docker compose down -v
+```
+
+Stop the Alloy Windows service separately if you no longer want it running.

--- a/windows-events/config.alloy
+++ b/windows-events/config.alloy
@@ -1,0 +1,84 @@
+// ###################################################################
+// Windows Security Event Log → Loki, with filtering and field labels
+// ###################################################################
+//
+// Differs from the broader `windows/` scenario in three ways:
+//   1. Security channel only (Application + System are covered there)
+//   2. Drops high-volume audit-noise event IDs that bury real signal
+//   3. Promotes security-specific fields (subject_user_name,
+//      target_user_name, logon_type) to labels for SOC-style queries
+//
+// Run target: a Windows host with Alloy installed natively. The
+// docker-compose.yml in this directory only runs Loki + Grafana;
+// Alloy itself is a Windows service.
+
+livedebugging {}
+
+// Ingest the Security channel. `use_incoming_timestamp = true` keeps
+// the original event time rather than the time Alloy received it,
+// which matters when replaying historical logs after an Alloy restart.
+loki.source.windowsevent "security" {
+	eventlog_name          = "Security"
+	use_incoming_timestamp = true
+	forward_to             = [loki.process.security.receiver]
+}
+
+loki.process "security" {
+	// Step 1: parse the windowsevent JSON wrapper.
+	stage.json {
+		expressions = {
+			message       = "",
+			eventRecordID = "",
+			channel       = "",
+			computer      = "",
+		}
+	}
+
+	// Step 2: parse the event message (XML/EventData) into top-level
+	// fields. The exact keys depend on event type — `eventlogmessage`
+	// pulls every named field from the XML/EventData payload.
+	stage.eventlogmessage {
+		source             = "message"
+		overwrite_existing = true
+	}
+
+	// Step 3: drop high-noise event IDs that are rarely useful in a
+	// SOC dashboard but consume most of the Security log volume:
+	//   4658 — handle to an object closed
+	//   4690 — attempt to duplicate a handle to an object
+	//   4674 — operation attempted on a privileged object
+	//   5379 — Credential Manager credentials read
+	stage.match {
+		selector = `{event_id=~"4658|4690|4674|5379"}`
+		action   = "drop"
+	}
+
+	// Step 4: promote useful fields to labels. Indexed labels make
+	// "show me all failed logons by username" queries cheap.
+	stage.labels {
+		values = {
+			event_id          = "",
+			subject_user_name = "",
+			target_user_name  = "",
+			logon_type        = "",
+		}
+	}
+
+	// Step 5: keep heavyweight fields out of labels but searchable
+	// via structured metadata.
+	stage.structured_metadata {
+		values = {
+			eventRecordID = "",
+			channel       = "",
+			computer      = "",
+		}
+	}
+
+	forward_to = [loki.write.endpoint.receiver]
+}
+
+loki.write "endpoint" {
+	endpoint {
+		url = "http://localhost:3100/loki/api/v1/push"
+	}
+}

--- a/windows-events/docker-compose.yml
+++ b/windows-events/docker-compose.yml
@@ -1,0 +1,37 @@
+services:
+
+  loki:
+    image: grafana/loki:${GRAFANA_LOKI_VERSION:-3.6.10}
+    ports:
+      - "3100:3100/tcp"
+    volumes:
+      - ./loki-config.yaml:/etc/loki/local-config.yaml
+    command: -config.file=/etc/loki/local-config.yaml
+
+  grafana:
+    image: grafana/grafana:${GRAFANA_VERSION:-13.0.1}
+    environment:
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_BASIC_ENABLED=false
+    ports:
+      - "3000:3000/tcp"
+    entrypoint:
+      - sh
+      - -euc
+      - |
+        mkdir -p /etc/grafana/provisioning/datasources
+        cat <<EOF > /etc/grafana/provisioning/datasources/ds.yaml
+        apiVersion: 1
+        datasources:
+        - name: Loki
+          type: loki
+          access: proxy
+          orgId: 1
+          url: http://loki:3100
+          basicAuth: false
+          isDefault: true
+          version: 1
+          editable: false
+        EOF
+        /run.sh

--- a/windows-events/loki-config.yaml
+++ b/windows-events/loki-config.yaml
@@ -1,0 +1,39 @@
+auth_enabled: false
+
+limits_config:
+  allow_structured_metadata: true
+  volume_enabled: true
+
+server:
+  http_listen_port: 3100
+
+common:
+  ring:
+    instance_addr: 0.0.0.0
+    kvstore:
+      store: inmemory
+  replication_factor: 1
+  path_prefix: /tmp/loki
+
+schema_config:
+  configs:
+    - from: 2020-05-15
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
+storage_config:
+  tsdb_shipper:
+    active_index_directory: /tmp/loki/index
+    cache_location: /tmp/loki/index_cache
+  filesystem:
+    directory: /tmp/loki/chunks
+
+pattern_ingester:
+  enabled: true
+
+ingester:
+  max_chunk_age: 5m


### PR DESCRIPTION
## Summary

Adds a focused, logs-only scenario for the **Windows Security event channel**, complementary to the existing `windows/` scenario rather than replacing it.

Closes #92.

## How this differs from the existing `windows/` scenario

| Aspect | `windows/` (broad) | `windows-events/` (this) |
|---|---|---|
| Channels | Application + System + Performance metrics | **Security** only |
| Processing | Pass-through with basic JSON parsing | **Drops noise event IDs** + extracts security-specific fields as labels |
| Backend | Loki + Prometheus + Grafana | **Loki + Grafana** (no metrics) |
| Demo intent | "ship Windows logs to Loki" | "make Security events queryable for SOC use cases" |

If a reviewer feels this overlap is too thin and would rather close #92 with a "covered by existing `windows/`", the alternative would be to swap #92 in the epic for one of the cuts (NVIDIA DCGM, Docker Swarm, OTel Collector → Alloy migration). Happy to take that direction instead — flagging here so it's a deliberate decision.

## Pipeline highlights

- **Channel filtering**: only the Security channel is ingested
- **Noise filtering**: `stage.match` drops event IDs 4658 / 4690 / 4674 / 5379, which together account for most of the audit-log volume but rarely carry SOC value
- **SOC-friendly labels**: `event_id`, `subject_user_name`, `target_user_name`, `logon_type` are promoted to labels so queries like `{event_id="4625", target_user_name="alice"}` are cheap
- **Structured metadata**: `eventRecordID`, `channel`, `computer` retained as searchable structured metadata, kept out of the label index

## Deployment shape

Same as the existing `windows/` scenario — `docker-compose.yml` runs only the backend (Loki + Grafana), Alloy is installed natively as a Windows service. README documents the install + audit-policy steps and provides example queries for failed logons, account creation, and privileged operations.

## Test plan

Verified locally before pushing:

- [x] `docker compose up -d` brings up Loki + Grafana cleanly
- [x] `curl http://localhost:3000/api/health` returns `database: ok`
- [x] Grafana auto-provisions the Loki datasource as default
- [x] `docker compose down -v` cleans up

CI to verify on this PR:

- [ ] `validate-scenarios` detect picks up `windows-events/`
- [ ] `Scan images (windows-events)` passes
- [ ] `Smoke test (windows-events)` passes — same trade-off as `windows/`: backend bring-up is validated; Windows-side Alloy is documented but not exercised in Linux CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)