### PR TITLE
Add systemd-journal scenario

### DIFF
--- a/.github/scenario-list.txt
+++ b/.github/scenario-list.txt
@@ -26,6 +26,7 @@ routing
 self-monitoring
 snmp
 syslog
+systemd-journal
 trace-delivery
 windows
 windows-events

--- a/systemd-journal/README.md
+++ b/systemd-journal/README.md
@@ -1,0 +1,106 @@
+# systemd journal to Loki — focused filtering recipes
+
+A focused logs-only scenario for shipping a Linux host's systemd journal to Loki, with filtering and label promotion tuned for keeping the index lean and queries fast.
+
+## How this differs from `linux/`
+
+| Aspect | `linux/` (existing) | `systemd-journal/` (this) |
+|---|---|---|
+| Scope | Metrics + journal + flat files (full Linux observability suite) | **Journal only** — focused scenario |
+| Pipeline | Pass-through ingest, all units, all priorities | **Drops noisy units + drops info/debug priorities** |
+| Stack | Prom + Loki + Grafana + node_exporter | **Loki + Grafana only** |
+| Labels promoted | none specifically | `unit`, `priority`, `hostname` |
+| Demo intent | "monitor a Linux box end-to-end" | "show advanced journal filtering recipes" |
+
+If you want general-purpose Linux observability, use `linux/`. If you specifically need journal filtering recipes (drop noisy units, drop low-priority entries, label by unit/priority for fast filtering), this scenario is the minimal moving-parts version.
+
+## Linux host required
+
+`loki.source.journal` reads `/var/log/journal` and `/run/log/journal`. **These directories only exist on Linux hosts running systemd**. On macOS or Windows Docker Desktop:
+
+- The bind mounts will resolve to empty directories (Docker creates them silently).
+- Alloy will start cleanly but the source will sit idle with no journal entries.
+- The scenario is functionally a no-op — there's no synthesised journal to fall back to.
+
+To exercise the scenario fully you need:
+- A Linux host (bare metal, VM, WSL2 with systemd, or a Linux VM on macOS such as OrbStack / Lima / multipass).
+- `systemd` writing journals to `/var/log/journal` (persistent) or `/run/log/journal` (volatile). Most distros ship with at least the volatile journal active.
+
+## Running
+
+On a Linux host:
+
+```bash
+cd systemd-journal
+docker compose up -d
+```
+
+Wait ~10 seconds, then open Grafana.
+
+## Accessing
+
+- **Grafana**: http://localhost:3000 (no login required)
+- **Alloy UI**: http://localhost:12345 — confirm components are healthy and use livedebugging to inspect entries flowing through each stage
+- **Loki API**: http://localhost:3100
+
+## Trying it out
+
+Generate some journal traffic on the Linux host:
+
+```bash
+# Trigger a notice
+logger -p user.notice "test from systemd-journal scenario"
+
+# Trigger an error
+logger -p user.err "this is a test error"
+
+# Tickle a service unit to produce events
+sudo systemctl restart cron 2>/dev/null || sudo systemctl restart crond
+```
+
+Then in Grafana Explore on Loki:
+
+```logql
+# All journal entries (after filtering)
+{job="systemd-journal"}
+
+# Errors only
+{job="systemd-journal", priority=~"err|crit|alert|emerg"}
+
+# A specific unit
+{job="systemd-journal", unit="ssh.service"}
+
+# A specific host (useful when shipping from many)
+{job="systemd-journal", hostname="my-server"}
+
+# All recent NetworkManager events
+{job="systemd-journal", unit="NetworkManager.service"}
+```
+
+## What's filtered out
+
+The pipeline drops these at the Alloy side:
+
+| Filter | What it drops | Why |
+|---|---|---|
+| `{unit=~"systemd-logind.service\|systemd-tmpfiles-clean.service\|cron.service"}` | Login session housekeeping, tmpfile cleanup, every cron tick | High-volume, low-signal in dev/ops dashboards |
+| `{priority=~"info\|debug"}` | LOG_INFO and LOG_DEBUG entries | Keep `notice` and above |
+
+To keep one of these back, edit `stage.match` in `config.alloy` — remove the corresponding entry from the regex.
+
+## Why run Alloy as root
+
+The Alloy container runs with `user: "0:0"`. On most Linux distros, `/var/log/journal/*.journal` files are owned by `root:systemd-journal` with mode 0640. Reading them requires either being root or a member of the `systemd-journal` group. Running Alloy as root inside a container with a read-only bind-mount keeps things simple for a demo. In production, prefer running the Alloy native package as a service — it joins the right groups automatically.
+
+## Stopping
+
+```bash
+docker compose down -v
+```
+
+## Customization ideas
+
+- **Promote more journal fields**: extend the `loki.relabel.journal` block. `__journal__pid` → `pid`, `__journal__exe` → `exe`, `__journal__cmdline` → `cmdline`, etc.
+- **Per-environment unit filters**: maintain different `stage.match` regexes for prod vs dev.
+- **Forward errors only**: add a `stage.match` keeping only `priority=~"err|crit|alert|emerg"` if you want a focused error stream.
+- **Multi-host fan-in**: deploy this on every Linux host with the same `loki.write` URL pointing at a central Loki cluster.

--- a/systemd-journal/config.alloy
+++ b/systemd-journal/config.alloy
@@ -1,0 +1,68 @@
+// systemd journal → Loki, with filtering recipes.
+//
+// Demonstrates three patterns the broader `linux/` scenario doesn't:
+//   1. Promoting useful journal fields (`unit`, `priority`, `hostname`)
+//      to Loki labels via `loki.relabel`.
+//   2. Dropping noisy systemd units that flood the journal but rarely
+//      carry useful signal.
+//   3. Dropping low-priority entries (info/debug) at ingestion time
+//      to keep Loki cardinality and storage low.
+//
+// Linux-host only — `loki.source.journal` reads /var/log/journal,
+// which doesn't exist on macOS or Windows. See README for details.
+
+livedebugging { enabled = true }
+
+// Translate the journal's underscore-prefixed metadata into clean
+// Loki label names. The journal exposes a lot of fields; we promote
+// only a few useful ones.
+loki.relabel "journal" {
+	forward_to = []
+
+	rule {
+		source_labels = ["__journal__systemd_unit"]
+		target_label  = "unit"
+	}
+
+	rule {
+		source_labels = ["__journal_priority_keyword"]
+		target_label  = "priority"
+	}
+
+	rule {
+		source_labels = ["__journal__hostname"]
+		target_label  = "hostname"
+	}
+}
+
+loki.source.journal "host" {
+	path          = "/var/log/journal"
+	max_age       = "12h"
+	relabel_rules = loki.relabel.journal.rules
+	labels        = { job = "systemd-journal" }
+	forward_to    = [loki.process.journal.receiver]
+}
+
+loki.process "journal" {
+	// Drop high-volume units that rarely carry actionable signal in a
+	// generic dev/ops dashboard. Tune this list to your environment.
+	stage.match {
+		selector = `{unit=~"systemd-logind.service|systemd-tmpfiles-clean.service|cron.service"}`
+		action   = "drop"
+	}
+
+	// Drop low-priority entries (info / debug). Keep notice and above.
+	// Adjust if you want to keep info messages.
+	stage.match {
+		selector = `{priority=~"info|debug"}`
+		action   = "drop"
+	}
+
+	forward_to = [loki.write.local.receiver]
+}
+
+loki.write "local" {
+	endpoint {
+		url = "http://loki:3100/loki/api/v1/push"
+	}
+}

--- a/systemd-journal/docker-compose.yml
+++ b/systemd-journal/docker-compose.yml
@@ -1,0 +1,56 @@
+services:
+
+  loki:
+    image: grafana/loki:${GRAFANA_LOKI_VERSION:-3.6.10}
+    ports:
+      - "3100:3100/tcp"
+    volumes:
+      - ./loki-config.yaml:/etc/loki/local-config.yaml
+    command: -config.file=/etc/loki/local-config.yaml
+
+  grafana:
+    image: grafana/grafana:${GRAFANA_VERSION:-13.0.1}
+    environment:
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_BASIC_ENABLED=false
+    ports:
+      - "3000:3000/tcp"
+    entrypoint:
+      - sh
+      - -euc
+      - |
+        mkdir -p /etc/grafana/provisioning/datasources
+        cat <<EOF > /etc/grafana/provisioning/datasources/ds.yaml
+        apiVersion: 1
+        datasources:
+        - name: Loki
+          type: loki
+          access: proxy
+          orgId: 1
+          url: http://loki:3100
+          basicAuth: false
+          isDefault: true
+          version: 1
+          editable: false
+        EOF
+        /run.sh
+
+  alloy:
+    image: grafana/alloy:${GRAFANA_ALLOY_VERSION:-v1.16.0}
+    # Run as root so Alloy can read /var/log/journal — the journal files
+    # are owned by root:systemd-journal with mode 0640 on most distros.
+    user: "0:0"
+    ports:
+      - "12345:12345"
+    volumes:
+      - ./config.alloy:/etc/alloy/config.alloy
+      # Bind-mount the host's journal read-only. On Linux hosts this
+      # exposes the actual systemd journal. On macOS/Windows the path
+      # doesn't exist and Docker creates an empty directory; Alloy
+      # will run but the source will report "no journal entries".
+      - /var/log/journal:/var/log/journal:ro
+      - /run/log/journal:/run/log/journal:ro
+    command: run --server.http.listen-addr=0.0.0.0:12345 --storage.path=/var/lib/alloy/data /etc/alloy/config.alloy
+    depends_on:
+      - loki

--- a/systemd-journal/loki-config.yaml
+++ b/systemd-journal/loki-config.yaml
@@ -1,0 +1,39 @@
+auth_enabled: false
+
+limits_config:
+  allow_structured_metadata: true
+  volume_enabled: true
+
+server:
+  http_listen_port: 3100
+
+common:
+  ring:
+    instance_addr: 0.0.0.0
+    kvstore:
+      store: inmemory
+  replication_factor: 1
+  path_prefix: /tmp/loki
+
+schema_config:
+  configs:
+    - from: 2020-05-15
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
+storage_config:
+  tsdb_shipper:
+    active_index_directory: /tmp/loki/index
+    cache_location: /tmp/loki/index_cache
+  filesystem:
+    directory: /tmp/loki/chunks
+
+pattern_ingester:
+  enabled: true
+
+ingester:
+  max_chunk_age: 5m


### PR DESCRIPTION
## Summary

Adds a focused, logs-only scenario for shipping a Linux host's systemd journal to Loki, with filtering and label-promotion recipes. Complementary to `linux/` rather than replacing it.

Closes #94.

## How this differs from the existing `linux/` scenario

| Aspect | `linux/` (existing) | `systemd-journal/` (this) |
|---|---|---|
| Scope | Metrics + journal + flat files (full Linux observability suite) | **Journal only** — focused scenario |
| Pipeline | Pass-through ingest, all units, all priorities | **Drops noisy units + drops info/debug priorities** |
| Stack | Prom + Loki + Grafana + node_exporter | **Loki + Grafana only** |
| Labels promoted | none specifically | `unit`, `priority`, `hostname` |
| Demo intent | "monitor a Linux box end-to-end" | "show advanced journal filtering recipes" |

If a reviewer feels the overlap is too thin, the alternative is to close #94 as "covered by `linux/`" and swap in a cuts-list candidate (NVIDIA DCGM, OTel Collector migration, Docker Swarm). Flagging here so it's a deliberate decision.

## Pipeline highlights

- **Label promotion via `loki.relabel`**: `__journal__systemd_unit` → `unit`, `__journal_priority_keyword` → `priority`, `__journal__hostname` → `hostname`.
- **Drop noisy units**: `stage.match` removes `systemd-logind.service`, `systemd-tmpfiles-clean.service`, and `cron.service`. Tunable per environment.
- **Drop low-priority entries**: `stage.match` keeps `notice` and above; drops `info`/`debug` at ingestion to save Loki storage and cardinality.

## Linux-host requirement

`loki.source.journal` reads `/var/log/journal` and `/run/log/journal`, which only exist on Linux hosts running systemd. The README is explicit about this constraint and lists Linux VM alternatives (OrbStack, Lima, multipass, WSL2 with systemd) for macOS/Windows developers.

On macOS Docker Desktop the bind mounts resolve to empty directories — Alloy still starts cleanly (verified locally), the journal source just sits idle. This is the same trade-off the existing `linux/` scenario already accepts: useful syntax demo on any host, real data only on Linux.

## Test plan

Verified locally before pushing (on macOS — backend boot only):

- [x] `docker compose up -d` brings up Alloy + Loki + Grafana cleanly with no exited containers
- [x] Alloy logs show clean startup, no errors on the missing journal mounts
- [x] `curl http://localhost:3000/api/health` returns `database: ok`
- [x] `docker compose down -v` cleans up

CI to verify on this PR:

- [ ] `validate-scenarios` detect picks up `systemd-journal/`
- [ ] `Scan images` passes
- [ ] `Smoke test` passes — same trade-off as `linux/`: backend bring-up is validated; real journal data only flows on a Linux host

🤖 Generated with [Claude Code](https://claude.com/claude-code)