### PR TITLE
Add aws-firehose-logs scenario (no AWS account needed)

### DIFF
--- a/.github/scenario-list.txt
+++ b/.github/scenario-list.txt
@@ -1,3 +1,4 @@
+aws-firehose-logs
 blackbox-probing
 continuous-profiling
 docker-monitoring

--- a/aws-firehose-logs/README.md
+++ b/aws-firehose-logs/README.md
@@ -1,0 +1,89 @@
+# AWS Kinesis Data Firehose to Loki — no AWS account required
+
+Demonstrates `loki.source.awsfirehose`, the HTTP receiver that accepts AWS Kinesis Data Firehose's documented delivery format. **You don't need an AWS account or any AWS SDKs** — Firehose is just an HTTPS POST in a known JSON shape, and this scenario emulates the producer with a small Python container.
+
+This is the same producer-emulator pattern used by [`syslog/`](../syslog/) and [`gelf-log-ingestion/`](../gelf-log-ingestion/).
+
+## Architecture
+
+- **`alloy`** runs `loki.source.awsfirehose` on port `:9999`, listening at `/awsfirehose/api/v1/push`
+- **`firehose-sender`** (Python) generates synthetic CloudWatch-style log batches every 5 seconds and POSTs them to Alloy in the documented Firehose delivery format (records array with gzip-compressed, base64-encoded data fields)
+- **`loki`** + **`grafana`** for storage and visualization, with the Loki datasource auto-provisioned
+
+The sender alternates between three log streams:
+1. VPC flow logs on `eni-0abc1234-all` (channel `/aws/vpc/flowlogs`)
+2. VPC flow logs on `eni-0def5678-all` (same channel, different stream)
+3. Lambda invocation logs on `[$LATEST]abc` (channel `/aws/lambda/checkout-service`)
+
+## Running
+
+```bash
+# From this directory
+docker compose up -d
+
+# Or from the repo root
+./run-example.sh aws-firehose-logs
+```
+
+## Accessing
+
+- **Grafana**: http://localhost:3000 (no login)
+- **Alloy UI**: http://localhost:12345 — confirm components healthy, use livedebugging to watch records flow through
+- **Firehose endpoint**: http://localhost:9999/awsfirehose/api/v1/push (POSTable from your laptop)
+- **Loki API**: http://localhost:3100
+
+## Trying it out
+
+Within ~10 seconds of bring-up, the sender starts producing batches. In Grafana Explore on Loki:
+
+```logql
+# All Firehose-delivered logs
+{log_group=~".+"}
+
+# Just VPC flow logs
+{log_group="/aws/vpc/flowlogs"}
+
+# A specific ENI
+{log_group="/aws/vpc/flowlogs", log_stream="eni-0abc1234-all"}
+
+# Lambda invocations
+{log_group="/aws/lambda/checkout-service"}
+
+# Just the data records (vs control messages)
+{msg_type="DATA_MESSAGE"}
+```
+
+The promoted labels `log_group`, `log_stream`, and `msg_type` come from the CloudWatch envelope — `loki.source.awsfirehose` automatically attaches `__aws_cw_log_group`, `__aws_cw_log_stream`, and `__aws_cw_msg_type` discovery labels when the records contain a CloudWatch subscription filter envelope; this scenario's `loki.relabel` block promotes them.
+
+## Send your own records
+
+The receiver is just an HTTP endpoint. From your laptop:
+
+```bash
+curl -X POST http://localhost:9999/awsfirehose/api/v1/push \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "requestId": "test-1",
+    "timestamp": 1234567890,
+    "records": [
+      {"data": "'$(printf '{"messageType":"DATA_MESSAGE","logGroup":"/manual","logStream":"laptop","logEvents":[{"id":"x","timestamp":1234567890000,"message":"hi from curl"}]}' | gzip | base64)'"}
+    ]
+  }'
+```
+
+This adds a one-off entry visible at `{log_group="/manual"}`.
+
+## Differences from real Firehose
+
+This scenario emulates the wire format. A real Firehose delivery stream has a few additional concerns the demo doesn't cover:
+
+- **Authentication**: real Firehose includes an `X-Amz-Firehose-Access-Key` header that the receiver validates. `loki.source.awsfirehose` supports this via the `access_key` argument; we leave it disabled in the demo for ease of trying it from curl. In production, **always** set an access key.
+- **TLS**: real Firehose requires HTTPS. Add `tls { cert_file = ..., key_file = ... }` to the Alloy `http` block in production.
+- **Retry semantics**: real Firehose retries on 5xx and partial successes. The Python sender here just logs failures and moves on.
+- **Custom labels via header**: real Firehose can set `X-Amz-Firehose-Common-Attributes` (label names prefixed `lbl_`). Try adding this to your own producer to see additional discovery labels appear.
+
+## Stopping
+
+```bash
+docker compose down -v
+```

--- a/aws-firehose-logs/config.alloy
+++ b/aws-firehose-logs/config.alloy
@@ -1,0 +1,47 @@
+// AWS Kinesis Data Firehose → Loki, no AWS account required.
+//
+// `loki.source.awsfirehose` is just an HTTP endpoint that accepts
+// Firehose's documented delivery format (a `records` array of base64
+// blobs). A small Python sender container in this scenario fakes the
+// producer side, posting CloudWatch-style log batches every few
+// seconds. The component auto-detects the CloudWatch envelope and
+// attaches the `__aws_cw_*` discovery labels we relabel below.
+
+livedebugging { enabled = true }
+
+// CloudWatch envelope discovery labels are exposed by
+// `loki.source.awsfirehose` only via its `relabel_rules` argument
+// (same pattern as `loki.source.journal`). They are NOT attached to
+// outgoing entries by default — running them through a standalone
+// `loki.relabel` after the source would see no `__aws_cw_*` labels.
+loki.relabel "firehose" {
+	forward_to = []
+
+	rule {
+		source_labels = ["__aws_cw_log_group"]
+		target_label  = "log_group"
+	}
+	rule {
+		source_labels = ["__aws_cw_log_stream"]
+		target_label  = "log_stream"
+	}
+	rule {
+		source_labels = ["__aws_cw_msg_type"]
+		target_label  = "msg_type"
+	}
+}
+
+loki.source.awsfirehose "fake" {
+	http {
+		listen_address = "0.0.0.0"
+		listen_port    = 9999
+	}
+	relabel_rules = loki.relabel.firehose.rules
+	forward_to    = [loki.write.local.receiver]
+}
+
+loki.write "local" {
+	endpoint {
+		url = "http://loki:3100/loki/api/v1/push"
+	}
+}

--- a/aws-firehose-logs/docker-compose.yml
+++ b/aws-firehose-logs/docker-compose.yml
@@ -1,0 +1,61 @@
+services:
+
+  loki:
+    image: grafana/loki:${GRAFANA_LOKI_VERSION:-3.6.10}
+    ports:
+      - "3100:3100/tcp"
+    volumes:
+      - ./loki-config.yaml:/etc/loki/local-config.yaml
+    command: -config.file=/etc/loki/local-config.yaml
+
+  grafana:
+    image: grafana/grafana:${GRAFANA_VERSION:-13.0.1}
+    environment:
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_BASIC_ENABLED=false
+    ports:
+      - "3000:3000/tcp"
+    entrypoint:
+      - sh
+      - -euc
+      - |
+        mkdir -p /etc/grafana/provisioning/datasources
+        cat <<EOF > /etc/grafana/provisioning/datasources/ds.yaml
+        apiVersion: 1
+        datasources:
+        - name: Loki
+          type: loki
+          access: proxy
+          orgId: 1
+          url: http://loki:3100
+          basicAuth: false
+          isDefault: true
+          version: 1
+          editable: false
+        EOF
+        /run.sh
+
+  alloy:
+    image: grafana/alloy:${GRAFANA_ALLOY_VERSION:-v1.16.0}
+    ports:
+      - "12345:12345"
+      - "9999:9999"
+    volumes:
+      - ./config.alloy:/etc/alloy/config.alloy
+    command: run --server.http.listen-addr=0.0.0.0:12345 --storage.path=/var/lib/alloy/data /etc/alloy/config.alloy
+    depends_on:
+      - loki
+
+  firehose-sender:
+    image: python:${PYTHON_VERSION:-3.11-slim}
+    volumes:
+      - ./firehose_sender.py:/firehose_sender.py:ro
+    environment:
+      - ALLOY_FIREHOSE_URL=http://alloy:9999/awsfirehose/api/v1/push
+      - INTERVAL_SECONDS=5
+      - EVENTS_PER_BATCH=8
+    depends_on:
+      - alloy
+    command: ["python3", "-u", "/firehose_sender.py"]
+    restart: unless-stopped

--- a/aws-firehose-logs/firehose_sender.py
+++ b/aws-firehose-logs/firehose_sender.py
@@ -1,0 +1,122 @@
+"""Fake AWS Kinesis Firehose producer for the aws-firehose-logs scenario.
+
+Generates synthetic VPC-flow-style log batches, wraps them in the
+CloudWatch logs subscription envelope (so Alloy attaches the
+`__aws_cw_*` discovery labels), then posts them to Alloy's
+`loki.source.awsfirehose` HTTP endpoint in the documented Firehose
+delivery format.
+
+No AWS account or SDK required — this is just an HTTP client.
+"""
+
+import base64
+import gzip
+import json
+import os
+import random
+import sys
+import time
+import uuid
+from datetime import datetime
+from urllib import request as urlrequest
+
+ENDPOINT = os.environ.get(
+    "ALLOY_FIREHOSE_URL",
+    "http://alloy:9999/awsfirehose/api/v1/push",
+)
+INTERVAL = float(os.environ.get("INTERVAL_SECONDS", "5"))
+EVENTS_PER_BATCH = int(os.environ.get("EVENTS_PER_BATCH", "8"))
+
+LOG_GROUPS = [
+    ("/aws/vpc/flowlogs", "eni-0abc1234-all"),
+    ("/aws/vpc/flowlogs", "eni-0def5678-all"),
+    ("/aws/lambda/checkout-service", "2026/04/28/[$LATEST]abc"),
+]
+
+ACTIONS = ["ACCEPT", "REJECT"]
+
+
+def vpc_flow_line() -> str:
+    src = f"10.0.{random.randint(0,255)}.{random.randint(1,254)}"
+    dst = f"10.0.{random.randint(0,255)}.{random.randint(1,254)}"
+    bytes_ = random.randint(40, 65000)
+    pkts = random.randint(1, 50)
+    action = random.choices(ACTIONS, weights=[9, 1])[0]
+    now = int(time.time())
+    return f"2 123456789012 eni-0abc1234 {src} {dst} 12345 443 6 {pkts} {bytes_} {now-30} {now} {action} OK"
+
+
+def lambda_log_line() -> str:
+    levels = ["INFO", "INFO", "INFO", "WARN", "ERROR"]
+    level = random.choice(levels)
+    request_id = str(uuid.uuid4())
+    return f"{datetime.utcnow().isoformat()}Z {level} RequestId: {request_id} processing checkout"
+
+
+def cloudwatch_envelope(log_group: str, log_stream: str, line_fn) -> dict:
+    """Build a CloudWatch logs subscription delivery envelope.
+
+    See: https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/SubscriptionFilters.html
+    """
+    return {
+        "messageType": "DATA_MESSAGE",
+        "owner": "123456789012",
+        "logGroup": log_group,
+        "logStream": log_stream,
+        "subscriptionFilters": ["AlloyDemo"],
+        "logEvents": [
+            {
+                "id": str(uuid.uuid4()),
+                "timestamp": int(time.time() * 1000),
+                "message": line_fn(),
+            }
+            for _ in range(EVENTS_PER_BATCH)
+        ],
+    }
+
+
+def encode_record(envelope: dict) -> dict:
+    """CloudWatch subscription delivery is gzip-compressed JSON, then
+    base64-encoded inside the Firehose record `data` field. See:
+    https://docs.aws.amazon.com/firehose/latest/dev/httpdeliveryrequestresponse.html
+    """
+    raw = json.dumps(envelope).encode()
+    compressed = gzip.compress(raw)
+    return {"data": base64.b64encode(compressed).decode()}
+
+
+def send_batch() -> None:
+    log_group, log_stream = random.choice(LOG_GROUPS)
+    line_fn = lambda_log_line if "lambda" in log_group else vpc_flow_line
+    envelope = cloudwatch_envelope(log_group, log_stream, line_fn)
+
+    body = {
+        "requestId": str(uuid.uuid4()),
+        "timestamp": int(time.time() * 1000),
+        "records": [encode_record(envelope)],
+    }
+    req = urlrequest.Request(
+        ENDPOINT,
+        data=json.dumps(body).encode(),
+        headers={
+            "Content-Type": "application/json",
+            "X-Amz-Firehose-Request-Id": body["requestId"],
+        },
+    )
+    try:
+        with urlrequest.urlopen(req, timeout=5) as resp:
+            print(f"POST {log_group}/{log_stream}: {resp.status}", flush=True)
+    except Exception as e:
+        print(f"POST {log_group}/{log_stream}: FAILED {e}", flush=True)
+
+
+def main() -> int:
+    # Wait briefly so Alloy's HTTP listener is up before the first POST.
+    time.sleep(3)
+    while True:
+        send_batch()
+        time.sleep(INTERVAL)
+
+
+if __name__ == "__main__":
+    sys.exit(main() or 0)

--- a/aws-firehose-logs/loki-config.yaml
+++ b/aws-firehose-logs/loki-config.yaml
@@ -1,0 +1,39 @@
+auth_enabled: false
+
+limits_config:
+  allow_structured_metadata: true
+  volume_enabled: true
+
+server:
+  http_listen_port: 3100
+
+common:
+  ring:
+    instance_addr: 0.0.0.0
+    kvstore:
+      store: inmemory
+  replication_factor: 1
+  path_prefix: /tmp/loki
+
+schema_config:
+  configs:
+    - from: 2020-05-15
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
+storage_config:
+  tsdb_shipper:
+    active_index_directory: /tmp/loki/index
+    cache_location: /tmp/loki/index_cache
+  filesystem:
+    directory: /tmp/loki/chunks
+
+pattern_ingester:
+  enabled: true
+
+ingester:
+  max_chunk_age: 5m


### PR DESCRIPTION
## Summary

Adds a top-level `aws-firehose-logs/` scenario demonstrating `loki.source.awsfirehose` end-to-end **without requiring an AWS account or any AWS SDKs** — Firehose is just an HTTPS POST in a documented JSON shape, so a small Python sender container emulates the producer side.

Closes #95.

## Why this works without AWS

`loki.source.awsfirehose` is an HTTP listener that accepts the documented Firehose [HTTP delivery format](https://docs.aws.amazon.com/firehose/latest/dev/httpdeliveryrequestresponse.html): a `records` array of base64-encoded blobs, optionally containing a CloudWatch logs subscription envelope. There's no AWS callback, no signature validation in the OSS path. Posting the same JSON shape that real Firehose would post is functionally identical from Alloy's point of view.

This is the same emulator pattern the existing `syslog/` and `gelf-log-ingestion/` scenarios already use.

## Architecture

- `alloy` runs `loki.source.awsfirehose` on `:9999/awsfirehose/api/v1/push`
- `firehose-sender` (Python) generates synthetic CloudWatch-style batches every 5s across three streams (two VPC flow log ENIs + a Lambda log group), gzip-compresses + base64-encodes them inside the Firehose delivery envelope, POSTs to Alloy
- `loki` + `grafana` for storage and visualization

## Pipeline highlights

One non-obvious point spelled out in the config comment: the CloudWatch envelope's discovery labels (`__aws_cw_log_group`, `__aws_cw_log_stream`, `__aws_cw_msg_type`) are exposed **only via the source's `relabel_rules` argument** — same pattern as `loki.source.journal`. A standalone downstream `loki.relabel` block won't see them because they're stripped before the source forwards entries. (This caught me during local validation — initial test had zero output despite 200 responses from the receiver.)

Promoted labels: `log_group`, `log_stream`, `msg_type`.

## Test plan

Verified end-to-end locally before pushing:

- [x] `docker compose up -d` brings up cleanly, all 4 containers running
- [x] `firehose-sender` POSTs every 5s with 200 responses
- [x] `loki_source_awsfirehose_records_received{type="cloudwatch-logs"}` increments
- [x] Loki query `{log_group="/aws/vpc/flowlogs"}` returns VPC flow records with `log_stream` and `msg_type` labels populated
- [x] `{log_group="/aws/lambda/checkout-service"}` returns the Lambda log group
- [x] Three streams visible across the two ENIs and the Lambda group
- [x] `docker compose down -v` cleans up

CI to verify on this PR: full `validate-scenarios` run (detect → scan → smoke), all green expected — every image is on Docker Hub, no special host requirements.

## What this isn't

The README documents the differences from real Firehose so users don't ship the demo to production:
- No `X-Amz-Firehose-Access-Key` validation (would be `access_key` argument in the source)
- No TLS (would be `tls { cert_file = ..., key_file = ... }` block)
- No retry / partial-success semantics in the sender
- Custom labels via `X-Amz-Firehose-Common-Attributes` header noted as a try-it-yourself extension

🤖 Generated with [Claude Code](https://claude.com/claude-code)