### PR TITLE
Replace per-variable renovate compose-fallback rules with one generic rule

### DIFF
--- a/image-versions.env
+++ b/image-versions.env
@@ -3,9 +3,15 @@
 # Renovate tracks each variable below — the `# renovate:` annotation
 # tells the bot which docker image the version refers to. Bumps to
 # this file land via renovate PRs that also bump the matching
-# `${VAR:-default}` fallback in every docker-compose file (renovate's
-# docker manager handles the fallbacks; the customManager in
-# renovate.json handles this file). Keep them in lockstep.
+# `${VAR:-default}` fallback in every docker-compose file. Both sides
+# are driven by customManagers in renovate.json: one for this file,
+# one generic rule that captures the depName from the `image:` line
+# in compose files. Keep them in lockstep — the check-image-versions
+# workflow will fail PRs where they drift.
+#
+# Adding a new image: declare `# renovate: datasource=docker depName=<image>`
+# + `<NAME>_VERSION=<value>` here, and reference it in compose as
+# `image: <image>:${<NAME>_VERSION:-<value>}`. No renovate.json edit needed.
 
 # Grafana images
 # renovate: datasource=docker depName=grafana/loki

--- a/renovate.json
+++ b/renovate.json
@@ -25,90 +25,16 @@
       "depNameTemplate": "k8s-monitoring",
       "registryUrlTemplate": "https://grafana.github.io/helm-charts"
     },
-
     {
       "customType": "regex",
-      "description": "Sync ${GRAFANA_VERSION:-default} fallbacks in compose files alongside image-versions.env updates. Renovate's docker-compose manager treats `${VAR}` substitution as a templated reference and won't update inline fallback defaults — without this customManager, the env file moves but the fallbacks drift, breaking `docker compose up` for users who don't pass --env-file.",
+      "description": "Sync ${*_VERSION:-default} fallbacks in every docker-compose file alongside image-versions.env updates. Captures depName from the image reference itself (e.g. `image: nginx/nginx-prometheus-exporter:${NGINX_EXPORTER_VERSION:-1.4.2}` → depName=nginx/nginx-prometheus-exporter, currentValue=1.4.2). One rule covers every variable — adding a new VERSION var to image-versions.env requires no change here as long as the compose line follows the convention `image: <depName>:${<NAME>_VERSION:-<value>}`. Renovate's docker-compose manager treats `${VAR}` substitution as a templated reference and won't update inline fallback defaults — without this customManager, the env file moves but the fallbacks drift, breaking `docker compose up` for users who don't pass --env-file.",
       "managerFilePatterns": [
         "/docker-compose(\\.coda)?\\.ya?ml$/"
       ],
       "matchStrings": [
-        "\\$\\{GRAFANA_VERSION:-(?<currentValue>[^}]+)\\}"
+        "image:\\s*(?<depName>\\S+?):\\$\\{[A-Z_]+_VERSION:-(?<currentValue>[^}]+)\\}"
       ],
-      "datasourceTemplate": "docker",
-      "depNameTemplate": "grafana/grafana"
-    },
-    {
-      "customType": "regex",
-      "description": "Sync ${GRAFANA_LOKI_VERSION:-default} fallbacks in compose files (see GRAFANA_VERSION rule).",
-      "managerFilePatterns": [
-        "/docker-compose(\\.coda)?\\.ya?ml$/"
-      ],
-      "matchStrings": [
-        "\\$\\{GRAFANA_LOKI_VERSION:-(?<currentValue>[^}]+)\\}"
-      ],
-      "datasourceTemplate": "docker",
-      "depNameTemplate": "grafana/loki"
-    },
-    {
-      "customType": "regex",
-      "description": "Sync ${GRAFANA_ALLOY_VERSION:-default} fallbacks in compose files (see GRAFANA_VERSION rule).",
-      "managerFilePatterns": [
-        "/docker-compose(\\.coda)?\\.ya?ml$/"
-      ],
-      "matchStrings": [
-        "\\$\\{GRAFANA_ALLOY_VERSION:-(?<currentValue>[^}]+)\\}"
-      ],
-      "datasourceTemplate": "docker",
-      "depNameTemplate": "grafana/alloy"
-    },
-    {
-      "customType": "regex",
-      "description": "Sync ${GRAFANA_TEMPO_VERSION:-default} fallbacks in compose files (see GRAFANA_VERSION rule).",
-      "managerFilePatterns": [
-        "/docker-compose(\\.coda)?\\.ya?ml$/"
-      ],
-      "matchStrings": [
-        "\\$\\{GRAFANA_TEMPO_VERSION:-(?<currentValue>[^}]+)\\}"
-      ],
-      "datasourceTemplate": "docker",
-      "depNameTemplate": "grafana/tempo"
-    },
-    {
-      "customType": "regex",
-      "description": "Sync ${GRAFANA_PYROSCOPE_VERSION:-default} fallbacks in compose files (see GRAFANA_VERSION rule).",
-      "managerFilePatterns": [
-        "/docker-compose(\\.coda)?\\.ya?ml$/"
-      ],
-      "matchStrings": [
-        "\\$\\{GRAFANA_PYROSCOPE_VERSION:-(?<currentValue>[^}]+)\\}"
-      ],
-      "datasourceTemplate": "docker",
-      "depNameTemplate": "grafana/pyroscope"
-    },
-    {
-      "customType": "regex",
-      "description": "Sync ${PROMETHEUS_VERSION:-default} fallbacks in compose files (see GRAFANA_VERSION rule).",
-      "managerFilePatterns": [
-        "/docker-compose(\\.coda)?\\.ya?ml$/"
-      ],
-      "matchStrings": [
-        "\\$\\{PROMETHEUS_VERSION:-(?<currentValue>[^}]+)\\}"
-      ],
-      "datasourceTemplate": "docker",
-      "depNameTemplate": "prom/prometheus"
-    },
-    {
-      "customType": "regex",
-      "description": "Sync ${PYTHON_VERSION:-default} fallbacks in compose files (see GRAFANA_VERSION rule).",
-      "managerFilePatterns": [
-        "/docker-compose(\\.coda)?\\.ya?ml$/"
-      ],
-      "matchStrings": [
-        "\\$\\{PYTHON_VERSION:-(?<currentValue>[^}]+)\\}"
-      ],
-      "datasourceTemplate": "docker",
-      "depNameTemplate": "python"
+      "datasourceTemplate": "docker"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Three open Renovate PRs (`curlimages/curl`, `nginx`, `nginx/nginx-prometheus-exporter`) are failing `check-image-versions` because renovate bumped `image-versions.env` but left the matching compose fallbacks stale.
- Root cause: `renovate.json` had a hand-maintained per-variable customManager for each compose fallback (`GRAFANA_VERSION`, `GRAFANA_LOKI_VERSION`, …). The nginx-monitoring scenario added three new VERSION vars without adding matching rules, so the env file moved while the compose fallbacks did not.
- Fix: replace the seven per-variable rules with one generic rule that captures `depName` from the `image:` line itself (the image reference is already the renovate docker depName). One rule covers every variable; adding a new image requires no `renovate.json` edit.
- No compose-file churn needed — every existing fallback already matches the convention `image: <depName>:${<NAME>_VERSION:-<value>}`. Verified the new regex captures all 10 unique `(depName, currentValue)` pairs across 77 compose files.
- Updated the comment block in `image-versions.env` to document the contract for new contributors.

## Test plan
- [x] `renovate.json` is valid JSON
- [x] New regex matches every existing `image: …:${VAR:-value}` line in the repo (10/10 deps captured, depNames align with `image-versions.env` annotations)
- [ ] After merge: the three open Renovate PRs need their compose fallbacks fixed manually (or close + let Renovate regenerate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)