### PR TITLE
fix(otel-span-metrics): drop broken tempo-init chown service

### DIFF
--- a/otel-span-metrics/docker-compose.yml
+++ b/otel-span-metrics/docker-compose.yml
@@ -59,20 +59,9 @@ services:
       - 3200:3200/tcp
     volumes:
       - ./tempo-config.yaml:/etc/tempo.yaml
-    depends_on:
-      - tempo-init
-      - memcached
-
-  # Init container to set up Tempo storage directories
-  tempo-init:
-    image: grafana/tempo:${GRAFANA_TEMPO_VERSION:-2.10.4}
-    user: root
-    entrypoint:
-      - "chown"
-      - "10001:10001"
-      - "/var/tempo"
-    volumes:
       - tempo-data:/var/tempo
+    depends_on:
+      - memcached
 
   memcached:
     image: memcached:1.6@sha256:277e0c4f249b118e95ab10e535bae2fa1af772271d9152f3468e58d59348db56


### PR DESCRIPTION
## Summary

- Removes the `tempo-init` service from `otel-span-metrics/docker-compose.yml` and mounts the `tempo-data` named volume directly on the `tempo` service instead.
- Unblocks the `Smoke test (otel-span-metrics)` CI check, which is currently failing on every PR that triggers it (e.g. #139).

## Why

Since **Tempo 2.10** the official `grafana/tempo` image is fully distroless — `chown` and the rest of busybox are gone. The `tempo-init` service was using that image purely to run `chown 10001:10001 /var/tempo`, so it now dies with:

```
exec: "chown": executable file not found in $PATH
```

…and because `tempo` had `depends_on: [tempo-init]`, the whole stack failed to come up.

The upstream Grafana Tempo [`single-binary` docker-compose example](https://github.com/grafana/tempo/tree/main/example/docker-compose/single-binary) doesn't use an init container at all — it just mounts a Docker named volume on `/var/tempo`. A fresh named volume has no pre-existing ownership, so Tempo (UID 10001) just creates and owns its own files. This PR matches that pattern.

Reference: [Tempo upgrade guide — UID 10001 and busybox removal](https://grafana.com/docs/tempo/latest/set-up-for-tracing/setup-tempo/upgrade/).

`otel-span-metrics/docker-compose.yml` was the only file in the repo using the broken `tempo-init` chown pattern (`grep -rn "tempo-init"` and `grep -l "grafana/tempo" | xargs grep -l chown` both return only this one file).

## Test plan

- [x] Local: `cd otel-span-metrics && docker compose up -d` succeeds; `docker compose logs tempo` shows `Tempo started`; `curl http://localhost:3200/ready` returns `200 ready`.
- [ ] CI: `Smoke test (otel-span-metrics)` passes on this PR.
- [ ] Re-run CI on #139 after merge — that PR's smoke test is expected to pass and it can then be merged.