### PR TITLE
feat: add cloudwatch-metrics scenario

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,12 @@ cd <scenario-dir> && docker compose down
 | -------- | ----------- |
 | [Faro frontend observability](faro-frontend-observability/) | Collect frontend web telemetry (logs, errors, web vitals) from browser applications using the Faro Web SDK. |
 
+### Cloud Monitoring
+
+| Scenario | Description |
+| -------- | ----------- |
+| [CloudWatch metrics](cloudwatch-metrics/) | Pull AWS CloudWatch metrics into Prometheus via `prometheus.exporter.cloudwatch`. Uses LocalStack for offline reproducibility — no AWS account required. |
+
 ### Infrastructure Monitoring
 
 | Scenario | Description |

--- a/cloudwatch-metrics/README.md
+++ b/cloudwatch-metrics/README.md
@@ -1,0 +1,93 @@
+# AWS CloudWatch metrics — no AWS account required
+
+Demonstrates `prometheus.exporter.cloudwatch`, Alloy's built-in wrapper around [YACE](https://github.com/nerdswords/yet-another-cloudwatch-exporter). **No real AWS account or live infrastructure needed** — [LocalStack](https://localstack.cloud/) emulates the CloudWatch and STS APIs locally, and a small Python seeder container plants synthetic `EC2/CPUUtilization` data points every 30 s.
+
+This is the same offline-reproducibility pattern used by [`aws-firehose-logs/`](../aws-firehose-logs/).
+
+## Architecture
+
+```
+metric-seeder (Python)
+  └── put_metric_data → LocalStack CloudWatch (:4566)
+                              ↑
+                        Alloy prometheus.exporter.cloudwatch
+                              ↓
+                        prometheus.scrape → prometheus.remote_write
+                              ↓
+                        Prometheus (:9090)
+                              ↑
+                        Grafana (:3000)
+```
+
+- **`localstack`** — emulates `cloudwatch` + `sts` APIs; no AWS credentials required
+- **`metric-seeder`** — pushes `CPUUtilization` (random 5–85 %) for `i-1234567890abcdef0` every 30 s
+- **`alloy`** — runs `prometheus.exporter.cloudwatch` pointed at LocalStack via `AWS_ENDPOINT_URL`; scrapes every 60 s and remote-writes to Prometheus
+- **`prometheus`** — stores and serves metrics
+- **`grafana`** — visualises with Prometheus datasource auto-provisioned
+
+## Running
+
+```bash
+# From this directory
+docker compose up -d
+
+# Or from the repo root
+./run-example.sh cloudwatch-metrics
+```
+
+LocalStack and the metric-seeder start first; Alloy waits for LocalStack to be healthy before scraping.
+
+## Accessing
+
+| Service | URL |
+|---|---|
+| **Grafana** | http://localhost:3000 (no login) |
+| **Prometheus** | http://localhost:9090 |
+| **Alloy UI** | http://localhost:12345 |
+| **LocalStack** | http://localhost:4566/_localstack/health |
+
+## Trying it out
+
+Within ~90 s of bring-up (LocalStack ready → seeder plants first points → Alloy scrapes → Prometheus ingests), metrics appear in Prometheus.
+
+Open **Grafana → Explore → Prometheus** and run:
+
+```promql
+# CPU utilisation for the seeded EC2 instance
+aws_ec2_cpuutilization_average
+
+# Maximum CPU in the last 5 m
+aws_ec2_cpuutilization_maximum
+
+# All CloudWatch-sourced metrics
+{job="cloudwatch/localstack/ec2_cpu"}
+```
+
+Or query Prometheus directly:
+
+```bash
+curl -sG 'http://localhost:9090/api/v1/query' \
+  --data-urlencode 'query=aws_ec2_cpuutilization_average' | jq .
+```
+
+In the **Alloy UI** (http://localhost:12345), navigate to **Graph** to see the pipeline:
+`prometheus.exporter.cloudwatch.localstack` → `prometheus.scrape.cloudwatch` → `prometheus.remote_write.local`
+
+Use **livedebugging** on `prometheus.scrape.cloudwatch` to watch metrics flow through in real time.
+
+## Adapting for real AWS
+
+To point this scenario at real CloudWatch instead of LocalStack:
+
+1. Remove the `localstack` and `metric-seeder` services from `docker-compose.yml`
+2. Remove the `AWS_ENDPOINT_URL` environment variable from the `alloy` service
+3. Set real credentials:
+   ```yaml
+   environment:
+     - AWS_ACCESS_KEY_ID=<your-key>
+     - AWS_SECRET_ACCESS_KEY=<your-secret>
+     - AWS_DEFAULT_REGION=us-east-1
+   ```
+4. Update the `dimensions` in `config.alloy` to match a real `InstanceId` in your account
+
+The `config.alloy` static job configuration and Alloy pipeline are identical for both LocalStack and real AWS.

--- a/cloudwatch-metrics/config.alloy
+++ b/cloudwatch-metrics/config.alloy
@@ -1,0 +1,46 @@
+// AWS CloudWatch metrics → Prometheus — no AWS account required.
+//
+// Uses LocalStack to emulate CloudWatch locally. A companion `metric-seeder`
+// container pushes synthetic EC2/CPUUtilization data points every 30 s so
+// Alloy has real data to scrape immediately on start-up.
+//
+// `prometheus.exporter.cloudwatch` wraps YACE and honours AWS SDK v2 endpoint
+// overrides; we point it at LocalStack via AWS_ENDPOINT_URL in docker-compose.
+
+livedebugging { enabled = true }
+
+// Static job: no live EC2 discovery needed — we target the exact InstanceId
+// that the metric-seeder plants in LocalStack CloudWatch.
+prometheus.exporter.cloudwatch "localstack" {
+	sts_region = "us-east-1"
+
+	static "ec2_cpu" {
+		regions   = ["us-east-1"]
+		namespace = "AWS/EC2"
+
+		dimensions = {
+			"InstanceId" = "i-1234567890abcdef0",
+		}
+
+		metric {
+			name       = "CPUUtilization"
+			statistics = ["Average", "Maximum"]
+			period     = "1m"
+		}
+	}
+}
+
+// Scrape the exporter every 60 s — CloudWatch data points are coarse-grained
+// so there is no benefit in scraping more frequently.
+prometheus.scrape "cloudwatch" {
+	targets         = prometheus.exporter.cloudwatch.localstack.targets
+	forward_to      = [prometheus.remote_write.local.receiver]
+	scrape_interval = "60s"
+}
+
+// Remote-write to the local Prometheus instance.
+prometheus.remote_write "local" {
+	endpoint {
+		url = "http://prometheus:9090/api/v1/write"
+	}
+}

--- a/cloudwatch-metrics/docker-compose.yml
+++ b/cloudwatch-metrics/docker-compose.yml
@@ -1,0 +1,92 @@
+services:
+
+  # LocalStack emulates the CloudWatch + STS APIs locally.
+  # No real AWS account or credentials needed.
+  localstack:
+    image: localstack/localstack:${LOCALSTACK_VERSION:-4.4.0}
+    ports:
+      - "4566:4566"
+    environment:
+      - SERVICES=cloudwatch,sts
+      - DEFAULT_REGION=us-east-1
+    healthcheck:
+      test: ["CMD", "curl", "-sf", "http://localhost:4566/_localstack/health"]
+      interval: 5s
+      timeout: 5s
+      retries: 15
+
+  # Pushes synthetic EC2/CPUUtilization data into LocalStack every 30 s.
+  metric-seeder:
+    image: python:${PYTHON_VERSION:-3.11-slim}
+    volumes:
+      - ./seed-metrics.py:/seed-metrics.py:ro
+    environment:
+      - AWS_ACCESS_KEY_ID=test
+      - AWS_SECRET_ACCESS_KEY=test
+      - AWS_DEFAULT_REGION=us-east-1
+      - AWS_ENDPOINT_URL=http://localstack:4566
+      - INTERVAL_SECONDS=30
+    command: >
+      sh -c "pip install boto3 --quiet && python -u /seed-metrics.py"
+    depends_on:
+      localstack:
+        condition: service_healthy
+    restart: unless-stopped
+
+  prometheus:
+    image: prom/prometheus:${PROMETHEUS_VERSION:-v3.11.3}
+    command:
+      - --web.enable-remote-write-receiver
+      - --config.file=/etc/prometheus/prometheus.yml
+    volumes:
+      - ./prom-config.yaml:/etc/prometheus/prometheus.yml
+    ports:
+      - "9090:9090"
+
+  grafana:
+    image: grafana/grafana:${GRAFANA_VERSION:-13.0.1}
+    environment:
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_BASIC_ENABLED=false
+    ports:
+      - "3000:3000/tcp"
+    entrypoint:
+      - sh
+      - -euc
+      - |
+        mkdir -p /etc/grafana/provisioning/datasources
+        cat <<EOF > /etc/grafana/provisioning/datasources/ds.yaml
+        apiVersion: 1
+        datasources:
+        - name: Prometheus
+          type: prometheus
+          orgId: 1
+          url: http://prometheus:9090
+          basicAuth: false
+          isDefault: true
+          version: 1
+          editable: false
+        EOF
+        /run.sh
+    depends_on:
+      - prometheus
+
+  alloy:
+    image: grafana/alloy:${GRAFANA_ALLOY_VERSION:-v1.16.1}
+    ports:
+      - "12345:12345"
+    volumes:
+      - ./config.alloy:/etc/alloy/config.alloy
+    environment:
+      # Point AWS SDK v2 at LocalStack instead of real AWS endpoints.
+      - AWS_ACCESS_KEY_ID=test
+      - AWS_SECRET_ACCESS_KEY=test
+      - AWS_DEFAULT_REGION=us-east-1
+      - AWS_ENDPOINT_URL=http://localstack:4566
+    command: run --server.http.listen-addr=0.0.0.0:12345 --storage.path=/var/lib/alloy/data /etc/alloy/config.alloy
+    depends_on:
+      localstack:
+        condition: service_healthy
+      prometheus:
+        condition: service_started

--- a/cloudwatch-metrics/prom-config.yaml
+++ b/cloudwatch-metrics/prom-config.yaml
@@ -1,0 +1,3 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s

--- a/cloudwatch-metrics/seed-metrics.py
+++ b/cloudwatch-metrics/seed-metrics.py
@@ -1,0 +1,45 @@
+"""
+CloudWatch metric seeder for LocalStack.
+
+Pushes synthetic EC2 CPUUtilization data points into LocalStack every
+INTERVAL_SECONDS so that prometheus.exporter.cloudwatch has something
+to scrape immediately without a real AWS account.
+"""
+import os
+import random
+import time
+
+import boto3
+from botocore.config import Config
+
+ENDPOINT    = os.getenv("AWS_ENDPOINT_URL", "http://localstack:4566")
+REGION      = os.getenv("AWS_DEFAULT_REGION", "us-east-1")
+INTERVAL    = int(os.getenv("INTERVAL_SECONDS", "30"))
+INSTANCE_ID = "i-1234567890abcdef0"
+
+cw = boto3.client(
+    "cloudwatch",
+    endpoint_url=ENDPOINT,
+    region_name=REGION,
+    aws_access_key_id=os.getenv("AWS_ACCESS_KEY_ID", "test"),
+    aws_secret_access_key=os.getenv("AWS_SECRET_ACCESS_KEY", "test"),
+    config=Config(retries={"max_attempts": 5}),
+)
+
+print(f"Seeder started — pushing to {ENDPOINT} every {INTERVAL}s", flush=True)
+
+while True:
+    cpu = round(random.uniform(5.0, 85.0), 2)
+    cw.put_metric_data(
+        Namespace="AWS/EC2",
+        MetricData=[
+            {
+                "MetricName": "CPUUtilization",
+                "Dimensions": [{"Name": "InstanceId", "Value": INSTANCE_ID}],
+                "Value": cpu,
+                "Unit": "Percent",
+            }
+        ],
+    )
+    print(f"  → CPUUtilization={cpu}%  instance={INSTANCE_ID}", flush=True)
+    time.sleep(INTERVAL)

--- a/image-versions.env
+++ b/image-versions.env
@@ -49,3 +49,7 @@ RABBITMQ_PERF_TEST_VERSION=2.24.0
 # vault-secrets scenario
 # renovate: datasource=docker depName=hashicorp/vault
 VAULT_VERSION=2.0.0
+
+# cloudwatch-metrics scenario
+# renovate: datasource=docker depName=localstack/localstack
+LOCALSTACK_VERSION=4.4.0


### PR DESCRIPTION
## Summary

Implements the cloudwatch-metrics scenario requested in #98.

Pulls AWS CloudWatch metrics into Prometheus using `prometheus.exporter.cloudwatch` with **no real AWS account required** — LocalStack emulates the CloudWatch and STS APIs locally.

## Architecture

```
metric-seeder (Python/boto3)
  └── PutMetricData → LocalStack CloudWatch (:4566)
                            ↑
                      Alloy prometheus.exporter.cloudwatch
                        (AWS_ENDPOINT_URL=http://localstack:4566)
                            ↓
                      prometheus.scrape → prometheus.remote_write
                            ↓
                      Prometheus (:9090) ← Grafana (:3000)
```

## Files added

| File | Purpose |
|------|---------|
| `config.alloy` | Static CloudWatch job — targets fixed `InstanceId` dimension, scrapes every 60s |
| `docker-compose.yml` | LocalStack + seeder + Alloy + Prometheus + Grafana |
| `seed-metrics.py` | Pushes `CPUUtilization` (random 5–85%) every 30s via boto3 |
| `prom-config.yaml` | Minimal Prometheus config |
| `README.md` | Architecture, PromQL queries, real-AWS adaptation guide |

Also:
- Added `LOCALSTACK_VERSION=4.4.0` to `image-versions.env` with Renovate annotation
- Added scenario to main `README.md` Cloud Monitoring section

## How endpoint override works

YACE v0.64 (bundled by Alloy) explicitly reads `AWS_ENDPOINT_URL` via `os.Getenv` and sets `BaseEndpoint` on each service client — CloudWatch, STS, EC2 etc. Setting this env var on the Alloy container in docker-compose is sufficient to redirect all API calls to LocalStack.

## Verifying success criteria

```bash
docker compose up -d
# wait ~90s for localstack + seeder + alloy scrape cycle

curl -sG http://localhost:9090/api/v1/query   --data-urlencode 'query=aws_ec2_cpuutilization_average' | jq .status
# returns: success
```

Or in Grafana Explore → Prometheus: `aws_ec2_cpuutilization_average`

Closes #98