### PR TITLE
Add From simulation scenario

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ These scenarios show distributed tracing with OpenTelemetry and Tempo.
 | Scenario | Description |
 | -------- | ----------- |
 | [Distributed tracing](trace-delivery/) | Learn distributed tracing through a sofa delivery workflow from order to doorstep. |
+| [From simulation](from-simulation/) | A self-running "mini universe" of the MGM+ series _From_. Autonomous characters, day/night cycle, creatures, Yellow Man imposter mode, and a perpetual village-wipe loop — emits a rich, story-shaped telemetry stream. |
 | [Game of tracing](game-of-tracing/) | Play an interactive strategy game that teaches distributed tracing, sampling, and service graphs. |
 | [OpenTelemetry basic tracing](otel-basic-tracing/) | Collect and visualize OpenTelemetry traces with Alloy and Tempo. |
 | [OpenTelemetry service graphs](otel-tracing-service-graphs/) | Generate service graphs with the Alloy `servicegraph` connector. |

--- a/from-simulation/README.md
+++ b/from-simulation/README.md
@@ -66,6 +66,17 @@ All variables are optional — defaults are in `docker-compose.yml` and `app/con
 | `OTEL_EXPORTER_OTLP_ENDPOINT`     | `http://alloy:4318`    | OTLP/HTTP endpoint for logs + metrics                  |
 | `PYROSCOPE_SERVER_ADDRESS`        | `http://alloy:9999`    | Pyroscope push endpoint                                |
 | `SERVICE_NAME`                    | `from-sim`             | Resource service.name attribute                        |
+| `PERSONALITY_DRIFT_RATE`          | `0.04`                 | How fast a survivor's personality traits drift per cycle |
+| `JOURNAL_FRAGMENT_SURVIVAL_PROB`  | `0.6`                  | Per-fragment chance a journal line survives a wipe     |
+| `DREAM_TRIGGER_SANITY_THRESHOLD`  | `40.0`                 | Sanity ceiling below which a sleeping character may dream |
+| `DREAM_TRIGGER_PROB`              | `0.08`                 | Per-eligible-sleep chance of starting a dream          |
+| `DREAM_DURATION_TICKS`            | `30`                   | How long a single dream lasts                          |
+| `BUS_ARRIVAL_CYCLE_INTERVAL`      | `5`                    | Cycles between bus arrivals                            |
+| `BUS_STAY_TICKS`                  | `1440`                 | Ticks the bus parks in town before departing           |
+| `YELLOW_HYDRA_MIN`                | `2`                    | Minimum simultaneous Yellow Man tendrils in IMPOSTER mode |
+| `YELLOW_HYDRA_MAX`                | `3`                    | Maximum simultaneous Yellow Man tendrils               |
+| `LIGHTHOUSE_CALL_TICK_FRAC`       | `0.4`                  | Fraction of NIGHT after which the lighthouse may call  |
+| `TRUST_BASELINE`                  | `0.5`                  | Initial pairwise trust value between characters        |
 
 ### Optional LLM narration
 
@@ -85,6 +96,39 @@ Without a key the simulation runs in pure deterministic mode and the **Narration
 > - `img/fromville-map.png` — full UI with day phase
 > - `img/fromville-night.png` — UI with night phase and creature breach
 > - `img/grafana-overview.png` — Grafana dashboard view
+
+## v2 features
+
+The second iteration adds cross-cycle memory, dreams, outsiders, and the lighthouse — six surfaces visible in the Fromville UI in addition to everything from v1.
+
+### Khatri's Journal (right column, sepia panel)
+
+Each cycle, characters jot fragments of village history into a shared Legacy. When the town falls and a new cycle begins, a fraction of fragments survive (controlled by `JOURNAL_FRAGMENT_SURVIVAL_PROB`) — their text is preserved but increasingly "burned": the higher a fragment's `burned` value, the more transparent its line in the journal panel. The HUD also surfaces `cycles_witnessed` ("Cycle N of all that has ever been") and a small "fragments" indicator.
+
+### Building hash marks
+
+Every time a creature breaches a building, a tally mark is etched into Legacy under that building's id. The UI renders up to twelve tally lines (groups of four with a diagonal slash) at the building's southeast corner; anything beyond twelve is summarised as "+N". These marks survive village wipes, so a building's scar count grows across cycles.
+
+### The Bus and Outsiders
+
+Periodically (every `BUS_ARRIVAL_CYCLE_INTERVAL` cycles) a yellow school bus drives in along the western dirt road, parks near the diner, and drops off "outsider" agents who pursue their own backstory goals for `BUS_STAY_TICKS` ticks before the bus departs east. Outsiders render as pale-gold dots with a "+" glyph above them; while the bus is in town, a yellow-bordered Bus panel lists each passenger with their backstory snippet and a countdown to the next arrival cycle. The SVG map gains continuation dirt-road segments at both edges so the bus path looks like it joins the existing oval.
+
+### Yellow Man hydra (tendrils)
+
+The Yellow Man is no longer a single imposter — in IMPOSTER mode he is now a small set of NPCs (between `YELLOW_HYDRA_MIN` and `YELLOW_HYDRA_MAX`). Every member of `payload.yellow.tendrils` gets a slow-pulsing mustard ring; the disguise leader (`yellow.disguised_as`) gets a brighter, faster ring. The town must identify all of them before the deadline.
+
+### Dreams and dream-mode
+
+When a sleeping character's sanity is below `DREAM_TRIGGER_SANITY_THRESHOLD`, they may begin to dream (`DREAM_TRIGGER_PROB` per eligible tick). Each active dream renders a small green-serif dialog box next to the dreamer with the latest one or two visitor lines, and the whole map shifts into "dream mode" — a hue-rotated, desaturated tint that returns to normal when no dreams are active. Dream lines that match certain trigger events become prophecies in Legacy that may fire one cycle later.
+
+### Lighthouse call
+
+Late in NIGHT (after `LIGHTHOUSE_CALL_TICK_FRAC` of the phase), the lighthouse may call a single character: they receive a slow aqua pulsing ring on the map and bias toward walking down to the lighthouse. When the call is active and the lighthouse's voice is heard, the "Voice from the Lighthouse" panel becomes visible — a black-background monospace radio that prints the rolling last ten `lighthouse_voice` event details with a CRT-style scanline twitch.
+
+### Stability notes for v2 UI
+
+- All v2 panels read snapshot fields **only**: `payload.legacy`, `payload.dreams`, `payload.bus`, `payload.lighthouse`, `payload.yellow.tendrils`. No new client/server contract is required beyond `snapshot_dict`.
+- The dream overlay, hash-mark groups, ring overlays, bus group, and outsider glyphs are all reused between ticks — they are created on demand and torn down only when the corresponding world state stops emitting them, so per-tick render cost stays near v1.
 
 ## Repository
 

--- a/from-simulation/README.md
+++ b/from-simulation/README.md
@@ -1,0 +1,91 @@
+# From — A simulation-driven telemetry scenario
+
+> A small, dread-soaked town runs forever. People hide indoors at dusk. Creatures crawl out of the forest. Sometimes the town falls and a new cycle begins. Every tick emits OpenTelemetry traces, metrics, logs, and continuous profiles into Grafana Alloy — so you can debug a *living* system instead of a synthetic load generator.
+
+## What this scenario demonstrates
+
+- A long-running Python simulation (`from-sim`) that produces traces, metrics, logs, and Pyroscope profiles in a coordinated, story-driven way.
+- A full LGMT + Pyroscope stack wired through Alloy, configured to receive OTLP/HTTP and OTLP/gRPC.
+- A live web map (the **Fromville** UI) so you can see the simulation events that produced the telemetry you're querying in Grafana.
+- Optional Claude-driven narration when `ANTHROPIC_API_KEY` is set — the LLM only colours flavour text and never affects deterministic simulation outcomes.
+
+## Run it
+
+```bash
+# from this directory
+docker compose up -d
+
+# or, from the repo root, with pinned image versions:
+./run-example.sh from-simulation
+```
+
+Tear down:
+
+```bash
+docker compose down
+```
+
+## Endpoints
+
+| Service        | URL                                    | Notes                                            |
+| -------------- | -------------------------------------- | ------------------------------------------------ |
+| Fromville UI   | <http://localhost:8080>                | Live map, event log, roster, stats               |
+| Snapshot JSON  | <http://localhost:8080/api/snapshot>   | Curl-friendly dump of the current world         |
+| Health probe   | <http://localhost:8080/health>         | `{"ok": true, "tick": ...}`                      |
+| Grafana        | <http://localhost:3000>                | Anonymous Admin; no login                        |
+| Alloy UI       | <http://localhost:12345>               | Pipeline debug graph                             |
+| Prometheus     | <http://localhost:9090>                | Direct PromQL                                    |
+| Tempo          | <http://localhost:3200>                | Tempo API                                        |
+| Loki           | <http://localhost:3100>                | Loki API                                         |
+| Pyroscope      | <http://localhost:4040>                | Continuous profiling                             |
+
+## Environment variables
+
+All variables are optional — defaults are in `docker-compose.yml` and `app/contracts.py::Config.from_env`.
+
+| Variable                          | Default                | Purpose                                                |
+| --------------------------------- | ---------------------- | ------------------------------------------------------ |
+| `TICK_HZ`                         | `2.0`                  | Simulation ticks per real second                       |
+| `TIME_SCALE`                      | `1.0`                  | Sim-minutes advanced per tick                          |
+| `SEED`                            | unset                  | RNG seed for deterministic runs                        |
+| `ANTHROPIC_API_KEY`               | unset                  | When set, enables Claude-driven narration              |
+| `LLM_MODEL`                       | `claude-haiku-4-5`     | Anthropic model id                                     |
+| `LLM_DECISION_RATE`               | `0.05`                 | Per-character probability of an LLM decision per tick  |
+| `LLM_YELLOW_RATE`                 | `0.25`                 | Probability the Yellow Man dialogue is LLM-driven      |
+| `LLM_MIN_TICK_GAP`                | `30`                   | Minimum ticks between LLM calls per actor              |
+| `LLM_GLOBAL_RPM`                  | `6`                    | Hard cap on Anthropic API calls per minute             |
+| `NPC_FLOOR`                       | `18`                   | Refill NPCs to at least this many active               |
+| `RESURRECTION_BASE_TICKS`         | `700`                  | Mean ticks before a dead character returns             |
+| `RESURRECTION_JITTER`             | `150`                  | Uniform jitter around the resurrection mean            |
+| `RECOGNITION_THRESHOLD`           | `3`                    | Witness count for "I know who you are" recognition     |
+| `YELLOW_APPEARANCE_DAYS_MIN`      | `5`                    | Min sim-days between Yellow Man appearances            |
+| `YELLOW_APPEARANCE_DAYS_MAX`      | `10`                   | Max sim-days between Yellow Man appearances            |
+| `YELLOW_IMPOSTER_PROB`            | `0.7`                  | Probability the Yellow Man arrives in IMPOSTER mode    |
+| `YELLOW_DEADLINE_TICKS`           | `1500`                 | Ticks the town has to identify the imposter            |
+| `LOG_LEVEL`                       | `INFO`                 | Python root logger level                               |
+| `OTEL_EXPORTER_OTLP_ENDPOINT`     | `http://alloy:4318`    | OTLP/HTTP endpoint for logs + metrics                  |
+| `PYROSCOPE_SERVER_ADDRESS`        | `http://alloy:9999`    | Pyroscope push endpoint                                |
+| `SERVICE_NAME`                    | `from-sim`             | Resource service.name attribute                        |
+
+### Optional LLM narration
+
+If you want the Claude narration channel, export your key in a `.env` file next to `docker-compose.yml`:
+
+```bash
+echo "ANTHROPIC_API_KEY=sk-ant-..." > .env
+docker compose up -d
+```
+
+Without a key the simulation runs in pure deterministic mode and the **Narration** panel in the UI stays hidden — every event is still produced, just without flavour prose.
+
+## Screenshots
+
+> _Placeholder — capture these once the stack runs end-to-end:_
+>
+> - `img/fromville-map.png` — full UI with day phase
+> - `img/fromville-night.png` — UI with night phase and creature breach
+> - `img/grafana-overview.png` — Grafana dashboard view
+
+## Repository
+
+Return to the [main repo README](../README.md) for the full scenario index.

--- a/from-simulation/README.md
+++ b/from-simulation/README.md
@@ -77,6 +77,11 @@ All variables are optional — defaults are in `docker-compose.yml` and `app/con
 | `YELLOW_HYDRA_MAX`                | `3`                    | Maximum simultaneous Yellow Man tendrils               |
 | `LIGHTHOUSE_CALL_TICK_FRAC`       | `0.4`                  | Fraction of NIGHT after which the lighthouse may call  |
 | `TRUST_BASELINE`                  | `0.5`                  | Initial pairwise trust value between characters        |
+| `MIND_REFLECT_EVERY_TICKS`        | `600`                  | Cadence per named character for the Mind's reflection pass (≈5 sim-min) |
+| `MIND_GOAL_TTL_ticks`             | `3600`                 | How long an active goal lives before it expires        |
+| `MIND_NPC_ENABLED`                | `true`                 | When `true`, NPCs run the lightweight `NpcMind` (no LLM cost) |
+| `LLM_THINKING_RPM`                | `2`                    | Reserved RPM slice for "thinking" LLM calls (Yellow Man tactics, belief flavour); split off the global RPM |
+| `DETERMINISTIC_MODE`              | `false`                | When `true`, every LLM `maybe_*` returns None so `SEED` runs are byte-identical |
 
 ### Optional LLM narration
 
@@ -133,6 +138,92 @@ Late in NIGHT (after `LIGHTHOUSE_CALL_TICK_FRAC` of the phase), the lighthouse m
 ### v3 — hand-drawn map & character tokens
 
 The map is now the **Claude Design hand-drawn Fromville** — a paper-stock meadow inside a dark forest ring with a single S-curve highway, internal dirt streets, three Faraway/Bottle Trees, a rotating lighthouse beam, and all 18 numbered township buildings (forest scatter is generated client-side from a seeded RNG so it stays consistent across sessions). A new **Township Index** side panel lists every building with its number, mini-icon, and name; the five talisman-protected buildings — **Colony House, Clinic, Church, Sheriff's Office, Matthews' Home** — are marked with a ★. Named characters now render as hand-drawn 60×80 token sprites (one `<symbol>` per character, dropped onto the map via `<use href="#token-{name}">`), and the Man in Yellow / Boy in White get their own distinct tokens. Building windows glow at DUSK and NIGHT and a radial-gradient overlay deepens the village in dream-time.
+
+### v9 — cognitive layer (Mind + AI Director)
+
+Named characters and (lightweight) NPCs now run a four-layer cognitive stack
+between the existing weighted-FSM and the optional LLM picker:
+
+1. **Memory stream** — retrieves recent `character_memory` rows scored by
+   recency × importance × structural relevance (deterministic; no embeddings).
+2. **Beliefs** — every `MIND_REFLECT_EVERY_TICKS` ticks each named character
+   clusters their recent memories and emits up to three typed beliefs
+   (`house_weak:X`, `yellow_suspect:Y`, `loss:Z`, …) that are persisted as
+   `character_memory` rows with `kind = "belief"` so they survive restart.
+3. **Goals** — a deterministic rule table maps beliefs + drives to one active
+   `Goal` per agent (`PROTECT_X`, `INVESTIGATE_X`, `REVENGE_X`, `FLEE_TO_Y`,
+   `FIND_ITEM_Z`). Open/close are recorded in memory.
+4. **Plan** — the active goal adds additive weight deltas onto the existing
+   FSM menu; the weighted-FSM choice still runs last, so `SEED`-pinned runs
+   stay deterministic.
+
+A world-level **AI Director** (`app/agents/director.py`) reads town tension
+(fear/sanity averages, food ratio, recent breach rate, yellow deadline) and
+tunes three knobs each tick:
+
+- `spawn_rate_mult` — creature cohort size at dusk
+- `yellow_appearance_bias` — added to `YELLOW_IMPOSTER_PROB`
+- `target_bias` — softmax over `legacy.building_breach_marks` and the new
+  `legacy.talisman_failure_count` so historically weak buildings draw the
+  next wave (creatures *learn* across cycles).
+
+The **Yellow Man** is now actively strategic — tendril NPCs are chosen by an
+"awareness × social-load" weight, and `LURE_OUTSIDE` prefers homes of
+load-bearing roles (SHERIFF / CARETAKER / PRIEST). The previously-broken LLM
+hook (`yellow_man.py:_consult_llm`) is wired to a generic
+`LLMDecider.maybe_pick_string` on its own thinking-budget bucket so reflection
+and tactical calls never starve the state-choice budget.
+
+Visibility:
+
+- HUD bar gains a **Minds** cell — Director pressure (0..1 with a colour
+  gradient), goal-mix pips by kind, and the live belief count.
+- Dossier panel adds a **Mind** section: active goal + top-3 beliefs with
+  confidence bars, plus a reflection counter.
+- OTel spans (`mind.recall`, `mind.reflect`, `mind.regoal`, `mind.shape_menu`,
+  `director.recalc`, `yellow.target_select`) and metrics
+  (`from_sim_director_pressure`, `from_sim_director_spawn_mult`,
+  `from_sim_mind_beliefs_active`, `from_sim_mind_goals_active{kind}`,
+  `from_sim_mind_reflections_total`, `from_sim_yellow_target_role{role}`,
+  plus a new `purpose` label on `from_sim_llm_calls_total`).
+
+LLM budget is split: 4 RPM for state-choice + `LLM_THINKING_RPM` (default 2)
+for thinking. With `ANTHROPIC_API_KEY` unset, or `DETERMINISTIC_MODE=true`,
+every cognitive op falls back to the deterministic path.
+
+### v9.1 — pressure-equilibrium pass
+
+Tuning pass on top of v9 to make monsters actually suppress survivor growth
+rather than the user reducing arrivals. Key changes:
+
+- Dusk creature cohort cap raised (12 → 20) and population scaling steepened
+  (one extra per 8 living agents instead of 12).
+- Cave spawner activates at DUSK as well as NIGHT, runs on a 60-tick cadence
+  (was 90), and the soft cap rises 8 → 14.
+- New mid-NIGHT wave (`creatures.tick_night_wave`) drops a half-strength
+  cohort once per simulated night so cohort depletion no longer empties the
+  map between dusk and dawn.
+- Stalker creatures multi-kill (up to 3 prey before retreating); swarmers
+  keep single-prey behaviour. A `creature_kill_streak` event fires on the
+  second catch so rampages are visible in the journal.
+- Hunt geometry: radius 110 → 150 (overcrowded 180 → 240), catch box 12 →
+  14, chase speed bonus 0.4 → 0.6.
+- `NPC_BREACH_DEATH_PROB` default 0.30 → 0.50 so getting through a door
+  matters.
+- AI Director gains a **population-stress** input: once live population
+  crosses ~1.5× `NPC_FLOOR`, it subtracts from the raw pressure score
+  (capped at 0.4), pushing the Director toward escalation. The spawn-mult
+  ceiling also rises 1.4× → 1.6×, so a thriving town gets a max cohort of
+  ~32 creatures.
+- HUD minds cell gains a `PS` pip alongside Director pressure; the dossier
+  is unchanged.
+
+New metrics: `from_sim_director_population_stress` (gauge),
+`from_sim_creatures_night_waves_total` (counter).
+New events: `creature_night_wave`, `creature_kill_streak`.
+
+The whole pass is deterministic with `SEED` set, and `DETERMINISTIC_MODE`
+still disables every LLM call.
 
 ## Repository
 

--- a/from-simulation/README.md
+++ b/from-simulation/README.md
@@ -130,6 +130,10 @@ Late in NIGHT (after `LIGHTHOUSE_CALL_TICK_FRAC` of the phase), the lighthouse m
 - All v2 panels read snapshot fields **only**: `payload.legacy`, `payload.dreams`, `payload.bus`, `payload.lighthouse`, `payload.yellow.tendrils`. No new client/server contract is required beyond `snapshot_dict`.
 - The dream overlay, hash-mark groups, ring overlays, bus group, and outsider glyphs are all reused between ticks — they are created on demand and torn down only when the corresponding world state stops emitting them, so per-tick render cost stays near v1.
 
+### v3 — hand-drawn map & character tokens
+
+The map is now the **Claude Design hand-drawn Fromville** — a paper-stock meadow inside a dark forest ring with a single S-curve highway, internal dirt streets, three Faraway/Bottle Trees, a rotating lighthouse beam, and all 18 numbered township buildings (forest scatter is generated client-side from a seeded RNG so it stays consistent across sessions). A new **Township Index** side panel lists every building with its number, mini-icon, and name; the five talisman-protected buildings — **Colony House, Clinic, Church, Sheriff's Office, Matthews' Home** — are marked with a ★. Named characters now render as hand-drawn 60×80 token sprites (one `<symbol>` per character, dropped onto the map via `<use href="#token-{name}">`), and the Man in Yellow / Boy in White get their own distinct tokens. Building windows glow at DUSK and NIGHT and a radial-gradient overlay deepens the village in dream-time.
+
 ## Repository
 
 Return to the [main repo README](../README.md) for the full scenario index.

--- a/from-simulation/app/Dockerfile
+++ b/from-simulation/app/Dockerfile
@@ -7,6 +7,11 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 COPY . .
 
+# v5 — SQLite Memory writes to /data/from.db by default. Ensure the dir exists
+# and is world-writeable so the container user can write even when no volume
+# is mounted (local-dev / sandbox runs).
+RUN mkdir -p /data && chmod 777 /data
+
 ENV FLASK_APP=app.py
 ENV FLASK_DEBUG=0
 ENV IN_DOCKER=1

--- a/from-simulation/app/Dockerfile
+++ b/from-simulation/app/Dockerfile
@@ -1,0 +1,17 @@
+FROM python:${PYTHON_VERSION:-3.11-slim}
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+ENV FLASK_APP=app.py
+ENV FLASK_DEBUG=0
+ENV IN_DOCKER=1
+ENV PYTHONUNBUFFERED=1
+
+EXPOSE 8080
+
+CMD ["python", "app.py"]

--- a/from-simulation/app/agents/base.py
+++ b/from-simulation/app/agents/base.py
@@ -1,0 +1,90 @@
+"""
+Shared geometry + utility helpers for every agent slice.
+
+The ``Agent`` ABC itself is in ``contracts.py``. This module is the small
+library of math/spatial helpers Agents B, C, and A's own creatures/supernaturals
+all need: distance, "move toward a point at a given speed", "find the nearest
+item to (x, y) by a key function".
+
+Keep this module pure (no world mutation, no telemetry). It must be importable
+by every agents/*.py file without forming an import cycle.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any, Callable, Iterable, Optional, Tuple
+
+
+def distance(a: Any, b: Any) -> float:
+    """Euclidean distance between two objects exposing ``.x``/``.y`` or tuples.
+
+    Accepts any object with ``.x`` and ``.y`` attributes, or a 2-tuple. Used by
+    every slice for proximity checks, so it must handle the mix gracefully.
+    """
+    ax, ay = _xy(a)
+    bx, by = _xy(b)
+    dx = ax - bx
+    dy = ay - by
+    return math.hypot(dx, dy)
+
+
+def _xy(obj: Any) -> Tuple[float, float]:
+    if isinstance(obj, tuple) and len(obj) == 2:
+        return float(obj[0]), float(obj[1])
+    return float(getattr(obj, "x")), float(getattr(obj, "y"))
+
+
+def move_toward(self: Any, tx: float, ty: float, speed: float) -> bool:
+    """Move ``self`` toward (tx, ty) at most ``speed`` pixels this tick.
+
+    Mutates ``self.x``/``self.y``. Returns ``True`` if the agent reached the
+    target this tick (within one ``speed`` step), ``False`` otherwise. The
+    return value lets the caller flip to the next sub-state without a separate
+    distance check.
+    """
+    dx = tx - self.x
+    dy = ty - self.y
+    d = math.hypot(dx, dy)
+    if d <= speed or d == 0.0:
+        self.x = float(tx)
+        self.y = float(ty)
+        return True
+    self.x += (dx / d) * speed
+    self.y += (dy / d) * speed
+    return False
+
+
+def nearest(
+    items: Iterable[Any],
+    x: float,
+    y: float,
+    key: Optional[Callable[[Any], Tuple[float, float]]] = None,
+) -> Optional[Any]:
+    """Return the item in ``items`` closest to (x, y), or None if empty.
+
+    ``key`` extracts an (x, y) pair from each item. Default uses ``.x``/``.y``.
+    """
+    best: Optional[Any] = None
+    best_d2 = math.inf
+    for it in items:
+        if key is None:
+            ix, iy = _xy(it)
+        else:
+            ix, iy = key(it)
+        dx = ix - x
+        dy = iy - y
+        d2 = dx * dx + dy * dy
+        if d2 < best_d2:
+            best = it
+            best_d2 = d2
+    return best
+
+
+def clamp(v: float, lo: float, hi: float) -> float:
+    """Clamp ``v`` to the closed interval [lo, hi]."""
+    if v < lo:
+        return lo
+    if v > hi:
+        return hi
+    return v

--- a/from-simulation/app/agents/bus.py
+++ b/from-simulation/app/agents/bus.py
@@ -1,0 +1,590 @@
+"""
+The Bus and the Outsiders — visitors from the world that supposedly exists
+outside the trees.
+
+A bus rolls into town on a long cycle cadence (``config.bus_arrival_cycle_interval``,
+default every 5 cycles, gated on D1 noon of a fresh cycle). It carries 1-3
+Outsiders, each with a tiny backstory and a single goal that drives their
+target-picking behaviour. They walk around for ``config.bus_stay_ticks`` and
+then the bus rolls back out the other side of town; any Outsider still alive
+gets back on, anyone dead becomes a journal fragment.
+
+Outsiders are NPC-ish but distinct: they have ``AgentKind.OUTSIDER``, a
+different marker class, and pursue ``State.OUTSIDER_GOAL`` instead of the
+NPC working/socialising FSM. They never become Yellow Man tendrils.
+
+Public surface:
+    * ``Outsider``           — Agent subclass.
+    * ``tick_bus(world)``    — engine hook, call once per tick.
+    * ``clear_outsiders``    — drop every outsider; safe to call lazily.
+
+Wiring contract for the simulation engine (Agent A): call ``tick_bus(world)``
+once per tick, ideally before ``tick_population`` so that any survivors who
+boarded the bus are gone from ``world.agents`` before the population reaper
+runs.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any, Dict, List, Optional, Tuple
+
+from contracts import (
+    Agent,
+    AgentKind,
+    BUS_PARK,
+    BUS_PATH_IN,
+    BUS_PATH_OUT,
+    Event,
+    FARAWAY_TREES,
+    MarkerClass,
+    Metric,
+    State,
+    Status,
+    World,
+)
+import legacy
+
+
+# ---------------------------------------------------------------------------
+# Backstories — used to seed the Outsiders that step off each bus.
+# ---------------------------------------------------------------------------
+
+# (name_seed, backstory, goal). The goal string drives _pick_outsider_target.
+_BACKSTORIES: List[Tuple[str, str, str]] = [
+    ("Sarah",       "doctor returning to Boston",                     "examine the talismans"),
+    ("Mike",        "journalist tracking the missing-persons cluster", "interview Khatri"),
+    ("Charlie",     "Vietnam vet looking for his brother",            "find the radio tower"),
+    ("Eleanor",     "schoolteacher from Tarrytown",                   "talk to the children"),
+    ("Marcus",      "trucker who took a wrong turn",                  "leave on the next bus"),
+    ("Father Holt", "another priest",                                 "examine the talismans"),
+]
+
+
+def _disambiguate_name(world: World, seed: str) -> str:
+    """If ``seed`` collides with an existing agent name, suffix it."""
+    existing = {getattr(a, "name", None) for a in world.agents.values()}
+    if seed not in existing:
+        return seed
+    # Match the npcs.py house style (II, III, ...).
+    romans = ["II", "III", "IV", "V", "VI", "VII", "VIII", "IX", "X"]
+    for tag in romans:
+        cand = f"{seed} {tag}"
+        if cand not in existing:
+            return cand
+    return f"{seed} {world.rng.randint(2, 999)}"
+
+
+# ---------------------------------------------------------------------------
+# Module-local id counter so Outsider ids never collide across arrivals.
+# ---------------------------------------------------------------------------
+
+_OUTSIDER_COUNTER = {"n": 0}
+
+
+def _next_outsider_id(world: World) -> str:
+    _OUTSIDER_COUNTER["n"] += 1
+    return f"outsider_{world.cycle_number}_{_OUTSIDER_COUNTER['n']}"
+
+
+# ---------------------------------------------------------------------------
+# Outsider — Agent subclass
+# ---------------------------------------------------------------------------
+
+
+class Outsider(Agent):
+    """A visitor from beyond the trees. Pursues a single backstory goal."""
+
+    kind = AgentKind.OUTSIDER
+    marker_class = MarkerClass.OUTSIDER
+
+    def __init__(
+        self,
+        outsider_id: str,
+        name: str,
+        backstory: str,
+        goal: str,
+        arrives_at_tick: int,
+        leaves_at_tick: int,
+        x: float,
+        y: float,
+    ) -> None:
+        self.id = outsider_id
+        self.name = name
+        self.backstory = backstory
+        self.goal = goal
+        self.arrives_at_tick = arrives_at_tick
+        self.leaves_at_tick = leaves_at_tick
+        self.x = float(x)
+        self.y = float(y)
+        self.target_x = float(x)
+        self.target_y = float(y)
+        self.status: Status = Status.ACTIVE
+        self.state: State = State.OUTSIDER_GOAL
+        self.fear: float = 0.0
+        self.sanity: float = 80.0
+        # Re-target cooldown so the outsider doesn't thrash every tick.
+        self._retarget_at_tick: int = 0
+
+    def to_dict(self) -> Dict[str, Any]:
+        d = super().to_dict()
+        d.update(
+            {
+                "name": self.name,
+                "backstory": self.backstory,
+                "goal": self.goal,
+                "state": self.state.value,
+                "status": self.status.value,
+                "fear": round(self.fear, 2),
+                "sanity": round(self.sanity, 2),
+                "leaves_in": max(0, self.leaves_at_tick - 0),  # filled by snapshot if needed
+                "target_x": round(self.target_x, 2),
+                "target_y": round(self.target_y, 2),
+            }
+        )
+        return d
+
+    # ------------------------------------------------------------- targeting
+
+    def _pick_target(self, world: World) -> Tuple[float, float]:
+        """Pick a target based on the outsider's goal."""
+        rng = world.rng
+        goal = (self.goal or "").lower()
+
+        if "khatri" in goal:
+            khatri = world.agents.get("Khatri")
+            if khatri is not None and getattr(khatri, "status", Status.ACTIVE) == Status.ACTIVE:
+                return (khatri.x + rng.uniform(-15, 15), khatri.y + rng.uniform(-15, 15))
+            # Fallback: church (Khatri's haunt).
+            for b in world.buildings.values():
+                if b.role_tag == "church":
+                    return (b.x + rng.uniform(-20, 20), b.y + rng.uniform(20, 40))
+
+        if "talisman" in goal:
+            talismans = [b for b in world.buildings.values() if b.has_talisman]
+            if talismans:
+                b = rng.choice(talismans)
+                return (b.x + rng.uniform(-25, 25), b.y + rng.uniform(20, 45))
+
+        if "radio tower" in goal or "tower" in goal:
+            # No actual tower in the map — wander between Faraway Trees as the
+            # next-best "looking for the edge of the world" behaviour.
+            if FARAWAY_TREES:
+                tx, ty = rng.choice(FARAWAY_TREES)
+                return (tx + rng.uniform(-30, 30), ty + rng.uniform(-30, 30))
+
+        if "children" in goal or "child" in goal:
+            # Drift toward the Matthews house — where the show's children live.
+            for b in world.buildings.values():
+                if b.role_tag == "matthews":
+                    return (b.x + rng.uniform(-25, 25), b.y + rng.uniform(20, 45))
+
+        if "next bus" in goal or "leave" in goal:
+            # Stand near the parked bus.
+            return (world.bus.x + rng.uniform(-25, 25), world.bus.y + rng.uniform(20, 45))
+
+        # Default: jitter near current position.
+        return (self.x + rng.uniform(-40, 40), self.y + rng.uniform(-40, 40))
+
+    # ----------------------------------------------------------------- tick
+
+    def tick(self, world: World) -> None:
+        if self.status != Status.ACTIVE:
+            return
+
+        # If our exit tick has arrived, mark ABSENT so the bus loop collects us.
+        if world.tick_count >= self.leaves_at_tick:
+            self.status = Status.ABSENT
+            return
+
+        # We haven't actually walked off the bus yet — wait.
+        if world.tick_count < self.arrives_at_tick:
+            return
+
+        # (Re)pick a target if arrived or cooldown elapsed.
+        dx = self.target_x - self.x
+        dy = self.target_y - self.y
+        d = math.hypot(dx, dy)
+        if d < 4.0 or world.tick_count >= self._retarget_at_tick:
+            tx, ty = self._pick_target(world)
+            self.target_x = tx
+            self.target_y = ty
+            self._retarget_at_tick = world.tick_count + world.rng.randint(40, 100)
+
+        # Step toward target.
+        step = 4.0
+        dx = self.target_x - self.x
+        dy = self.target_y - self.y
+        d = math.hypot(dx, dy)
+        if d > step and d > 0.0:
+            self.x += dx * (step / d)
+            self.y += dy * (step / d)
+        else:
+            self.x = self.target_x
+            self.y = self.target_y
+
+
+# ---------------------------------------------------------------------------
+# Bus marker — purely a render hint; the bus state lives on ``world.bus``.
+# ---------------------------------------------------------------------------
+
+
+class _BusMarker:
+    """``Agent``-shaped object so the frontend can render the bus dot.
+
+    We don't subclass ``Agent`` because the bus doesn't tick autonomously —
+    ``tick_bus`` drives ``world.bus`` directly and the marker mirrors that.
+    """
+
+    kind = AgentKind.SUPERNATURAL  # closest-fit existing kind for snapshot
+    marker_class = MarkerClass.BUS
+
+    def __init__(self, x: float, y: float) -> None:
+        self.id = "bus_marker"
+        self.x = float(x)
+        self.y = float(y)
+
+    def tick(self, world: World) -> None:  # pragma: no cover - driven externally
+        pass
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "id": self.id,
+            "kind": self.kind.value,
+            "marker_class": self.marker_class.value,
+            "x": round(self.x, 2),
+            "y": round(self.y, 2),
+        }
+
+
+def _ensure_bus_marker(world: World) -> _BusMarker:
+    """Find or spawn the bus marker in ``world.supernaturals``."""
+    for s in world.supernaturals:
+        if getattr(s, "id", None) == "bus_marker":
+            return s  # type: ignore[return-value]
+    marker = _BusMarker(world.bus.x, world.bus.y)
+    world.supernaturals.append(marker)
+    return marker
+
+
+def _remove_bus_marker(world: World) -> None:
+    world.supernaturals[:] = [
+        s for s in world.supernaturals if getattr(s, "id", None) != "bus_marker"
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Public: clear outsiders (called lazily when bus is inactive).
+# ---------------------------------------------------------------------------
+
+
+def clear_outsiders(world: World) -> None:
+    """Drop every Outsider from ``world.agents`` and reset the id counter.
+
+    Safe to call between cycles or whenever the bus is inactive — sweeps
+    leftover outsider ids without emitting any event.
+    """
+    out_ids = [
+        a.id for a in list(world.agents.values())
+        if getattr(a, "kind", None) == AgentKind.OUTSIDER
+    ]
+    for oid in out_ids:
+        world.agents.pop(oid, None)
+    world.bus.passengers.clear()
+    _remove_bus_marker(world)
+    _OUTSIDER_COUNTER["n"] = 0
+
+
+# ---------------------------------------------------------------------------
+# Bus internals
+# ---------------------------------------------------------------------------
+
+
+_BUS_SPEED_PX = 6.0
+
+
+def _step_toward(x: float, y: float, tx: float, ty: float, step: float) -> Tuple[float, float, bool]:
+    """Return new (x, y, arrived)."""
+    dx = tx - x
+    dy = ty - y
+    d = math.hypot(dx, dy)
+    if d <= step or d == 0.0:
+        return tx, ty, True
+    return x + dx * (step / d), y + dy * (step / d), False
+
+
+def _pick_backstories(world: World, n: int) -> List[Tuple[str, str, str]]:
+    """Pick ``n`` distinct backstory tuples for this arrival."""
+    pool = list(_BACKSTORIES)
+    world.rng.shuffle(pool)
+    return pool[: max(1, min(n, len(pool)))]
+
+
+def _begin_arrival(world: World) -> None:
+    """Roll the bus onto the dirt road, spawn 1-3 outsiders, schedule next arrival."""
+    cfg = world.config
+    rng = world.rng
+    bus = world.bus
+
+    bus.active = True
+    bus.arrival_tick = world.tick_count
+    bus.departure_tick = world.tick_count + cfg.bus_stay_ticks
+    bus.path_index = 0
+    if BUS_PATH_IN:
+        bus.x, bus.y = BUS_PATH_IN[0]
+    bus.passengers.clear()
+    # Clear any leftover departure sentinel from a prior visit.
+    if hasattr(bus, "_departing"):
+        try:
+            delattr(bus, "_departing")
+        except AttributeError:
+            pass
+
+    # Reset the marker.
+    _remove_bus_marker(world)
+    _ensure_bus_marker(world)
+
+    # Schedule the next visit relative to legacy cycles witnessed.
+    bus.next_arrival_cycle = (
+        world.legacy.cycles_witnessed + cfg.bus_arrival_cycle_interval
+    )
+
+    # Spawn 1-3 outsiders.
+    n_outsiders = rng.randint(1, 3)
+    picks = _pick_backstories(world, n_outsiders)
+    arrive_at = world.tick_count + 10
+    leave_at = bus.departure_tick - 10
+    spawned: List[Outsider] = []
+    for seed, backstory, goal in picks:
+        name = _disambiguate_name(world, seed)
+        oid = _next_outsider_id(world)
+        # Start them at the parked-bus location; they only "appear" after arrive_at.
+        ox, oy = BUS_PARK
+        ox += rng.uniform(-6, 6)
+        oy += rng.uniform(8, 18)
+        outsider = Outsider(
+            outsider_id=oid,
+            name=name,
+            backstory=backstory,
+            goal=goal,
+            arrives_at_tick=arrive_at,
+            leaves_at_tick=leave_at,
+            x=ox,
+            y=oy,
+        )
+        world.agents[oid] = outsider
+        bus.passengers.append(oid)
+        spawned.append(outsider)
+
+    world.emit(
+        Event(
+            tick=world.tick_count,
+            type="bus_arrival",
+            subject="bus",
+            detail=f"the bus rolled in with {len(spawned)} passengers",
+            severity="info",
+        )
+    )
+    for o in spawned:
+        world.emit(
+            Event(
+                tick=world.tick_count,
+                type="outsider_joined",
+                subject=o.id,
+                detail=f"{o.name} — {o.backstory}; goal: {o.goal}",
+                severity="info",
+            )
+        )
+
+
+def _drive_in(world: World) -> None:
+    """Step the bus along BUS_PATH_IN."""
+    bus = world.bus
+    if bus.path_index >= len(BUS_PATH_IN):
+        # Sit at BUS_PARK.
+        bus.x, bus.y = BUS_PARK
+        marker = _ensure_bus_marker(world)
+        marker.x, marker.y = bus.x, bus.y
+        return
+
+    tx, ty = BUS_PATH_IN[bus.path_index]
+    new_x, new_y, arrived = _step_toward(bus.x, bus.y, tx, ty, _BUS_SPEED_PX)
+    bus.x, bus.y = new_x, new_y
+    if arrived:
+        bus.path_index += 1
+    marker = _ensure_bus_marker(world)
+    marker.x, marker.y = bus.x, bus.y
+
+
+def _drive_out(world: World) -> None:
+    """Drive the bus along BUS_PATH_OUT; on completion, collect passengers."""
+    bus = world.bus
+    # path_index resets to 0 when departure begins; we track via a sentinel:
+    # we re-use ``path_index`` after departure (since drive-in is complete by then).
+    if bus.path_index < len(BUS_PATH_OUT):
+        tx, ty = BUS_PATH_OUT[bus.path_index]
+        new_x, new_y, arrived = _step_toward(bus.x, bus.y, tx, ty, _BUS_SPEED_PX)
+        bus.x, bus.y = new_x, new_y
+        if arrived:
+            bus.path_index += 1
+        marker = _ensure_bus_marker(world)
+        marker.x, marker.y = bus.x, bus.y
+        return
+
+    # Path complete — collect survivors and depart.
+    survivors: List[Outsider] = []
+    for oid in list(bus.passengers):
+        agent = world.agents.get(oid)
+        if isinstance(agent, Outsider) and agent.status in (Status.ACTIVE, Status.ABSENT):
+            survivors.append(agent)
+            world.agents.pop(oid, None)
+
+    for o in survivors:
+        world.emit(
+            Event(
+                tick=world.tick_count,
+                type="outsider_left",
+                subject=o.id,
+                detail=f"{o.name} boarded the bus out of town",
+                severity="info",
+            )
+        )
+
+    world.emit(
+        Event(
+            tick=world.tick_count,
+            type="bus_depart",
+            subject="bus",
+            detail=f"the bus left with {len(survivors)} passenger(s)",
+            severity="info",
+        )
+    )
+
+    # Reset bus state.
+    bus.active = False
+    bus.passengers.clear()
+    bus.path_index = 0
+    bus.arrival_tick = 0
+    bus.departure_tick = 0
+    if hasattr(bus, "_departing"):
+        try:
+            delattr(bus, "_departing")
+        except AttributeError:
+            pass
+    _remove_bus_marker(world)
+
+
+def _begin_departure(world: World) -> None:
+    """Flip the bus into drive-out mode.
+
+    We use a sentinel attribute ``_departing`` on ``world.bus`` (set via
+    ``setattr``) to distinguish drive-in from drive-out phases, since both
+    re-use ``path_index``.
+    """
+    bus = world.bus
+    bus.path_index = 0
+    # Snap to the parked location to start the outbound run cleanly.
+    bus.x, bus.y = BUS_PARK
+    setattr(bus, "_departing", True)
+
+
+def _reap_dead_outsiders(world: World) -> None:
+    """Sweep DEAD outsiders, emit event + journal."""
+    dead_ids: List[str] = []
+    for a in list(world.agents.values()):
+        if getattr(a, "kind", None) != AgentKind.OUTSIDER:
+            continue
+        if getattr(a, "status", Status.ACTIVE) == Status.DEAD:
+            dead_ids.append(a.id)
+
+    for oid in dead_ids:
+        outsider = world.agents.pop(oid, None)
+        if outsider is None:
+            continue
+        name = getattr(outsider, "name", oid)
+        goal = getattr(outsider, "goal", "something they would not say")
+        # Drop from passenger list — they will not be boarding.
+        if oid in world.bus.passengers:
+            world.bus.passengers.remove(oid)
+        world.emit(
+            Event(
+                tick=world.tick_count,
+                type="outsider_died",
+                subject=oid,
+                detail=f"{name} did not get back on the bus",
+                severity="warn",
+            )
+        )
+        try:
+            legacy.record(world, "outsider_died", name=name, goal=goal)
+        except Exception:
+            # Journal failure must never break the tick.
+            pass
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+def _count_active_outsiders(world: World) -> int:
+    return sum(
+        1
+        for a in world.agents.values()
+        if getattr(a, "kind", None) == AgentKind.OUTSIDER
+        and getattr(a, "status", Status.ACTIVE) == Status.ACTIVE
+    )
+
+
+def tick_bus(world: World) -> None:
+    """Engine hook — call once per tick.
+
+    Drives the bus state machine:
+
+        1. If bus inactive and the cycle/D1-noon conditions are met -> arrive.
+        2. If bus inactive and stray outsiders remain -> lazily sweep them.
+        3. While active: drive in / park / drive out.
+        4. Always: reap any newly DEAD outsiders + update telemetry gauge.
+    """
+    cfg = world.config
+    bus = world.bus
+
+    if not bus.active:
+        # Decide whether to arrive.
+        ready = (
+            world.legacy.cycles_witnessed >= bus.next_arrival_cycle
+            and world.time.day == 1
+            and world.time.hour == 12
+        )
+        if ready:
+            _begin_arrival(world)
+        else:
+            # Lazy sweep — if the bus isn't here, no outsider should be either.
+            stragglers = [
+                a.id for a in list(world.agents.values())
+                if getattr(a, "kind", None) == AgentKind.OUTSIDER
+            ]
+            if stragglers:
+                clear_outsiders(world)
+
+    else:
+        # Active — drive the state machine.
+        departing = bool(getattr(bus, "_departing", False))
+
+        if departing:
+            _drive_out(world)
+        elif world.tick_count >= bus.departure_tick:
+            # Departure tick hit. Fast-forward through any remaining drive-in
+            # waypoints (so the bus visibly leaves rather than vanishing).
+            _begin_departure(world)
+            _drive_out(world)
+        else:
+            _drive_in(world)
+
+    # Always reap dead outsiders + update gauge.
+    _reap_dead_outsiders(world)
+    if world.telemetry is not None:
+        world.telemetry.gauge_set(
+            Metric.OUTSIDERS_ACTIVE,
+            float(_count_active_outsiders(world)),
+        )

--- a/from-simulation/app/agents/bus.py
+++ b/from-simulation/app/agents/bus.py
@@ -353,7 +353,10 @@ def _begin_arrival(world: World) -> None:
     n_outsiders = rng.randint(1, 3)
     picks = _pick_backstories(world, n_outsiders)
     arrive_at = world.tick_count + 10
-    leave_at = bus.departure_tick - 10
+    # v8 — outsiders no longer board the departing bus, so the leave-tick is
+    # effectively never. Keeping the field set far in the future avoids a
+    # brief ABSENT flicker just before the bus drives off.
+    leave_at = 10 ** 12
     spawned: List[Outsider] = []
     for seed, backstory, goal in picks:
         name = _disambiguate_name(world, seed)
@@ -431,36 +434,37 @@ def _drive_out(world: World) -> None:
         marker.x, marker.y = bus.x, bus.y
         return
 
-    # Path complete — collect survivors and depart.
-    survivors: List[Outsider] = []
+    # v8 — lore says no one can leave Fromville. The bus drives out empty.
+    # Any outsider who arrived stays as a permanent resident — they're
+    # already in world.agents and will continue to tick. The departure
+    # message reflects the change so the journal doesn't lie.
+    stranded: List[Outsider] = []
     for oid in list(bus.passengers):
         agent = world.agents.get(oid)
-        if isinstance(agent, Outsider) and agent.status in (Status.ACTIVE, Status.ABSENT):
-            survivors.append(agent)
-            world.agents.pop(oid, None)
-
-    for o in survivors:
-        world.emit(
-            Event(
-                tick=world.tick_count,
-                type="outsider_left",
-                subject=o.id,
-                detail=f"{o.name} boarded the bus out of town",
-                severity="info",
-            )
-        )
+        if isinstance(agent, Outsider):
+            stranded.append(agent)
+            # Their lifetime gate is no longer meaningful — drop it so the
+            # Outsider tick doesn't suddenly flip them to ABSENT.
+            agent.leaves_at_tick = 10 ** 12
+            if agent.status == Status.ABSENT:
+                agent.status = Status.ACTIVE
 
     world.emit(
         Event(
             tick=world.tick_count,
             type="bus_depart",
             subject="bus",
-            detail=f"the bus left with {len(survivors)} passenger(s)",
+            detail=(
+                "the bus rolls out empty — the road won't keep its passengers"
+                if stranded
+                else "the bus left town the way it came"
+            ),
             severity="info",
         )
     )
 
-    # Reset bus state.
+    # Reset bus state. We intentionally DO NOT clear passengers from
+    # world.agents — they remain as wandering residents.
     bus.active = False
     bus.passengers.clear()
     bus.path_index = 0

--- a/from-simulation/app/agents/cars.py
+++ b/from-simulation/app/agents/cars.py
@@ -1,0 +1,347 @@
+"""
+v6 — Car agent.
+
+Cars are the second vehicle in the From simulation, alongside the Bus. A car
+drives in along the same S-curve as the bus, parks at a slightly different
+spur point (``CAR_PARK_XY``), drops off exactly one NPC arrival, attempts to
+leave, and reliably breaks down after a couple of outbound waypoints. The
+broken-down hulk becomes a permanent wreck in ``world.legacy.permanent_wrecks``
+(capped FIFO at ``MAX_PERMANENT_WRECKS``) so long-running sessions visibly
+accumulate scars from past arrivals.
+
+Public surface:
+
+  * ``Car(Agent)``            — the agent class, lives in ``world.supernaturals``.
+  * ``spawn_car(world, npc_id)``  — entry point for ``population.py`` to flip a
+                                   foot-arrival roll into a car-arrival roll.
+  * ``tick_cars(world)``       — engine hook; drives every live Car forward.
+
+The Car re-uses ``CAR_PATH_IN`` / ``CAR_PARK_XY`` / ``CAR_PATH_OUT`` from
+contracts; speed mirrors the bus at 6 px/tick.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any, Dict, List, Optional, Tuple
+
+import legacy as _legacy
+from contracts import (
+    Agent,
+    AgentKind,
+    CAR_BREAKDOWN_AFTER_WAYPOINTS,
+    CAR_PARK_XY,
+    CAR_PATH_IN,
+    CAR_PATH_OUT,
+    Event,
+    MAX_PERMANENT_WRECKS,
+    MarkerClass,
+    World,
+)
+
+
+# --- tunables -------------------------------------------------------------
+
+_CAR_SPEED_PX = 6.0
+_CAR_PARK_DWELL_TICKS = 30  # how long the car sits parked while the NPC alights
+
+# Sub-state strings (kept narrow to this module; not the global State enum).
+_STATE_INBOUND = "INBOUND"
+_STATE_PARKED = "PARKED"
+_STATE_OUTBOUND = "OUTBOUND"
+_STATE_BROKEN = "BROKEN"
+
+
+# Module-local id counter so Car ids never collide across arrivals.
+_CAR_COUNTER = {"n": 0}
+
+
+def _next_car_id(world: World) -> str:
+    _CAR_COUNTER["n"] += 1
+    return f"car_{world.cycle_number}_{_CAR_COUNTER['n']}"
+
+
+def _step_toward(
+    x: float, y: float, tx: float, ty: float, step: float
+) -> Tuple[float, float, bool]:
+    """Return (new_x, new_y, arrived). Mirrors bus.py."""
+    dx = tx - x
+    dy = ty - y
+    d = math.hypot(dx, dy)
+    if d <= step or d == 0.0:
+        return tx, ty, True
+    return x + dx * (step / d), y + dy * (step / d), False
+
+
+class Car(Agent):
+    """A survivor's arrival car. Drives in, drops one passenger, breaks down.
+
+    Lives in ``world.supernaturals`` and ticks once per engine tick via
+    ``tick_cars``. The car is removed from supernaturals at the BROKEN
+    transition; its final (x, y) plus the current cycle number become a row
+    in ``world.legacy.permanent_wrecks``.
+    """
+
+    kind = AgentKind.SUPERNATURAL  # closest-fit existing kind; mirrors the bus
+    marker_class = MarkerClass.CAR
+
+    def __init__(
+        self,
+        car_id: str,
+        passenger_npc_id: Optional[str],
+        x: float,
+        y: float,
+    ) -> None:
+        self.id = car_id
+        self.passenger_npc_id = passenger_npc_id
+        self.x = float(x)
+        self.y = float(y)
+        self.substate: str = _STATE_INBOUND
+        self.path_index: int = 0
+        self.parked_for_ticks: int = 0
+        # Count outbound waypoints completed so we can trigger breakdown.
+        self.outbound_waypoints_done: int = 0
+
+    # --- snapshot ----------------------------------------------------------
+    def to_dict(self) -> Dict[str, Any]:
+        d = super().to_dict()
+        d.update(
+            {
+                "substate": self.substate,
+                "passenger": self.passenger_npc_id,
+                "path_index": self.path_index,
+            }
+        )
+        return d
+
+    # --- tick is the no-op; tick_cars() drives the Car via _step() ---------
+    def tick(self, world: World) -> None:  # pragma: no cover - driven externally
+        # Cars are driven by ``tick_cars(world)`` so the engine wiring stays
+        # explicit (mirrors how the bus works). The Agent ABC requires this
+        # method to exist, hence the no-op.
+        pass
+
+    # --- internal: one step of the state machine ---------------------------
+    def step(self, world: World) -> None:
+        if self.substate == _STATE_INBOUND:
+            self._step_inbound(world)
+        elif self.substate == _STATE_PARKED:
+            self._step_parked(world)
+        elif self.substate == _STATE_OUTBOUND:
+            self._step_outbound(world)
+        # BROKEN is terminal and only encountered for one final tick before the
+        # Car is removed from supernaturals; nothing to do here.
+
+    def _step_inbound(self, world: World) -> None:
+        if self.path_index >= len(CAR_PATH_IN):
+            # Snap to the park slot and transition to PARKED.
+            self.x, self.y = CAR_PARK_XY
+            self._transition_parked(world)
+            return
+        tx, ty = CAR_PATH_IN[self.path_index]
+        new_x, new_y, arrived = _step_toward(self.x, self.y, tx, ty, _CAR_SPEED_PX)
+        self.x, self.y = new_x, new_y
+        if arrived:
+            self.path_index += 1
+            if self.path_index >= len(CAR_PATH_IN):
+                # Snap to park slot on the same tick we exhaust the waypoints.
+                self.x, self.y = CAR_PARK_XY
+                self._transition_parked(world)
+
+    def _step_parked(self, world: World) -> None:
+        self.parked_for_ticks += 1
+        # The car is anchored at the park slot.
+        self.x, self.y = CAR_PARK_XY
+        if self.parked_for_ticks >= _CAR_PARK_DWELL_TICKS:
+            self._transition_outbound(world)
+
+    def _step_outbound(self, world: World) -> None:
+        if self.path_index >= len(CAR_PATH_OUT):
+            # Ran the whole out-path without breaking down — that means the
+            # breakdown threshold was higher than the path length. Treat as
+            # a graceful departure: remove the car without registering a
+            # wreck. (With the defaults, this branch is unreachable.)
+            self._depart_clean(world)
+            return
+        tx, ty = CAR_PATH_OUT[self.path_index]
+        new_x, new_y, arrived = _step_toward(self.x, self.y, tx, ty, _CAR_SPEED_PX)
+        self.x, self.y = new_x, new_y
+        if arrived:
+            self.path_index += 1
+            self.outbound_waypoints_done += 1
+            # Break down after the configured number of outbound waypoints.
+            if self.outbound_waypoints_done >= CAR_BREAKDOWN_AFTER_WAYPOINTS:
+                self._transition_broken(world)
+
+    # --- transitions -------------------------------------------------------
+    def _transition_parked(self, world: World) -> None:
+        self.substate = _STATE_PARKED
+        self.parked_for_ticks = 0
+        # Snapshot the parked location.
+        self.x, self.y = CAR_PARK_XY
+        # Flag the pending NPC so population.py can alight them this tick.
+        if self.passenger_npc_id is not None:
+            world.car_pending_npc_id = self.passenger_npc_id
+        world.emit(
+            Event(
+                tick=world.tick_count,
+                type="car_arrival",
+                subject=self.id,
+                detail=(
+                    f"a battered car pulled up — dropping off "
+                    f"{self.passenger_npc_id or 'someone'}"
+                ),
+                severity="info",
+            )
+        )
+        try:
+            # Resolve the passenger's display name so the journal entry uses
+            # "Lemuel stepped out", not the literal "{name} stepped out".
+            passenger_name = "Someone"
+            if self.passenger_npc_id is not None:
+                npc = world.agents.get(self.passenger_npc_id)
+                if npc is not None:
+                    passenger_name = getattr(npc, "name", None) or self.passenger_npc_id
+            _legacy.record(world, "car_arrival", name=passenger_name, car=self.id)
+        except Exception:
+            pass
+
+    def _transition_outbound(self, world: World) -> None:
+        self.substate = _STATE_OUTBOUND
+        self.path_index = 0
+        self.outbound_waypoints_done = 0
+        world.emit(
+            Event(
+                tick=world.tick_count,
+                type="car_departure",
+                subject=self.id,
+                detail="the car tried to leave town",
+                severity="info",
+            )
+        )
+
+    def _transition_broken(self, world: World) -> None:
+        self.substate = _STATE_BROKEN
+        # Register the wreck on legacy with FIFO eviction. The frontend reads
+        # ``world.legacy.permanent_wrecks`` directly via snapshot_dict.
+        cycle = world.cycle_number
+        world.legacy.permanent_wrecks.append((float(self.x), float(self.y), int(cycle)))
+        if len(world.legacy.permanent_wrecks) > MAX_PERMANENT_WRECKS:
+            world.legacy.permanent_wrecks.pop(0)
+        world.emit(
+            Event(
+                tick=world.tick_count,
+                type="car_broke_down",
+                subject=self.id,
+                detail=f"the car broke down at ({self.x:.0f},{self.y:.0f})",
+                severity="warn",
+            )
+        )
+        try:
+            _legacy.record(world, "car_broke_down", car=self.id)
+        except Exception:
+            pass
+        # Yank from supernaturals so the moving marker disappears; the wreck
+        # is rendered as a separate static layer by the frontend from the
+        # legacy list.
+        _remove_car(world, self.id)
+        # Clear the active-car slot so the next arrival roll is free.
+        world.active_car_id = None
+
+    def _depart_clean(self, world: World) -> None:
+        """Unreachable with default CAR_BREAKDOWN_AFTER_WAYPOINTS, but safe."""
+        world.emit(
+            Event(
+                tick=world.tick_count,
+                type="car_departure",
+                subject=self.id,
+                detail="the car drove out of town",
+                severity="info",
+            )
+        )
+        _remove_car(world, self.id)
+        world.active_car_id = None
+
+
+# ---------------------------------------------------------------------------
+# Module helpers
+# ---------------------------------------------------------------------------
+
+
+def _find_car(world: World, car_id: str) -> Optional[Car]:
+    for s in world.supernaturals:
+        if isinstance(s, Car) and s.id == car_id:
+            return s
+    return None
+
+
+def _remove_car(world: World, car_id: str) -> None:
+    world.supernaturals[:] = [
+        s for s in world.supernaturals
+        if not (isinstance(s, Car) and s.id == car_id)
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Public — spawn a car (called by population.py)
+# ---------------------------------------------------------------------------
+
+
+def spawn_car(world: World, npc_id: Optional[str]) -> Car:
+    """Create a Car and register it as the world's active arrival vehicle.
+
+    The car starts at the first waypoint of ``CAR_PATH_IN`` so it visibly
+    rolls in from the road edge. The passenger NPC id is held on the Car;
+    when the car parks, ``world.car_pending_npc_id`` is set so population.py
+    can alight the passenger that same tick.
+    """
+    if CAR_PATH_IN:
+        x, y = CAR_PATH_IN[0]
+    else:
+        x, y = CAR_PARK_XY
+
+    car = Car(
+        car_id=_next_car_id(world),
+        passenger_npc_id=npc_id,
+        x=x,
+        y=y,
+    )
+    world.supernaturals.append(car)
+    world.active_car_id = car.id
+    return car
+
+
+# ---------------------------------------------------------------------------
+# Public — tick driver
+# ---------------------------------------------------------------------------
+
+
+def tick_cars(world: World) -> None:
+    """Engine hook — drives every live Car one step.
+
+    Safe to call when no Car is live (cheap no-op). Honours the world's
+    ``active_car_id`` slot for end-of-life housekeeping.
+    """
+    # Iterate over a snapshot so transitions that pop from supernaturals
+    # don't break the loop.
+    for s in list(world.supernaturals):
+        if isinstance(s, Car):
+            try:
+                s.step(world)
+            except Exception:
+                # Step failures must never kill the tick. Log via the event
+                # emitter so we still get a breadcrumb.
+                world.emit(
+                    Event(
+                        tick=world.tick_count,
+                        type="tick_warn",
+                        subject=getattr(s, "id", "car_unknown"),
+                        detail="car step failed",
+                        severity="warn",
+                    )
+                )
+
+    # Defensive: if our ``active_car_id`` no longer corresponds to anything
+    # in supernaturals (e.g. a hot-reload wiped the list), clear it.
+    if world.active_car_id is not None and _find_car(world, world.active_car_id) is None:
+        world.active_car_id = None

--- a/from-simulation/app/agents/caves.py
+++ b/from-simulation/app/agents/caves.py
@@ -1,0 +1,244 @@
+"""
+v6 — cave exploration mechanic.
+
+When a character enters ``State.EXPLORING_CAVES`` (set by Agent B's movement
+system for INVESTIGATOR / SEER on DAY phases), their movement system walks
+them toward ``CAVE_ENTRY_XY``. Once they're within 25 px of the entry, this
+module starts ticking a per-character ``caves_progress`` counter on the
+agent.
+
+At 30 ticks of exploration we roll one outcome from a weighted table:
+
+  * 0.40 — ``cave_fragment_found``    (journal-only; legacy.cave_clues_found++)
+  * 0.30 — ``cave_clue_found``        (Item.CAVE_CLUE added to inventory)
+  * 0.22 — ``cave_scare``             (fear +30, FLEEING)
+  * 0.05 — uneventful                 (just a "found nothing" emit)
+  * 0.03 — ``cave_lost``              (status=ABSENT — kicks off the standard
+                                       700-tick resurrection cycle)
+
+After the outcome rolls (or as a safety bound after 60 ticks) we reset the
+counter and switch the character's state back to ``WANDERING`` so the rest of
+the FSM resumes. Inventory writes and event emission go through the same
+pattern the rest of the engine uses (set the field, emit a canonical event,
+record a journal fragment via ``legacy.record``).
+
+Wiring contract: ``simulation._do_tick`` should call ``tick_caves(world)``
+once per tick, after population and before social.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import legacy as _legacy
+from contracts import (
+    CAVE_ENTRY_XY,
+    Event,
+    Item,
+    State,
+    Status,
+    World,
+)
+from agents.base import distance
+
+
+# How close to the cave entry counts as "inside". The cave mouth occupies
+# roughly a 50 px halo on the SVG — 60 px gives an explorer credit for
+# being "in the caves" the moment they hit the outer ring, which matches
+# the visual and lets progress accumulate before the FSM re-samples.
+_CAVE_RADIUS_PX = 60.0
+# How long a character pokes around before rolling an outcome.
+_CAVE_OUTCOME_TICKS = 30
+# Hard upper bound — even if the outcome was missed, force the cave run to
+# end after this many ticks so we never leave a character spinning forever.
+_CAVE_MAX_TICKS = 60
+
+# Outcome keys + weights, in the order ``rng.choices`` is happy with.
+_OUTCOMES = (
+    "cave_fragment_found",
+    "cave_clue_found",
+    "cave_scare",
+    "cave_uneventful",
+    "cave_lost",
+)
+_OUTCOME_WEIGHTS = (0.40, 0.30, 0.22, 0.05, 0.03)
+
+
+def _at_cave_entry(agent: Any) -> bool:
+    cx, cy = CAVE_ENTRY_XY
+    # ``distance`` handles tuple-or-object; pass a plain tuple to avoid leaking
+    # a private dataclass.
+    return distance(agent, (cx, cy)) <= _CAVE_RADIUS_PX
+
+
+def _end_run(agent: Any, world: World, detail: str) -> None:
+    """End the cave run cleanly — reset progress, emit bookend, restore state."""
+    setattr(agent, "caves_progress", 0)
+    # Only flip back to WANDERING if the agent is still alive and present.
+    # If the outcome was ``cave_scare`` they're already FLEEING; if
+    # ``cave_lost`` they're ABSENT. We honour those.
+    if (
+        getattr(agent, "status", Status.ACTIVE) == Status.ACTIVE
+        and getattr(agent, "state", None) == State.EXPLORING_CAVES
+    ):
+        agent.state = State.WANDERING
+    world.emit(
+        Event(
+            tick=world.tick_count,
+            type="cave_explored",
+            subject=getattr(agent, "id", "?"),
+            detail=detail,
+            severity="info",
+        )
+    )
+
+
+def _roll_outcome(agent: Any, world: World) -> None:
+    """Pick one weighted outcome and apply its side effects + events."""
+    rng = world.rng
+    name = getattr(agent, "name", getattr(agent, "id", "?"))
+    pick = rng.choices(_OUTCOMES, weights=_OUTCOME_WEIGHTS, k=1)[0]
+
+    if pick == "cave_fragment_found":
+        world.legacy.cave_clues_found += 1
+        world.emit(
+            Event(
+                tick=world.tick_count,
+                type="cave_fragment_found",
+                subject=getattr(agent, "id", "?"),
+                detail=f"{name} found a fragment in the caves",
+                severity="info",
+            )
+        )
+        try:
+            _legacy.record(world, "cave_fragment_found", name=name)
+        except Exception:
+            pass
+        _end_run(agent, world, f"{name} returned with a fragment")
+        return
+
+    if pick == "cave_clue_found":
+        # Add a CAVE_CLUE to the character's inventory (string key, as the
+        # engine stores Item.value -> count).
+        inv = getattr(agent, "inventory", None)
+        if isinstance(inv, dict):
+            key = Item.CAVE_CLUE.value
+            inv[key] = int(inv.get(key, 0)) + 1
+        world.emit(
+            Event(
+                tick=world.tick_count,
+                type="cave_clue_found",
+                subject=getattr(agent, "id", "?"),
+                detail=f"{name} picked up a strange object in the caves",
+                severity="info",
+            )
+        )
+        try:
+            _legacy.record(world, "cave_clue_found", name=name)
+        except Exception:
+            pass
+        _end_run(agent, world, f"{name} pocketed something from the caves")
+        return
+
+    if pick == "cave_scare":
+        try:
+            agent.fear = min(100.0, float(getattr(agent, "fear", 0.0)) + 30.0)
+        except Exception:
+            pass
+        # FLEEING is our "panic home" state. The character's own FSM resumes
+        # next tick and will eventually decay back to WANDERING.
+        if getattr(agent, "status", Status.ACTIVE) == Status.ACTIVE:
+            agent.state = State.FLEEING
+        world.emit(
+            Event(
+                tick=world.tick_count,
+                type="cave_scare",
+                subject=getattr(agent, "id", "?"),
+                detail=f"{name} fled the caves",
+                severity="warn",
+            )
+        )
+        # No legacy line — fear is its own story; nothing to remember beyond
+        # the event log.
+        # Reset progress + bookend, but don't override the FLEEING state.
+        setattr(agent, "caves_progress", 0)
+        world.emit(
+            Event(
+                tick=world.tick_count,
+                type="cave_explored",
+                subject=getattr(agent, "id", "?"),
+                detail=f"{name} ran out of the caves",
+                severity="info",
+            )
+        )
+        return
+
+    if pick == "cave_uneventful":
+        world.emit(
+            Event(
+                tick=world.tick_count,
+                type="cave_explored",
+                subject=getattr(agent, "id", "?"),
+                detail="found nothing worth carrying home",
+                severity="info",
+            )
+        )
+        _end_run(agent, world, f"{name} surfaced empty-handed")
+        return
+
+    if pick == "cave_lost":
+        # Rare bad outcome: status flips to ABSENT, which the standard
+        # population/resurrection loop in population.py will eventually
+        # bring back ~700 ticks later.
+        try:
+            agent.status = Status.ABSENT
+        except Exception:
+            pass
+        world.emit(
+            Event(
+                tick=world.tick_count,
+                type="cave_lost",
+                subject=getattr(agent, "id", "?"),
+                detail=f"{name} did not come out of the caves",
+                severity="crit",
+            )
+        )
+        try:
+            _legacy.record(world, "cave_lost", name=name)
+        except Exception:
+            pass
+        # No state restore — ABSENT characters don't tick.
+        setattr(agent, "caves_progress", 0)
+        return
+
+
+def tick_caves(world: World) -> None:
+    """Engine hook — drives every EXPLORING_CAVES character forward one tick.
+
+    Idempotent + cheap when nobody is exploring. Honours ``Status.ACTIVE`` —
+    DEAD/ABSENT/etc. agents are skipped.
+    """
+    for agent in list(world.agents.values()):
+        if getattr(agent, "state", None) != State.EXPLORING_CAVES:
+            # Reset any stale counter on agents who left the state for any
+            # reason (B's movement system can override us on a phase flip).
+            if getattr(agent, "caves_progress", 0):
+                setattr(agent, "caves_progress", 0)
+            continue
+        if getattr(agent, "status", Status.ACTIVE) != Status.ACTIVE:
+            continue
+        if not _at_cave_entry(agent):
+            # Still walking in — let movement bring them. Don't tick yet.
+            continue
+
+        progress = int(getattr(agent, "caves_progress", 0)) + 1
+        setattr(agent, "caves_progress", progress)
+
+        if progress == _CAVE_OUTCOME_TICKS:
+            _roll_outcome(agent, world)
+            continue
+
+        # Safety bound: if for some reason we sailed past the outcome tick
+        # (e.g. some other module bumped caves_progress), force-end the run.
+        if progress >= _CAVE_MAX_TICKS:
+            _end_run(agent, world, "the caves gave up nothing more")

--- a/from-simulation/app/agents/characters.py
+++ b/from-simulation/app/agents/characters.py
@@ -157,7 +157,7 @@ class _Seed:
 CHARACTER_SEEDS: List[_Seed] = [
     _Seed(
         name="Boyd",
-        dwelling_id="camper",
+        dwelling_id="sheriff_office",
         role=Role.SHERIFF,
         personality={"brave": 0.9, "social": 0.5, "devout": 0.3,
                      "paranoid": 0.4, "caretaker": 0.6, "leader": 0.8},
@@ -173,7 +173,7 @@ CHARACTER_SEEDS: List[_Seed] = [
     ),
     _Seed(
         name="Jim",
-        dwelling_id="matthews_house",
+        dwelling_id="matthews_home",
         role=Role.ENGINEER,
         personality={"brave": 0.7, "social": 0.5, "devout": 0.2,
                      "paranoid": 0.6, "caretaker": 0.5, "leader": 0.4},
@@ -181,7 +181,7 @@ CHARACTER_SEEDS: List[_Seed] = [
     ),
     _Seed(
         name="Tabitha",
-        dwelling_id="matthews_house",
+        dwelling_id="matthews_home",
         role=Role.CARETAKER,
         personality={"brave": 0.5, "social": 0.7, "devout": 0.6,
                      "paranoid": 0.5, "caretaker": 0.95, "leader": 0.4},
@@ -189,7 +189,7 @@ CHARACTER_SEEDS: List[_Seed] = [
     ),
     _Seed(
         name="Ethan",
-        dwelling_id="matthews_house",
+        dwelling_id="matthews_home",
         role=Role.CHILD,
         personality={"brave": 0.6, "social": 0.6, "devout": 0.2,
                      "paranoid": 0.4, "caretaker": 0.2, "leader": 0.1},
@@ -213,7 +213,7 @@ CHARACTER_SEEDS: List[_Seed] = [
     ),
     _Seed(
         name="Kenny",
-        dwelling_id="colony_house",
+        dwelling_id="lius_home",
         role=Role.DEPUTY,
         personality={"brave": 0.7, "social": 0.7, "devout": 0.3,
                      "paranoid": 0.4, "caretaker": 0.6, "leader": 0.4},
@@ -229,7 +229,7 @@ CHARACTER_SEEDS: List[_Seed] = [
     ),
     _Seed(
         name="Sara",
-        dwelling_id="lighthouse",
+        dwelling_id="myers_home",
         role=Role.SEER,
         personality={"brave": 0.5, "social": 0.4, "devout": 0.6,
                      "paranoid": 0.7, "caretaker": 0.4, "leader": 0.3},

--- a/from-simulation/app/agents/characters.py
+++ b/from-simulation/app/agents/characters.py
@@ -31,13 +31,24 @@ from contracts import (
     Agent,
     AgentKind,
     BUILDING_LAYOUT,
+    CAR_GRAVEYARD_XY,
+    CAVE_ENTRY_XY,
+    CHOOSING_STONE_XY,
+    CRASH_SITE_XY,
     Event,
+    FARAWAY_TREES,
+    FOREST_SPAWN_POINTS,
+    GRAVE_MOUNDS,
+    HIDEOUT_TRUCK_XY,
     Item,
+    LIGHTHOUSE_XY,
     MarkerClass,
     Phase,
     Role,
+    RUINS_XY,
     State,
     Status,
+    WINDMILL_XY,
     World,
 )
 
@@ -131,10 +142,13 @@ ROLE_PRIORITY: Dict[Role, List[State]] = {
     Role.CARETAKER: [State.CARETAKING, State.MOURNING, State.CONVERSING],
     Role.CHILD: [State.PLAYING, State.SLEEPING],
     Role.BRIDGE: [State.GOSSIPING, State.EXPEDITION],
-    Role.INVESTIGATOR: [State.INVESTIGATING, State.WANDERING, State.ARGUING],
+    # v6 — INVESTIGATOR / SEER actively seek out the caves during DAY so we
+    # see characters physically explore the unused landmark. EXPLORING_CAVES
+    # joins their role-bonus list (2× weight).
+    Role.INVESTIGATOR: [State.INVESTIGATING, State.EXPLORING_CAVES, State.WANDERING, State.ARGUING],
     Role.DEPUTY: [State.PATROLLING, State.CARETAKING, State.MEETING],
     Role.PRIEST: [State.PRAYING, State.CONVERSING, State.MEDIATING],
-    Role.SEER: [State.WANDERING, State.CONVERSING],
+    Role.SEER: [State.WANDERING, State.EXPLORING_CAVES, State.CONVERSING],
 }
 
 ROLE_BONUS = 2.0
@@ -146,8 +160,21 @@ AWARENESS_BUMP_PER_TICK = 0.05
 
 # Per-tick drift constants.
 HUNGER_RATE = 0.04
+# In EATING state with food available, hunger drops faster than it climbs and
+# the meal taxes the larder. Tuned so 1 EATING tick erases roughly 1 minute of
+# normal hunger gain — characters don't need to camp at the diner all day, a
+# couple of minutes of eating brings them back to comfortable.
+HUNGER_EATING_RECOVERY = 0.40
+# Food drained per character-tick spent eating, on top of the per-agent
+# background drain in food.py. Kept small so the village's standing larder
+# is mostly drained by passive consumption rather than active eaters.
+HUNGER_EATING_FOOD_COST = 0.02
 FATIGUE_RATE = 0.03
-SANITY_RECOVERY = 0.01
+SANITY_RECOVERY = 0.05
+# Sleeping (only valid when sheltered) restores sanity quickly so a peaceful
+# night offsets the wakeful corrosion. Tuned so a ~6 sim-hour rest gets a
+# character from 0 back to ~70 — enough to function the next day.
+SANITY_SLEEP_RECOVERY = 0.20
 SANITY_NIGHT_DRAIN = 0.04
 
 
@@ -302,6 +329,29 @@ class Character(Agent):
         # v5 — passive event observation (avoid recording the same event twice).
         self._last_observed_event_tick: int = -10_000
 
+        # v6 — short human-readable sentence describing what this character is
+        # doing right now. Refreshed on every _enter(); also rotated when the
+        # CALLED override kicks in. Surfaced via to_dict() for the roster row +
+        # dossier "Right now" line. Default empty until first _enter().
+        self.intent: str = ""
+        # v8 — flips True when the character is at their dwelling in a
+        # SHELTERING/SLEEPING/DREAMING state. The frontend reads this and
+        # hides the map token so the user sees who is exposed.
+        self._indoors: bool = False
+        # v6 — cursors for landmark rotations. Lazy zero-init.
+        self._patrol_index: int = 0
+        self._invest_index: int = 0
+        # v6 — last major intent category emitted as an ``intent_change`` event.
+        # Used to keep the event log sparse — only fire when category changes.
+        self._last_intent_category: str = ""
+        # v9 — per-character cognitive layer. Lazy import to dodge the
+        # ``characters`` ↔ ``mind`` cycle at module-load time.
+        try:
+            from agents.mind import Mind
+            self.mind = Mind(self.id)
+        except Exception:
+            self.mind = None
+
     # ----------------------------------------------------------- v5 inventory
     def _inv_has(self, item: str) -> bool:
         """True if this character is carrying at least one of ``item``."""
@@ -365,15 +415,35 @@ class Character(Agent):
         self._music_box_reaction(world)
 
         # ---- Drives & sanity ---------------------------------------------
-        self.hunger = min(100.0, self.hunger + HUNGER_RATE)
+        # Hunger rises every tick unless the agent is actively eating AND
+        # there's food in the larder. EATING in an empty village still drains
+        # nothing (food is gone) but it doesn't satisfy them either, so the
+        # food economy stays load-bearing.
+        if self.state == State.EATING and world.food_supply > 0:
+            self.hunger = max(0.0, self.hunger - HUNGER_EATING_RECOVERY)
+            world.food_supply = max(0.0, world.food_supply - HUNGER_EATING_FOOD_COST)
+        else:
+            self.hunger = min(100.0, self.hunger + HUNGER_RATE)
         if self.state == State.SLEEPING:
             self.fatigue = max(0.0, self.fatigue - FATIGUE_RATE * 5)
         else:
             self.fatigue = min(100.0, self.fatigue + FATIGUE_RATE)
+        # Sanity drain: NIGHT outside of sleep is corrosive. NIGHT spent
+        # asleep recovers modestly; daytime recovery is gentle but enough to
+        # claw back most of an undisturbed night by sundown.
         if world.time.phase == Phase.NIGHT and self.state != State.SLEEPING:
             self.sanity = max(0.0, self.sanity - SANITY_NIGHT_DRAIN)
+        elif self.state == State.SLEEPING:
+            self.sanity = min(100.0, self.sanity + SANITY_SLEEP_RECOVERY)
         else:
             self.sanity = min(100.0, self.sanity + SANITY_RECOVERY)
+        # Starvation: above ~85 hunger, sanity erodes slowly. Above 95, fear
+        # creeps up too. This couples the food economy back into the panic
+        # loop so creature nights are deadlier when the larder is empty.
+        if self.hunger > 85:
+            self.sanity = max(0.0, self.sanity - 0.02)
+        if self.hunger > 95:
+            self.fear = min(100.0, self.fear + 0.03)
 
         # ---- Awareness: bump for nearby yellow-touched NPCs --------------
         self._update_awareness(world)
@@ -402,6 +472,19 @@ class Character(Agent):
             # Fall through to WANDERING — should be a node in any sane table.
             menu = [(State.WANDERING, 1.0)]
 
+        # ---- v9: cognitive bias ------------------------------------------
+        # Reflection (cadence-gated inside) and goal-derived menu weights.
+        # Bias is additive on existing weights; the weighted-FSM choice
+        # below still makes the final pick, so SEED determinism holds.
+        extra_context = ""
+        if getattr(self, "mind", None) is not None:
+            try:
+                self.mind.maybe_reflect(world, self)
+                menu = self.mind.shape_menu(world, self, menu)
+                extra_context = self.mind.goal_context()
+            except Exception:  # never let cognition kill a tick
+                pass
+
         # ---- Optional LLM consultation -----------------------------------
         chosen: Optional[State] = None
         cfg = world.config
@@ -412,7 +495,23 @@ class Character(Agent):
             and (world.tick_count - self.last_llm_tick) >= cfg.llm_min_tick_gap
         ):
             try:
-                chosen = world.llm_decider.maybe_decide(self, world, menu)
+                # v9 — call site previously passed (self, world, menu) which
+                # didn't match the decider signature; it always raised and
+                # the LLM never actually fired. Pass the real arguments.
+                menu_states = [s for s, _ in menu]
+                result = world.llm_decider.maybe_decide(
+                    actor_id=self.id,
+                    current_state=self.state,
+                    phase=world.time.phase,
+                    fear=float(self.fear),
+                    menu=menu_states,
+                    current_tick=int(world.tick_count),
+                    extra_context=extra_context,
+                )
+                if isinstance(result, tuple) and result:
+                    chosen = result[0]
+                elif isinstance(result, State):
+                    chosen = result
             except Exception:  # never let an LLM hiccup kill the tick
                 chosen = None
             self.last_llm_tick = world.tick_count
@@ -430,7 +529,38 @@ class Character(Agent):
         if chosen != self.state:
             self._enter(world, chosen)
 
+        # v8 — keep the CONVERSING target refreshed each tick so partners
+        # actually converge instead of drifting apart with stale targets.
+        if self.state == State.CONVERSING:
+            self.target = self._target_for_role_and_state(self.state, world)
+
         self._step_toward_target(world)
+
+        # v8 — track whether the character is actually inside their dwelling.
+        # When indoors, the frontend hides the map token so the user can see
+        # who is exposed. We also keep the building's occupants set live so
+        # the click-house dossier reflects "who is here right now".
+        self._update_indoor_presence(world)
+
+    def _update_indoor_presence(self, world: World) -> None:
+        """Sync ``self._indoors`` and the dwelling's occupant set."""
+        from agents.base import distance as _dist
+        home = world.buildings.get(self.dwelling_id) if self.dwelling_id else None
+        # Indoor states + close to the dwelling => indoors.
+        indoor_states = (State.SHELTERING, State.SLEEPING, State.DREAMING)
+        is_indoors = False
+        if home is not None and self.state in indoor_states:
+            if _dist(self, home) <= 24.0:
+                is_indoors = True
+        # Update occupancy set + flag.
+        if is_indoors:
+            if home is not None:
+                home.occupants.add(self.id)
+            self._indoors = True
+        else:
+            if home is not None and self.id in home.occupants:
+                home.occupants.discard(self.id)
+            self._indoors = False
 
     # ----------------------------------------------------------- v4 helpers
     def _music_box_reaction(self, world: World) -> None:
@@ -537,12 +667,30 @@ class Character(Agent):
     def _hard_override(self, world: World) -> Optional[State]:
         if self.state == State.IRRATIONAL:
             return State.IRRATIONAL  # sticky
+        # v6 — once the lighthouse picks you, you walk to it. Sticky until the
+        # lighthouse module clears ``world.lighthouse_called`` (e.g. on
+        # swallow / cycle reset). agents/lighthouse.py owns the selection;
+        # this branch just enforces the destination bias.
+        if self.state == State.CALLED:
+            return State.CALLED  # sticky
+        if getattr(world, "lighthouse_called", None) == self.id:
+            return State.CALLED
         if self.fear > 80.0:
             return State.FLEEING
         if world.time.phase == Phase.NIGHT:
             b = world.buildings.get(self.dwelling_id)
             if b is not None and b.has_talisman:
                 return State.SHELTERING
+        # Starving and safe: drop everything and find food. Diner/Bar by day,
+        # dwelling kitchen otherwise. Skipped when already eating so we don't
+        # thrash transitions.
+        if (
+            self.hunger > 75.0
+            and self.state != State.EATING
+            and world.food_supply > 0
+            and world.time.phase in (Phase.DAY, Phase.DUSK, Phase.DAWN)
+        ):
+            return State.EATING
         return None
 
     def _candidate_menu(self, world: World) -> List[Tuple[State, float]]:
@@ -588,6 +736,38 @@ class Character(Agent):
                     break
             if not boosted:
                 out.append((State.EXPEDITION, 3.0))
+        # v7: barn destroyed → strong FORAGING bias for any character whose
+        # current state is reasonably interruptible (FARMING/WANDERING/
+        # GOSSIPING/SCAVENGING). Also nudges when food is low even without a
+        # barn breach. ENGINEER takes a smaller boost — they head to repair
+        # instead (see REPAIRING below).
+        barn_down = (
+            getattr(world, "barn_destroyed_until_tick", 0) > world.tick_count
+        )
+        food_low = getattr(world, "food_shortage", False)
+        if (barn_down or food_low) and world.time.phase == Phase.DAY:
+            mult = 4.0 if barn_down else 2.0
+            # ENGINEER's role is to fix; they get a REPAIRING boost not FORAGING.
+            if self.role == Role.ENGINEER and barn_down:
+                boosted_repair = False
+                for i, (s, w) in enumerate(out):
+                    if s == State.REPAIRING:
+                        out[i] = (s, w * 4.0)
+                        boosted_repair = True
+                        break
+                if not boosted_repair:
+                    out.append((State.REPAIRING, 4.0))
+            else:
+                boosted = False
+                for i, (s, w) in enumerate(out):
+                    if s == State.FORAGING:
+                        out[i] = (s, w * mult)
+                        boosted = True
+                        break
+                if not boosted:
+                    # Inject FORAGING into the menu if it wasn't already there
+                    # (transition table only lists it from FARMING).
+                    out.append((State.FORAGING, mult))
         # v5: nudge from SQLite memory before returning.
         out = self._apply_memory_bias_list(out, world)
         return out
@@ -803,6 +983,22 @@ class Character(Agent):
             return False  # entered via fear.py only
         if s == State.HYPNOTIZED:
             return False  # entered via creatures
+        # v6 — CALLED is set externally by lighthouse.py; do not let the
+        # weighted FSM wander into it on its own.
+        if s == State.CALLED:
+            return False
+        # v6 — EXPLORING_CAVES is a DAY-only investigative state, primarily for
+        # the INVESTIGATOR and SEER. Other roles may occasionally take it but at
+        # a much lower weight (handled by base weight + role bonus in the
+        # transition table); the precondition here just gates time-of-day.
+        if s == State.EXPLORING_CAVES:
+            if world.time.phase != Phase.DAY:
+                return False
+        # v7 — FORAGING is DAY-only. Walking 200+ px to the windmill at night
+        # would just feed the foragers to a creature.
+        if s == State.FORAGING:
+            if world.time.phase != Phase.DAY:
+                return False
         return True
 
     def _enter(self, world: World, new_state: State) -> None:
@@ -810,13 +1006,73 @@ class Character(Agent):
             return
         self.state = new_state
         self.state_since_tick = world.tick_count
-        self.target = self._target_for(new_state, world)
+        self.target = self._target_for_role_and_state(new_state, world)
+        # v6 — refresh intent sentence on every state change.
+        self._refresh_intent(world)
 
-    def _target_for(self, s: State, world: World) -> Optional[Tuple[float, float]]:
+    # ----------------------------------------------------------- v6 landmarks
+    # Patrol rotation order — used by SHERIFF / DEPUTY in PATROLLING.
+    _PATROL_ROUTE: List[str] = [
+        "sheriff_office", "church", "colony_house", "diner",
+    ]
+
+    # SEER (Sara) investigation rotation — far trees + the choosing stone.
+    _SEER_INVEST_POINTS: List[Tuple[float, float]] = [
+        FARAWAY_TREES[0], FARAWAY_TREES[1], FARAWAY_TREES[2], CHOOSING_STONE_XY,
+    ]
+
+    # INVESTIGATOR (Jade) investigation rotation — every unsolved landmark.
+    _INVESTIGATOR_POINTS: List[Tuple[float, float]] = [
+        CAVE_ENTRY_XY, CRASH_SITE_XY, HIDEOUT_TRUCK_XY, CHOOSING_STONE_XY,
+    ]
+
+    # Wandering pool (used when paranoia is low).
+    _WANDER_POINTS: List[Tuple[float, float]] = [
+        CHOOSING_STONE_XY, WINDMILL_XY, CAR_GRAVEYARD_XY,
+    ]
+
+    # Friendly landmark names keyed by exact (x, y). Used by intent strings.
+    _LANDMARK_NAMES: Dict[Tuple[float, float], str] = {
+        CAVE_ENTRY_XY: "the caves",
+        CRASH_SITE_XY: "the crash site",
+        HIDEOUT_TRUCK_XY: "the hideout truck",
+        CHOOSING_STONE_XY: "the Choosing Stone",
+        WINDMILL_XY: "the windmill",
+        CAR_GRAVEYARD_XY: "the car graveyard",
+        LIGHTHOUSE_XY: "the lighthouse",
+        RUINS_XY: "the Dungeon",
+        FARAWAY_TREES[0]: "the Faraway Tree",
+        FARAWAY_TREES[1]: "the Faraway Tree",
+        FARAWAY_TREES[2]: "the Faraway Tree",
+    }
+
+    def _target_for_role_and_state(
+        self, s: State, world: World,
+    ) -> Optional[Tuple[float, float]]:
+        """v6 purposeful-movement table.
+
+        Every state resolves to a real landmark (or a per-role rotation of
+        landmarks) rather than a random map coordinate, so the viewer can
+        always read what a character is doing from where they are walking.
+        """
+        rng = world.rng
         b = world.buildings.get(self.dwelling_id)
         home = (b.x, b.y) if b else (self.x, self.y)
-        if s in (State.SLEEPING, State.SHELTERING):
+
+        if s in (State.SLEEPING, State.SHELTERING, State.DREAMING):
             return home
+        if s == State.FLEEING:
+            return home
+        if s == State.EATING:
+            # Day -> diner; otherwise home kitchen.
+            if world.time.phase in (Phase.DAY, Phase.DAWN, Phase.DUSK):
+                diner = world.buildings.get("diner")
+                if diner is not None:
+                    return (diner.x, diner.y)
+            return home
+        if s == State.GOSSIPING:
+            diner = world.buildings.get("diner")
+            return (diner.x, diner.y) if diner else home
         if s == State.PRAYING:
             ch = world.buildings.get("church")
             return (ch.x, ch.y) if ch else home
@@ -824,46 +1080,296 @@ class Character(Agent):
             ch = world.buildings.get("colony_house")
             return (ch.x + 20, ch.y + 60) if ch else home
         if s == State.REPAIRING:
-            ch = world.buildings.get("matthews_house")
-            return (ch.x, ch.y) if ch else home
-        if s == State.CARETAKING or s == State.MEDICAL_CARE:
-            ch = world.buildings.get("clinic")
-            return (ch.x, ch.y) if ch else home
-        if s == State.PATROLLING:
-            # roam the village centre
-            return (
-                world.rng.uniform(300, 700),
-                world.rng.uniform(300, 500),
-            )
+            # Pick the building still cooling off the longest; otherwise the
+            # sheriff's office as a sensible default for the engineer.
+            best_b = None
+            best_left = 0
+            for bld in world.buildings.values():
+                left = bld.cooling_off_until_tick - world.tick_count
+                if left > best_left:
+                    best_left = left
+                    best_b = bld
+            if best_b is not None:
+                return (best_b.x, best_b.y)
+            so = world.buildings.get("sheriff_office")
+            return (so.x, so.y) if so else home
+        if s in (State.CARETAKING, State.MEDICAL_CARE):
+            clinic = world.buildings.get("clinic")
+            return (clinic.x, clinic.y) if clinic else home
         if s == State.PLAYING:
-            return (
-                world.rng.uniform(400, 600),
-                world.rng.uniform(380, 480),
-            )
-        if s == State.WANDERING:
-            return (
-                world.rng.uniform(150, 850),
-                world.rng.uniform(150, 600),
-            )
-        if s == State.FLEEING:
+            # Children play between the pool and the bar — a real "village
+            # green" cluster rather than empty coordinates.
+            pool = world.buildings.get("pool")
+            cx, cy = (pool.x, pool.y) if pool else (470.0, 480.0)
+            return (cx + rng.uniform(-25, 25), cy + rng.uniform(-25, 25))
+        if s == State.PATROLLING:
+            if self.role in (Role.SHERIFF, Role.DEPUTY):
+                route = self._PATROL_ROUTE
+                bid = route[self._patrol_index % len(route)]
+                self._patrol_index = (self._patrol_index + 1) % len(route)
+                bld = world.buildings.get(bid)
+                if bld is not None:
+                    return (
+                        bld.x + rng.uniform(-8.0, 8.0),
+                        bld.y + rng.uniform(-8.0, 8.0),
+                    )
+            # Fallback: village centre near sheriff's office.
+            so = world.buildings.get("sheriff_office")
+            if so is not None:
+                return (so.x + rng.uniform(-40, 40), so.y + rng.uniform(-40, 40))
             return home
+        if s == State.WANDERING:
+            paranoid = self.personality.get("paranoid", 0.0)
+            if paranoid > 0.5 and FOREST_SPAWN_POINTS:
+                tx, ty = rng.choice(FOREST_SPAWN_POINTS)
+                return (tx + rng.uniform(-10, 10), ty + rng.uniform(-10, 10))
+            # Mostly-safe wanderers visit map landmarks.
+            pool = list(self._WANDER_POINTS) + [rng.choice(FARAWAY_TREES)]
+            bus = world.buildings.get("abandoned_bus")
+            if bus is not None:
+                pool.append((bus.x, bus.y))
+            tx, ty = rng.choice(pool)
+            return (tx + rng.uniform(-12, 12), ty + rng.uniform(-12, 12))
         if s == State.SCAVENGING:
+            if FOREST_SPAWN_POINTS:
+                # Pick the closest 3 forest waypoints and choose randomly
+                # among them — keeps scavenging local rather than teleporty.
+                pts = sorted(
+                    FOREST_SPAWN_POINTS,
+                    key=lambda p: math.hypot(p[0] - self.x, p[1] - self.y),
+                )[:3]
+                tx, ty = rng.choice(pts)
+                return (tx + rng.uniform(-8, 8), ty + rng.uniform(-8, 8))
+            return home
+        if s == State.INVESTIGATING:
+            if self.role == Role.SEER:
+                pts = self._SEER_INVEST_POINTS
+                tx, ty = pts[self._invest_index % len(pts)]
+                self._invest_index = (self._invest_index + 1) % len(pts)
+                return (tx + rng.uniform(-10, 10), ty + rng.uniform(-10, 10))
+            if self.role == Role.INVESTIGATOR:
+                pts = self._INVESTIGATOR_POINTS
+                tx, ty = pts[self._invest_index % len(pts)]
+                self._invest_index = (self._invest_index + 1) % len(pts)
+                return (tx + rng.uniform(-10, 10), ty + rng.uniform(-10, 10))
+            # Other roles: poke around a building entrance.
+            bld_ids = list(world.buildings.keys())
+            if bld_ids:
+                bld = world.buildings[rng.choice(bld_ids)]
+                return (bld.x + rng.uniform(-15, 15), bld.y + rng.uniform(-15, 15))
+            return home
+        if s == State.EXPLORING_CAVES:
             return (
-                world.rng.uniform(100, 900),
-                world.rng.uniform(100, 600),
+                CAVE_ENTRY_XY[0] + rng.uniform(-8, 8),
+                CAVE_ENTRY_XY[1] + rng.uniform(-8, 8),
             )
-        if s == State.GOSSIPING:
-            diner = world.buildings.get("diner")
-            return (diner.x, diner.y) if diner else home
+        if s == State.FORAGING:
+            # v7 — pick a forage zone (windmill/lake/pond). We stick to the
+            # one we chose at state entry by stashing it on the character; on
+            # first entry the cursor is None so we pick at random.
+            from contracts import FORAGE_ZONES
+            chosen = getattr(self, "_forage_zone", None)
+            if chosen is None or chosen not in FORAGE_ZONES:
+                chosen = rng.choice(FORAGE_ZONES)
+                self._forage_zone = chosen
+            return (chosen[0] + rng.uniform(-12, 12), chosen[1] + rng.uniform(-12, 12))
+        if s == State.CALLED:
+            return LIGHTHOUSE_XY
         if s == State.MOURNING:
+            # Nearest grave mound to current position. Falls back to churchyard.
+            if GRAVE_MOUNDS:
+                gx, gy = min(
+                    GRAVE_MOUNDS,
+                    key=lambda p: math.hypot(p[0] - self.x, p[1] - self.y),
+                )
+                return (gx, gy)
             ch = world.buildings.get("church")
             return (ch.x + 10, ch.y + 30) if ch else home
-        if s == State.INVESTIGATING:
-            return (
-                world.rng.uniform(150, 850),
-                world.rng.uniform(150, 600),
-            )
+        if s == State.CARRYING_BOX:
+            return RUINS_XY
+        if s == State.CONVERSING:
+            # v8 — converge on the partner so the conversation reads as
+            # "these two are talking to each other" instead of two ghosts
+            # staring across the village. Use the midpoint so both dots
+            # drift together.
+            partner_id = getattr(self, "conversation_partner", None)
+            partner = world.agents.get(partner_id) if partner_id else None
+            if partner is not None:
+                mx = (self.x + partner.x) * 0.5
+                my = (self.y + partner.y) * 0.5
+                return (mx, my)
+            return home
+        if s == State.GOSSIPING:
+            # Already returns the diner above — but if the diner is somehow
+            # missing, prefer the bar (the secondary social hub) over home.
+            bar = world.buildings.get("bar")
+            if bar is not None:
+                return (bar.x + rng.uniform(-10, 10), bar.y + rng.uniform(-10, 10))
+            return home
         return home
+
+    # Backwards-compat: keep the old name as a thin alias in case any
+    # subsystem still calls ``_target_for`` directly.
+    def _target_for(self, s: State, world: World) -> Optional[Tuple[float, float]]:
+        return self._target_for_role_and_state(s, world)
+
+    # ----------------------------------------------------------- v6 intent
+    def _refresh_intent(self, world: World) -> None:
+        """Recompute ``self.intent`` for the current state.
+
+        Called from ``_enter``. Emits a sparse ``intent_change`` event only when
+        the intent category transitions to one of a handful of major beats
+        (heading to lighthouse / caves / Dungeon / mourning) — the per-tick
+        roster row reads the string directly, so we don't need an event for
+        every minor wander.
+        """
+        s = self.state
+        target = self.target
+        landmark = self._pick_landmark_name_in_world(target, world)
+
+        if s == State.PATROLLING:
+            text = f"{self.name} is patrolling toward {landmark}."
+            cat = "patrolling"
+        elif s == State.EXPLORING_CAVES:
+            text = f"{self.name} is walking to the caves."
+            cat = "caves"
+        elif s == State.FORAGING:
+            zone = getattr(self, "_forage_zone", None)
+            place = "the windmill"
+            if zone is not None:
+                if zone[1] < 230:
+                    place = "the western pond" if zone[0] < 300 else "the windmill"
+                else:
+                    place = "the lakeside river"
+            text = f"{self.name} is foraging at {place}."
+            cat = "foraging"
+        elif s == State.CARRYING_BOX:
+            text = f"{self.name} is carrying the music box to the Dungeon."
+            cat = "music_box_carry"
+        elif s == State.EXPEDITION:
+            text = f"{self.name} is leading a party into the forest."
+            cat = "expedition"
+        elif s == State.EATING:
+            text = f"{self.name} is heading {('to the diner' if landmark.lower() == 'diner' else 'home')} to eat."
+            cat = "eating"
+        elif s == State.MOURNING:
+            text = f"{self.name} is mourning at {landmark}."
+            cat = "mourning"
+        elif s == State.PRAYING:
+            text = f"{self.name} is praying at the church."
+            cat = "praying"
+        elif s == State.MEETING:
+            text = f"{self.name} is at a meeting at Colony House."
+            cat = "meeting"
+        elif s == State.ARGUING:
+            partner = getattr(self, "conversation_partner", None) or "someone"
+            text = f"{self.name} is arguing with {partner}."
+            cat = "arguing"
+        elif s == State.FLEEING:
+            text = f"{self.name} is fleeing in panic."
+            cat = "fleeing"
+        elif s == State.SHELTERING:
+            home = world.buildings.get(self.dwelling_id)
+            home_name = home.name if home is not None else "home"
+            text = f"{self.name} is sheltering at {home_name}."
+            cat = "sheltering"
+        elif s == State.CALLED:
+            text = f"{self.name} is being drawn to the lighthouse."
+            cat = "called"
+        elif s == State.SLEEPING:
+            text = f"{self.name} is sleeping."
+            cat = "sleeping"
+        elif s == State.FARMING:
+            text = f"{self.name} is tending the colony farm."
+            cat = "farming"
+        elif s == State.SCAVENGING:
+            text = f"{self.name} is scavenging the forest edge."
+            cat = "scavenging"
+        elif s == State.INVESTIGATING:
+            text = f"{self.name} is investigating {landmark}."
+            cat = "investigating"
+        elif s == State.WANDERING:
+            text = f"{self.name} is wandering near {landmark}."
+            cat = "wandering"
+        elif s == State.CONVERSING:
+            partner = getattr(self, "conversation_partner", None) or "someone"
+            text = f"{self.name} is conversing with {partner}."
+            cat = "conversing"
+        elif s == State.IRRATIONAL:
+            text = f"{self.name} is not themselves."
+            cat = "irrational"
+        elif s == State.CARETAKING:
+            text = f"{self.name} is caring for the wounded."
+            cat = "caretaking"
+        elif s == State.MEDICAL_CARE:
+            text = f"{self.name} is at the clinic."
+            cat = "medical"
+        elif s == State.REPAIRING:
+            text = f"{self.name} is repairing {landmark}."
+            cat = "repairing"
+        elif s == State.GOSSIPING:
+            text = f"{self.name} is gossiping at the diner."
+            cat = "gossiping"
+        elif s == State.PLAYING:
+            text = f"{self.name} is playing near the pool."
+            cat = "playing"
+        elif s == State.MEDIATING:
+            text = f"{self.name} is trying to keep the peace."
+            cat = "mediating"
+        else:
+            text = f"{self.name} is here."
+            cat = "idle"
+
+        self.intent = text
+
+        # Only emit an intent_change event for a small allowlist of "major"
+        # category transitions — the dossier reads ``self.intent`` directly,
+        # so we don't need one event per wander.
+        major = {"called", "caves", "music_box_carry", "expedition",
+                 "fleeing", "mourning"}
+        if cat != self._last_intent_category and cat in major:
+            try:
+                world.emit(Event(
+                    tick=world.tick_count,
+                    type="intent_change",
+                    subject=self.id,
+                    detail=text,
+                    severity="info",
+                ))
+            except Exception:
+                pass
+        self._last_intent_category = cat
+
+    def _pick_landmark_name_in_world(
+        self, xy: Optional[Tuple[float, float]], world: World,
+    ) -> str:
+        """Friendly name for an (x, y) — closest landmark, grave, or building.
+
+        When the character is in MOURNING, grave mounds win even if they share
+        a tile with the Choosing Stone — the player wants to read "at Abby's
+        grave", not the geographic coincidence.
+        """
+        if xy is None:
+            return "somewhere"
+        if self.state == State.MOURNING:
+            for gx, gy in GRAVE_MOUNDS:
+                if math.hypot(xy[0] - gx, xy[1] - gy) < 25.0:
+                    return "Abby's grave"
+        # Match named landmarks within their natural jitter radius (15 px).
+        for k, name in self._LANDMARK_NAMES.items():
+            if math.hypot(xy[0] - k[0], xy[1] - k[1]) < 15.0:
+                return name
+        for gx, gy in GRAVE_MOUNDS:
+            if math.hypot(xy[0] - gx, xy[1] - gy) < 25.0:
+                return "Abby's grave"
+        best: Optional[str] = None
+        best_d = 60.0
+        for b in world.buildings.values():
+            d = math.hypot(xy[0] - b.x, xy[1] - b.y)
+            if d < best_d:
+                best_d = d
+                best = b.name
+        return best or "the woods"
 
     def _step_toward_target(self, world: World) -> None:
         if self.target is None:
@@ -872,11 +1378,24 @@ class Character(Agent):
         speed = 2.5
         if self.state == State.FLEEING:
             speed = 5.0
-        elif self.state in (State.SLEEPING, State.SHELTERING, State.PRAYING,
-                            State.MOURNING, State.MEDIATING):
-            speed = 0.0
         elif self.state == State.PLAYING:
             speed = 3.5
+        elif self.state in (State.SLEEPING, State.MEDIATING):
+            # Genuinely stationary: only freeze once we've arrived. Until then
+            # the character hurries to the right spot so the SVG shows them
+            # where they're supposed to be.
+            dx = self.target[0] - self.x
+            dy = self.target[1] - self.y
+            d = math.hypot(dx, dy)
+            speed = 0.0 if d < 6.0 else 3.0
+        elif self.state in (State.SHELTERING, State.PRAYING, State.MOURNING):
+            # v8 — these used to be speed=0 which stranded the token wherever
+            # the character was when the state flipped. Keep walking until we
+            # arrive at the church / grave / dwelling, then snap still.
+            dx = self.target[0] - self.x
+            dy = self.target[1] - self.y
+            d = math.hypot(dx, dy)
+            speed = 0.0 if d < 6.0 else 3.5
         if speed <= 0:
             return
         try:
@@ -923,6 +1442,13 @@ class Character(Agent):
             "sanity": round(self.sanity, 1),
             "personality": {k: round(v, 2) for k, v in self.personality.items()},
             "awareness": {k: round(v, 2) for k, v in self.awareness.items()},
+            # v6 — current intent sentence (may be "" if the character hasn't
+            # ticked through a state change yet). Surfaced in the roster row
+            # and the click-dossier "Right now" line.
+            "intent": self.intent,
+            # v8 — frontend hides the dot when ``indoors`` is true so the
+            # map shows only who is currently outside / exposed.
+            "indoors": bool(getattr(self, "_indoors", False)),
         })
         return d
 

--- a/from-simulation/app/agents/characters.py
+++ b/from-simulation/app/agents/characters.py
@@ -32,6 +32,7 @@ from contracts import (
     AgentKind,
     BUILDING_LAYOUT,
     Event,
+    Item,
     MarkerClass,
     Phase,
     Role,
@@ -298,6 +299,53 @@ class Character(Agent):
 
         # Cross-cycle bookkeeping
         self._obituary_written: bool = False
+        # v5 — passive event observation (avoid recording the same event twice).
+        self._last_observed_event_tick: int = -10_000
+
+    # ----------------------------------------------------------- v5 inventory
+    def _inv_has(self, item: str) -> bool:
+        """True if this character is carrying at least one of ``item``."""
+        try:
+            return int(self.inventory.get(item, 0)) > 0
+        except Exception:
+            return False
+
+    def _inv_add(self, item: str, delta: int, world: World) -> int:
+        """Adjust inventory, persist to memory, and emit pickup/drop events.
+
+        Returns the new quantity. ``delta`` may be negative to drop. Quantity
+        is clamped at zero — callers should check ``_inv_has`` before
+        attempting a drop.
+        """
+        try:
+            cur = int(self.inventory.get(item, 0))
+        except Exception:
+            cur = 0
+        new = max(0, cur + int(delta))
+        if new == 0:
+            self.inventory.pop(item, None)
+        else:
+            self.inventory[item] = new
+        # v5 — record via memory if attached.
+        if world.memory is not None:
+            try:
+                world.memory.record_inventory_change(
+                    world, self.id, item, int(delta), new,
+                )
+            except Exception:
+                pass
+        # Emit a canonical event so other subsystems see the transfer.
+        if delta > 0:
+            world.emit(Event(
+                tick=world.tick_count, type="item_picked_up",
+                subject=self.id, detail=f"{item} x{int(delta)} (have {new})",
+            ))
+        elif delta < 0:
+            world.emit(Event(
+                tick=world.tick_count, type="item_dropped",
+                subject=self.id, detail=f"{item} x{abs(int(delta))} (have {new})",
+            ))
+        return new
 
     # ------------------------------------------------------------------ tick
     def tick(self, world: World) -> None:
@@ -329,6 +377,9 @@ class Character(Agent):
 
         # ---- Awareness: bump for nearby yellow-touched NPCs --------------
         self._update_awareness(world)
+
+        # ---- v5: passive observation of recent breach events --------------
+        self._observe_recent_events(world)
 
         # ---- Sticky / pinned states --------------------------------------
         if self.state == State.MEETING and world.tick_count < self.meeting_until_tick:
@@ -537,7 +588,143 @@ class Character(Agent):
                     break
             if not boosted:
                 out.append((State.EXPEDITION, 3.0))
+        # v5: nudge from SQLite memory before returning.
+        out = self._apply_memory_bias_list(out, world)
         return out
+
+    # ----------------------------------------------------------- v5 memory
+    def _apply_memory_bias_list(
+        self, menu: List[Tuple[State, float]], world: World,
+    ) -> List[Tuple[State, float]]:
+        """Bias a (state, weight) list by recent character_memory rows.
+
+        Wraps :meth:`_apply_memory_bias` so callers can keep menu as a list of
+        tuples (the format the LLM/weighted-choice expects). Falls through
+        without error if memory is missing or malformed.
+        """
+        if world.memory is None or not menu:
+            return menu
+        weights: Dict[State, float] = {s: w for s, w in menu}
+        try:
+            biased = self._apply_memory_bias(weights, world)
+        except Exception:
+            return menu
+        return [(s, biased.get(s, w)) for s, w in menu]
+
+    def _apply_memory_bias(
+        self, weights: Dict[State, float], world: World,
+    ) -> Dict[State, float]:
+        """Multiplier-style bias from this character's recent memory.
+
+        Pulls in argument / breach / meeting rows for the configured recall
+        window and scales relevant state weights. Carrying a music box also
+        boosts EXPEDITION via the memory channel so v4 carrier behaviour
+        survives even when the engine's transient ``music_box_carrier`` flag
+        is briefly cleared.
+        """
+        if world.memory is None:
+            return weights
+        cfg = world.config
+        recall_window = int(getattr(cfg, "memory_recall_window_ticks", 1200))
+
+        try:
+            recent_args = world.memory.recall_for(
+                world, self.id,
+                kinds={"argument", "meeting_disagree"},
+                lookback_ticks=recall_window,
+            )
+        except Exception:
+            recent_args = []
+        if recent_args:
+            if State.ARGUING in weights:
+                weights[State.ARGUING] *= 1.30
+            if State.CONVERSING in weights:
+                weights[State.CONVERSING] *= 0.60
+
+        try:
+            recent_breaches = world.memory.recall_for(
+                world, self.id,
+                kinds={"breach_observed"},
+                lookback_ticks=1500,
+            )
+        except Exception:
+            recent_breaches = []
+        if recent_breaches:
+            if State.SHELTERING in weights:
+                weights[State.SHELTERING] *= 0.50
+
+        try:
+            positive_meetings = world.memory.recall_for(
+                world, self.id,
+                kinds={"meeting_agree", "recognized"},
+                lookback_ticks=1500,
+            )
+        except Exception:
+            positive_meetings = []
+        if positive_meetings and len(positive_meetings) >= 2:
+            if State.MEETING in weights:
+                weights[State.MEETING] *= 1.20
+
+        # Carrying a music box — reinforce v4 carrier behaviour via memory.
+        if self._inv_has(Item.MUSIC_BOX.value):
+            if State.EXPEDITION in weights:
+                weights[State.EXPEDITION] *= 3.0
+
+        return weights
+
+    # ----------------------------------------------------------- v5 observe
+    def _observe_recent_events(self, world: World) -> None:
+        """Record a ``breach_observed`` memory if a creature_breach happened nearby.
+
+        We peek at the tail of ``world.events`` and use a ``_last_observed_event_tick``
+        guard so we never write the same observation twice.
+        """
+        if world.memory is None:
+            return
+        events = world.events
+        if events is None:
+            return
+        try:
+            recent = list(events)[-5:]
+        except Exception:
+            return
+        for evt in recent:
+            try:
+                if evt.tick <= self._last_observed_event_tick:
+                    continue
+                if evt.type != "creature_breach":
+                    continue
+            except Exception:
+                continue
+            # Locate the building involved. Subject may be the building id
+            # (npc_problems.py path) or the creature id (creatures.py path,
+            # in which case the building name lives in the detail).
+            building_id: Optional[str] = None
+            subj = getattr(evt, "subject", "") or ""
+            if subj in world.buildings:
+                building_id = subj
+            else:
+                detail = (getattr(evt, "detail", "") or "").lower()
+                for bid, b in world.buildings.items():
+                    if b.name.lower() in detail:
+                        building_id = bid
+                        break
+            # Skip if we can't locate the building.
+            if building_id is None:
+                continue
+            b = world.buildings.get(building_id)
+            if b is None:
+                continue
+            d = math.hypot(self.x - b.x, self.y - b.y)
+            if d > 200.0:
+                continue
+            try:
+                world.memory.record_character_memory(
+                    world, self.id, "breach_observed", subject=building_id,
+                )
+            except Exception:
+                pass
+            self._last_observed_event_tick = evt.tick
 
     # Words inside a prophecy payload that hint at a state being warned against.
     _PROPHECY_WARNINGS: Dict[str, List[State]] = {

--- a/from-simulation/app/agents/characters.py
+++ b/from-simulation/app/agents/characters.py
@@ -1,0 +1,642 @@
+"""
+Main characters of From — the named townsfolk who drive social life.
+
+Agent B owns this module. Characters are full ``Agent`` subclasses; their state
+machine is the canonical one from ``agents/states.py`` (TRANSITION_TABLE).
+Each tick we:
+
+1. Sample candidate next states from the transition table.
+2. Filter by precondition (time of day, status, dwelling state, etc.).
+3. Weight each candidate by ``base * tod_mult * personality_mult * role_bonus``.
+4. Apply hard overrides (night-in-talisman -> SHELTERING, fear>80 -> FLEEING,
+   IRRATIONAL sticky).
+5. Optionally consult the LLM (``world.llm_decider.maybe_decide``).
+6. Pick weighted-random.
+7. Move toward target relevant to the new state.
+8. Bookkeeping: hunger/fatigue/sanity drift, awareness bumps for nearby
+   yellow-touched NPCs.
+
+The bottom of this file also exposes ``tick_societies(world)`` — Agent A is
+expected to call this once per simulation tick AFTER the character ticks have
+run; it drives social rituals, resurrection, and expeditions.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Tuple
+
+from contracts import (
+    Agent,
+    AgentKind,
+    BUILDING_LAYOUT,
+    Event,
+    MarkerClass,
+    Phase,
+    Role,
+    State,
+    Status,
+    World,
+)
+
+# Agent A's helpers — we trust the names from the brief.
+from agents.base import distance, move_toward  # type: ignore  # noqa: F401
+from agents.states import TRANSITION_TABLE  # type: ignore  # noqa: F401
+
+
+# ---------------------------------------------------------------------------
+# Tuning knobs
+# ---------------------------------------------------------------------------
+
+# Time-of-day multipliers applied per candidate state.
+TOD_MULT: Dict[Phase, Dict[State, float]] = {
+    Phase.DAWN: {
+        State.SLEEPING: 1.4,
+        State.PRAYING: 1.3,
+        State.WANDERING: 0.6,
+        State.PATROLLING: 0.8,
+    },
+    Phase.DAY: {
+        State.FARMING: 1.6,
+        State.PATROLLING: 1.4,
+        State.REPAIRING: 1.4,
+        State.GOSSIPING: 1.3,
+        State.PLAYING: 1.5,
+        State.SCAVENGING: 1.2,
+        State.EXPEDITION: 1.3,
+        State.SLEEPING: 0.2,
+        State.SHELTERING: 0.3,
+    },
+    Phase.DUSK: {
+        State.SHELTERING: 1.3,
+        State.MEETING: 1.2,
+        State.PRAYING: 1.1,
+        State.WANDERING: 0.6,
+        State.PATROLLING: 1.0,
+    },
+    Phase.NIGHT: {
+        State.SLEEPING: 1.8,
+        State.SHELTERING: 1.6,
+        State.PATROLLING: 0.4,
+        State.WANDERING: 0.1,
+        State.FARMING: 0.05,
+        State.PLAYING: 0.05,
+    },
+}
+
+# Personality -> states that personality boosts.
+PERSONALITY_BOOST: Dict[str, Dict[State, float]] = {
+    "brave": {
+        State.PATROLLING: 1.4, State.EXPEDITION: 1.5,
+        State.INVESTIGATING: 1.3, State.FLEEING: 0.4,
+    },
+    "social": {
+        State.GOSSIPING: 1.5, State.MEETING: 1.4,
+        State.CONVERSING: 1.5, State.MEDIATING: 1.2,
+    },
+    "devout": {
+        State.PRAYING: 1.8, State.MOURNING: 1.3, State.MEDIATING: 1.2,
+    },
+    "paranoid": {
+        State.INVESTIGATING: 1.6, State.SHELTERING: 1.4,
+        State.FLEEING: 1.4, State.ARGUING: 1.2, State.GOSSIPING: 1.2,
+    },
+    "caretaker": {
+        State.CARETAKING: 1.8, State.MEDICAL_CARE: 1.5, State.MOURNING: 1.2,
+    },
+    "leader": {
+        State.MEETING: 1.5, State.MEDIATING: 1.4, State.PATROLLING: 1.1,
+    },
+}
+
+ROLE_PRIORITY: Dict[Role, List[State]] = {
+    Role.SHERIFF: [State.PATROLLING, State.MEETING, State.EXPEDITION],
+    Role.LEADER_COLONY: [State.MEETING, State.FARMING, State.ARGUING],
+    Role.ENGINEER: [State.REPAIRING, State.EXPEDITION, State.CARETAKING],
+    Role.CARETAKER: [State.CARETAKING, State.MOURNING, State.CONVERSING],
+    Role.CHILD: [State.PLAYING, State.SLEEPING],
+    Role.BRIDGE: [State.GOSSIPING, State.EXPEDITION],
+    Role.INVESTIGATOR: [State.INVESTIGATING, State.WANDERING, State.ARGUING],
+    Role.DEPUTY: [State.PATROLLING, State.CARETAKING, State.MEETING],
+    Role.PRIEST: [State.PRAYING, State.CONVERSING, State.MEDIATING],
+    Role.SEER: [State.WANDERING, State.CONVERSING],
+}
+
+ROLE_BONUS = 2.0
+
+# Awareness threshold — once a yellow-touched NPC has accumulated this much
+# suspicion in a character's eyes, that character will call for a meeting.
+AWARENESS_PROXIMITY = 80.0  # px — within this we bump awareness each tick
+AWARENESS_BUMP_PER_TICK = 0.05
+
+# Per-tick drift constants.
+HUNGER_RATE = 0.04
+FATIGUE_RATE = 0.03
+SANITY_RECOVERY = 0.01
+SANITY_NIGHT_DRAIN = 0.04
+
+
+# ---------------------------------------------------------------------------
+# Character class
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _Seed:
+    """Static seed for one character — turned into a Character at world init."""
+    name: str
+    dwelling_id: str
+    role: Role
+    personality: Dict[str, float]
+    schedule: List[Tuple[Phase, State]] = field(default_factory=list)
+
+
+CHARACTER_SEEDS: List[_Seed] = [
+    _Seed(
+        name="Boyd",
+        dwelling_id="camper",
+        role=Role.SHERIFF,
+        personality={"brave": 0.9, "social": 0.5, "devout": 0.3,
+                     "paranoid": 0.4, "caretaker": 0.6, "leader": 0.8},
+        schedule=[(Phase.DAY, State.PATROLLING), (Phase.NIGHT, State.SHELTERING)],
+    ),
+    _Seed(
+        name="Donna",
+        dwelling_id="colony_house",
+        role=Role.LEADER_COLONY,
+        personality={"brave": 0.6, "social": 0.8, "devout": 0.4,
+                     "paranoid": 0.4, "caretaker": 0.6, "leader": 0.95},
+        schedule=[(Phase.DAY, State.FARMING), (Phase.DUSK, State.MEETING)],
+    ),
+    _Seed(
+        name="Jim",
+        dwelling_id="matthews_house",
+        role=Role.ENGINEER,
+        personality={"brave": 0.7, "social": 0.5, "devout": 0.2,
+                     "paranoid": 0.6, "caretaker": 0.5, "leader": 0.4},
+        schedule=[(Phase.DAY, State.REPAIRING), (Phase.NIGHT, State.SHELTERING)],
+    ),
+    _Seed(
+        name="Tabitha",
+        dwelling_id="matthews_house",
+        role=Role.CARETAKER,
+        personality={"brave": 0.5, "social": 0.7, "devout": 0.6,
+                     "paranoid": 0.5, "caretaker": 0.95, "leader": 0.4},
+        schedule=[(Phase.DAY, State.CARETAKING), (Phase.DUSK, State.MOURNING)],
+    ),
+    _Seed(
+        name="Ethan",
+        dwelling_id="matthews_house",
+        role=Role.CHILD,
+        personality={"brave": 0.6, "social": 0.6, "devout": 0.2,
+                     "paranoid": 0.4, "caretaker": 0.2, "leader": 0.1},
+        schedule=[(Phase.DAY, State.PLAYING), (Phase.NIGHT, State.SLEEPING)],
+    ),
+    _Seed(
+        name="Julie",
+        dwelling_id="colony_house",
+        role=Role.BRIDGE,
+        personality={"brave": 0.7, "social": 0.8, "devout": 0.3,
+                     "paranoid": 0.5, "caretaker": 0.5, "leader": 0.4},
+        schedule=[(Phase.DAY, State.GOSSIPING), (Phase.DUSK, State.WANDERING)],
+    ),
+    _Seed(
+        name="Jade",
+        dwelling_id="colony_house",
+        role=Role.INVESTIGATOR,
+        personality={"brave": 0.7, "social": 0.4, "devout": 0.2,
+                     "paranoid": 0.85, "caretaker": 0.3, "leader": 0.4},
+        schedule=[(Phase.DAY, State.INVESTIGATING), (Phase.DUSK, State.WANDERING)],
+    ),
+    _Seed(
+        name="Kenny",
+        dwelling_id="colony_house",
+        role=Role.DEPUTY,
+        personality={"brave": 0.7, "social": 0.7, "devout": 0.3,
+                     "paranoid": 0.4, "caretaker": 0.6, "leader": 0.4},
+        schedule=[(Phase.DAY, State.PATROLLING), (Phase.NIGHT, State.SHELTERING)],
+    ),
+    _Seed(
+        name="Khatri",
+        dwelling_id="church",
+        role=Role.PRIEST,
+        personality={"brave": 0.5, "social": 0.6, "devout": 0.95,
+                     "paranoid": 0.3, "caretaker": 0.7, "leader": 0.5},
+        schedule=[(Phase.DAWN, State.PRAYING), (Phase.DUSK, State.PRAYING)],
+    ),
+    _Seed(
+        name="Sara",
+        dwelling_id="lighthouse",
+        role=Role.SEER,
+        personality={"brave": 0.5, "social": 0.4, "devout": 0.6,
+                     "paranoid": 0.7, "caretaker": 0.4, "leader": 0.3},
+        schedule=[(Phase.DAY, State.WANDERING), (Phase.NIGHT, State.CONVERSING)],
+    ),
+]
+
+
+class Character(Agent):
+    """One named townsperson."""
+
+    kind = AgentKind.CHARACTER
+    marker_class = MarkerClass.CHAR
+
+    def __init__(
+        self,
+        name: str,
+        dwelling_id: str,
+        role: Role,
+        personality: Dict[str, float],
+        schedule: List[Tuple[Phase, State]],
+        x: float,
+        y: float,
+    ) -> None:
+        self.id = name
+        self.name = name
+        self.dwelling_id = dwelling_id
+        self.role = role
+        self.personality = dict(personality)
+        self.schedule = list(schedule)
+        self.x = float(x)
+        self.y = float(y)
+
+        # Behavioural state
+        self.state: State = State.SLEEPING
+        self.state_since_tick: int = 0
+
+        # Drives
+        self.hunger: float = 20.0
+        self.fatigue: float = 20.0
+        self.fear: float = 0.0
+        self.sanity: float = 100.0
+
+        self.inventory: Dict[str, int] = {}
+        self.status: Status = Status.ACTIVE
+        self.last_llm_tick: int = -10_000
+        self.awareness: Dict[str, float] = {}
+
+        # Social / society bookkeeping
+        self.meeting_until_tick: int = 0
+        self.arguing_until_tick: int = 0
+        self.conversation_partner: Optional[str] = None
+        self.expedition_role: Optional[str] = None  # "leader" | "member" | None
+        self.target: Optional[Tuple[float, float]] = None
+
+    # ------------------------------------------------------------------ tick
+    def tick(self, world: World) -> None:
+        if self.status in (Status.DEAD, Status.ABSENT):
+            return
+
+        # ---- Drives & sanity ---------------------------------------------
+        self.hunger = min(100.0, self.hunger + HUNGER_RATE)
+        if self.state == State.SLEEPING:
+            self.fatigue = max(0.0, self.fatigue - FATIGUE_RATE * 5)
+        else:
+            self.fatigue = min(100.0, self.fatigue + FATIGUE_RATE)
+        if world.time.phase == Phase.NIGHT and self.state != State.SLEEPING:
+            self.sanity = max(0.0, self.sanity - SANITY_NIGHT_DRAIN)
+        else:
+            self.sanity = min(100.0, self.sanity + SANITY_RECOVERY)
+
+        # ---- Awareness: bump for nearby yellow-touched NPCs --------------
+        self._update_awareness(world)
+
+        # ---- Sticky / pinned states --------------------------------------
+        if self.state == State.MEETING and world.tick_count < self.meeting_until_tick:
+            return
+        if self.state == State.ARGUING and world.tick_count < self.arguing_until_tick:
+            self.fear = min(100.0, self.fear + 0.3)
+            self.sanity = max(0.0, self.sanity - 0.1)
+            return
+
+        # ---- Hard overrides ----------------------------------------------
+        forced = self._hard_override(world)
+        if forced is not None:
+            self._enter(world, forced)
+            self._step_toward_target(world)
+            return
+
+        # ---- Build candidate menu ----------------------------------------
+        menu = self._candidate_menu(world)
+        if not menu:
+            # Fall through to WANDERING — should be a node in any sane table.
+            menu = [(State.WANDERING, 1.0)]
+
+        # ---- Optional LLM consultation -----------------------------------
+        chosen: Optional[State] = None
+        cfg = world.config
+        if (
+            cfg.anthropic_api_key
+            and getattr(world, "llm_decider", None) is not None
+            and world.rng.random() < cfg.llm_decision_rate
+            and (world.tick_count - self.last_llm_tick) >= cfg.llm_min_tick_gap
+        ):
+            try:
+                chosen = world.llm_decider.maybe_decide(self, world, menu)
+            except Exception:  # never let an LLM hiccup kill the tick
+                chosen = None
+            self.last_llm_tick = world.tick_count
+            if chosen is not None:
+                world.emit(Event(
+                    tick=world.tick_count, type="llm_decision",
+                    subject=self.id, detail=f"{self.state.value}->{chosen.value}",
+                ))
+
+        if chosen is None:
+            states = [s for s, _ in menu]
+            weights = [w for _, w in menu]
+            chosen = world.rng.choices(states, weights=weights, k=1)[0]
+
+        if chosen != self.state:
+            self._enter(world, chosen)
+
+        self._step_toward_target(world)
+
+    # ----------------------------------------------------------- helpers
+    def _hard_override(self, world: World) -> Optional[State]:
+        if self.state == State.IRRATIONAL:
+            return State.IRRATIONAL  # sticky
+        if self.fear > 80.0:
+            return State.FLEEING
+        if world.time.phase == Phase.NIGHT:
+            b = world.buildings.get(self.dwelling_id)
+            if b is not None and b.has_talisman:
+                return State.SHELTERING
+        return None
+
+    def _candidate_menu(self, world: World) -> List[Tuple[State, float]]:
+        table = TRANSITION_TABLE.get(self.state, {})
+        if not table:
+            return []
+        phase = world.time.phase
+        tod = TOD_MULT.get(phase, {})
+        priority = set(ROLE_PRIORITY.get(self.role, []))
+
+        out: List[Tuple[State, float]] = []
+        # TRANSITION_TABLE entries are (next_state, base_weight, tod_multipliers)
+        # 3-tuples (Agent A's format). We apply both A's per-transition phase
+        # multiplier AND B's coarser TOD_MULT bias on top of it.
+        for next_state, base, tod_mult in table:
+            if not self._precondition_ok(next_state, world):
+                continue
+            w = float(base) * float(tod_mult.get(phase, 1.0))
+            w *= tod.get(next_state, 1.0)
+            # Personality multiplier — product over all traits that touch this state.
+            for trait, val in self.personality.items():
+                boost_map = PERSONALITY_BOOST.get(trait, {})
+                if next_state in boost_map:
+                    factor = boost_map[next_state]
+                    # Lerp 1.0 -> factor by trait strength.
+                    w *= 1.0 + (factor - 1.0) * val
+            if next_state in priority:
+                w *= ROLE_BONUS
+            if w > 0:
+                out.append((next_state, w))
+        return out
+
+    def _precondition_ok(self, s: State, world: World) -> bool:
+        # Multi-agent states are entered by the social loop, not by self.tick().
+        if s in (State.MEETING, State.ARGUING, State.CONVERSING,
+                 State.MEDIATING, State.EXPEDITION):
+            return False
+        if s == State.SLEEPING and world.time.phase == Phase.DAY:
+            # children may nap, others mostly don't
+            if self.role != Role.CHILD:
+                return False
+        if s == State.PLAYING and self.role != Role.CHILD:
+            return False
+        if s == State.PRAYING and self.role not in (Role.PRIEST, Role.SEER) \
+                and self.personality.get("devout", 0.0) < 0.4:
+            return False
+        if s == State.IRRATIONAL:
+            return False  # entered via fear.py only
+        if s == State.HYPNOTIZED:
+            return False  # entered via creatures
+        return True
+
+    def _enter(self, world: World, new_state: State) -> None:
+        if new_state == self.state:
+            return
+        self.state = new_state
+        self.state_since_tick = world.tick_count
+        self.target = self._target_for(new_state, world)
+
+    def _target_for(self, s: State, world: World) -> Optional[Tuple[float, float]]:
+        b = world.buildings.get(self.dwelling_id)
+        home = (b.x, b.y) if b else (self.x, self.y)
+        if s in (State.SLEEPING, State.SHELTERING):
+            return home
+        if s == State.PRAYING:
+            ch = world.buildings.get("church")
+            return (ch.x, ch.y) if ch else home
+        if s == State.FARMING:
+            ch = world.buildings.get("colony_house")
+            return (ch.x + 20, ch.y + 60) if ch else home
+        if s == State.REPAIRING:
+            ch = world.buildings.get("matthews_house")
+            return (ch.x, ch.y) if ch else home
+        if s == State.CARETAKING or s == State.MEDICAL_CARE:
+            ch = world.buildings.get("clinic")
+            return (ch.x, ch.y) if ch else home
+        if s == State.PATROLLING:
+            # roam the village centre
+            return (
+                world.rng.uniform(300, 700),
+                world.rng.uniform(300, 500),
+            )
+        if s == State.PLAYING:
+            return (
+                world.rng.uniform(400, 600),
+                world.rng.uniform(380, 480),
+            )
+        if s == State.WANDERING:
+            return (
+                world.rng.uniform(150, 850),
+                world.rng.uniform(150, 600),
+            )
+        if s == State.FLEEING:
+            return home
+        if s == State.SCAVENGING:
+            return (
+                world.rng.uniform(100, 900),
+                world.rng.uniform(100, 600),
+            )
+        if s == State.GOSSIPING:
+            diner = world.buildings.get("diner")
+            return (diner.x, diner.y) if diner else home
+        if s == State.MOURNING:
+            ch = world.buildings.get("church")
+            return (ch.x + 10, ch.y + 30) if ch else home
+        if s == State.INVESTIGATING:
+            return (
+                world.rng.uniform(150, 850),
+                world.rng.uniform(150, 600),
+            )
+        return home
+
+    def _step_toward_target(self, world: World) -> None:
+        if self.target is None:
+            return
+        # Walk speed depends on state.
+        speed = 2.5
+        if self.state == State.FLEEING:
+            speed = 5.0
+        elif self.state in (State.SLEEPING, State.SHELTERING, State.PRAYING,
+                            State.MOURNING, State.MEDIATING):
+            speed = 0.0
+        elif self.state == State.PLAYING:
+            speed = 3.5
+        if speed <= 0:
+            return
+        try:
+            nx, ny = move_toward((self.x, self.y), self.target, speed)
+            self.x, self.y = nx, ny
+        except Exception:
+            # If A's helper signature differs, fall back to a tiny linear step.
+            dx = self.target[0] - self.x
+            dy = self.target[1] - self.y
+            d = math.hypot(dx, dy) or 1.0
+            self.x += speed * dx / d
+            self.y += speed * dy / d
+
+    def _update_awareness(self, world: World) -> None:
+        touched = getattr(world, "yellow_touched_npcs", set())
+        if not touched:
+            return
+        for npc_id in list(touched):
+            other = world.agents.get(npc_id)
+            if other is None:
+                continue
+            try:
+                d = distance((self.x, self.y), (other.x, other.y))
+            except Exception:
+                d = math.hypot(self.x - other.x, self.y - other.y)
+            if d <= AWARENESS_PROXIMITY:
+                # paranoid characters notice more.
+                paranoid = self.personality.get("paranoid", 0.5)
+                bump = AWARENESS_BUMP_PER_TICK * (0.7 + 0.6 * paranoid)
+                self.awareness[npc_id] = self.awareness.get(npc_id, 0.0) + bump
+
+    # ------------------------------------------------------------ serialise
+    def to_dict(self) -> Dict[str, Any]:
+        d = super().to_dict()
+        d.update({
+            "name": self.name,
+            "role": self.role.value,
+            "state": self.state.value,
+            "status": self.status.value,
+            "dwelling_id": self.dwelling_id,
+            "hunger": round(self.hunger, 1),
+            "fatigue": round(self.fatigue, 1),
+            "fear": round(self.fear, 1),
+            "sanity": round(self.sanity, 1),
+            "personality": {k: round(v, 2) for k, v in self.personality.items()},
+            "awareness": {k: round(v, 2) for k, v in self.awareness.items()},
+        })
+        return d
+
+
+# ---------------------------------------------------------------------------
+# Builders
+# ---------------------------------------------------------------------------
+
+
+def _building_xy(building_id: str) -> Tuple[float, float]:
+    for (bid, _name, x, y, _f, _t, _r) in BUILDING_LAYOUT:
+        if bid == building_id:
+            return (float(x), float(y))
+    return (500.0, 350.0)
+
+
+def build_characters(world: World) -> None:
+    """Instantiate every seeded character and register in ``world.agents``."""
+    for seed in CHARACTER_SEEDS:
+        x, y = _building_xy(seed.dwelling_id)
+        # Small jitter so they don't all overlap at spawn.
+        x += world.rng.uniform(-15.0, 15.0)
+        y += world.rng.uniform(-15.0, 15.0)
+        c = Character(
+            name=seed.name,
+            dwelling_id=seed.dwelling_id,
+            role=seed.role,
+            personality=seed.personality,
+            schedule=seed.schedule,
+            x=x, y=y,
+        )
+        world.agents[c.id] = c
+        b = world.buildings.get(seed.dwelling_id)
+        if b is not None:
+            b.occupants.add(c.id)
+
+
+def respawn_character(world: World, name: str) -> None:
+    """Re-instantiate a character at a forest intake point with status RETURNING."""
+    seed = next((s for s in CHARACTER_SEEDS if s.name == name), None)
+    if seed is None:
+        return
+    from contracts import NPC_INTAKE_POINTS
+    ix, iy = world.rng.choice(NPC_INTAKE_POINTS)
+    ix += world.rng.uniform(-15.0, 15.0)
+    iy += world.rng.uniform(-15.0, 15.0)
+    c = Character(
+        name=seed.name,
+        dwelling_id=seed.dwelling_id,
+        role=seed.role,
+        personality=seed.personality,
+        schedule=seed.schedule,
+        x=ix, y=iy,
+    )
+    c.status = Status.RETURNING
+    c.state = State.WANDERING
+    world.agents[c.id] = c
+    world.recognition_counts[c.id] = 0
+    world.emit(Event(
+        tick=world.tick_count, type="homecoming",
+        subject=c.id, detail=f"{c.name} has returned from the forest",
+        severity="warn",
+    ))
+
+
+# ---------------------------------------------------------------------------
+# Top-level society tick — Agent A must call this once per tick AFTER agents.
+# ---------------------------------------------------------------------------
+
+
+def tick_societies(world: World) -> None:
+    """Drive social loop, resurrection countdown, and expedition lifecycle.
+
+    Agent A should call this exactly once at the END of each simulation tick,
+    after every Agent.tick() has run.
+    """
+    # Late imports — avoid hard fail at module import time if a sibling file
+    # is still being authored.
+    try:
+        from agents.social import tick_social
+        tick_social(world)
+    except Exception as exc:  # pragma: no cover
+        if world.telemetry is not None:
+            try:
+                world.telemetry.get_logger().exception("tick_social failed: %s", exc)
+            except Exception:
+                pass
+
+    try:
+        from agents.resurrection import tick_resurrection
+        tick_resurrection(world)
+    except Exception as exc:  # pragma: no cover
+        if world.telemetry is not None:
+            try:
+                world.telemetry.get_logger().exception("tick_resurrection failed: %s", exc)
+            except Exception:
+                pass
+
+    try:
+        from agents.expedition import tick_expeditions
+        tick_expeditions(world)
+    except Exception as exc:  # pragma: no cover
+        if world.telemetry is not None:
+            try:
+                world.telemetry.get_logger().exception("tick_expeditions failed: %s", exc)
+            except Exception:
+                pass

--- a/from-simulation/app/agents/characters.py
+++ b/from-simulation/app/agents/characters.py
@@ -40,6 +40,17 @@ from contracts import (
     World,
 )
 
+# v4: rhyme lines surfaced by Sara, keyed by current music box phase.
+_RHYME_LINES: Dict[str, str] = {
+    "TOUCH": "They touch — I can hear it from the ruins.",
+    "BREAK": "They break — it took Paula. Or someone. Soon.",
+    "STEAL": "They come for three. The dungeon. Take it there.",
+    "TERMINAL": "They come for three… we are too late.",
+}
+
+# v4: ~one sim day at 2 Hz; rhyme cadence for Sara.
+_RHYME_TICK_GAP = 720
+
 # Agent A's helpers — we trust the names from the brief.
 from agents.base import distance, move_toward  # type: ignore  # noqa: F401
 from agents.states import TRANSITION_TABLE  # type: ignore  # noqa: F401
@@ -302,6 +313,9 @@ class Character(Agent):
         if self.status == Status.ABSENT:
             return
 
+        # ---- v4: Sara/Khatri/Boyd music-box reactions --------------------
+        self._music_box_reaction(world)
+
         # ---- Drives & sanity ---------------------------------------------
         self.hunger = min(100.0, self.hunger + HUNGER_RATE)
         if self.state == State.SLEEPING:
@@ -367,6 +381,107 @@ class Character(Agent):
 
         self._step_toward_target(world)
 
+    # ----------------------------------------------------------- v4 helpers
+    def _music_box_reaction(self, world: World) -> None:
+        """Sara hears the Rhyme; Khatri calls a meeting; Boyd grabs the box.
+
+        All three reactions are character-role-gated and self-throttled with
+        per-instance state. None of them mutate engine-owned fields except via
+        the documented v4 contracts (``world.music_box_carrier`` / events).
+        """
+        phase = getattr(world, "music_box_phase", "DORMANT")
+
+        # ---- Sara hears the music (SEER + non-dormant box) -----------------
+        if self.role == Role.SEER and phase != "DORMANT":
+            last_tick = getattr(self, "_sara_last_rhyme_tick", -10_000)
+            last_phase = getattr(self, "_sara_last_phase", None)
+            # Find nearest music box marker (if any) within 200 px.
+            near_box = False
+            try:
+                for s in world.supernaturals:
+                    if getattr(s, "marker_class", None) == MarkerClass.MUSIC_BOX:
+                        d = math.hypot(self.x - s.x, self.y - s.y)
+                        if d <= 200.0:
+                            near_box = True
+                            break
+            except Exception:
+                near_box = False
+            phase_advanced = (phase != last_phase)
+            cadence_ok = (world.tick_count - last_tick) >= _RHYME_TICK_GAP
+            if (cadence_ok and near_box) or phase_advanced:
+                line = _RHYME_LINES.get(phase)
+                if line:
+                    try:
+                        world.narrations.append({
+                            "actor": "Sara",
+                            "reason": line,
+                            "state": State.WANDERING.value,
+                        })
+                        if len(world.narrations) > 50:
+                            del world.narrations[: len(world.narrations) - 50]
+                    except Exception:
+                        pass
+                    try:
+                        world.rhyme_heard.append(line)
+                    except Exception:
+                        pass
+                    world.emit(Event(
+                        tick=world.tick_count, type="rhyme_heard",
+                        subject=self.id, detail=line, severity="warn",
+                    ))
+                    self.sanity = max(0.0, self.sanity - 0.3)
+                    self._sara_last_rhyme_tick = world.tick_count
+                    self._sara_last_phase = phase
+                    world._sara_has_warned = True  # type: ignore[attr-defined]
+
+        # ---- Khatri calls the meeting (PRIEST after Sara has warned) -------
+        if (
+            self.role == Role.PRIEST
+            and getattr(world, "_sara_has_warned", False)
+            and self.state not in (State.MEETING, State.ARGUING,
+                                   State.DREAMING, State.IRRATIONAL)
+            and not getattr(self, "_khatri_proposed_destroy", False)
+        ):
+            already = any(
+                mo.topic == "destroy_music_box"
+                for mo in (world.meeting_outcomes or [])
+            )
+            if not already:
+                try:
+                    from agents.social import propose_meeting
+                    propose_meeting(world, "Khatri", "destroy_music_box", "church")
+                    self._khatri_proposed_destroy = True
+                except Exception:
+                    pass
+
+        # ---- Boyd picks up the box (SHERIFF) -------------------------------
+        if (
+            self.role == Role.SHERIFF
+            and getattr(world, "music_box_carrier", None) is None
+            and phase != "DORMANT"
+        ):
+            try:
+                target = None
+                for s in world.supernaturals:
+                    if getattr(s, "marker_class", None) != MarkerClass.MUSIC_BOX:
+                        continue
+                    d = math.hypot(self.x - s.x, self.y - s.y)
+                    if d <= 80.0:
+                        target = s
+                        break
+                if target is not None:
+                    world.music_box_carrier = self.id
+                    self.state = State.CARRYING_BOX
+                    self.state_since_tick = world.tick_count
+                    world.emit(Event(
+                        tick=world.tick_count, type="music_box_picked_up",
+                        subject=self.id,
+                        detail="Boyd took it from where it was dropped.",
+                        severity="warn",
+                    ))
+            except Exception:
+                pass
+
     # ----------------------------------------------------------- helpers
     def _hard_override(self, world: World) -> Optional[State]:
         if self.state == State.IRRATIONAL:
@@ -410,6 +525,18 @@ class Character(Agent):
             w *= prophecy_mult.get(next_state, 1.0)
             if w > 0:
                 out.append((next_state, w))
+        # v4: music-box carrier wants to deal with this — strong EXPEDITION bias.
+        if self.id == getattr(world, "music_box_carrier", None):
+            # Either boost an existing EXPEDITION slot, or inject one so the
+            # LLM (and any future relaxed precondition) sees the intent.
+            boosted = False
+            for i, (s, w) in enumerate(out):
+                if s == State.EXPEDITION:
+                    out[i] = (s, w * 3.0)
+                    boosted = True
+                    break
+            if not boosted:
+                out.append((State.EXPEDITION, 3.0))
         return out
 
     # Words inside a prophecy payload that hint at a state being warned against.

--- a/from-simulation/app/agents/characters.py
+++ b/from-simulation/app/agents/characters.py
@@ -44,6 +44,8 @@ from contracts import (
 from agents.base import distance, move_toward  # type: ignore  # noqa: F401
 from agents.states import TRANSITION_TABLE  # type: ignore  # noqa: F401
 
+import legacy
+
 
 # ---------------------------------------------------------------------------
 # Tuning knobs
@@ -283,9 +285,21 @@ class Character(Agent):
         self.expedition_role: Optional[str] = None  # "leader" | "member" | None
         self.target: Optional[Tuple[float, float]] = None
 
+        # Cross-cycle bookkeeping
+        self._obituary_written: bool = False
+
     # ------------------------------------------------------------------ tick
     def tick(self, world: World) -> None:
-        if self.status in (Status.DEAD, Status.ABSENT):
+        if self.status == Status.DEAD:
+            # First DEAD-status tick: write an obituary into the journal.
+            if not self._obituary_written:
+                self._obituary_written = True
+                try:
+                    legacy.record(world, "char_death", name=self.name)
+                except Exception:
+                    pass
+            return
+        if self.status == Status.ABSENT:
             return
 
         # ---- Drives & sanity ---------------------------------------------
@@ -372,6 +386,7 @@ class Character(Agent):
         phase = world.time.phase
         tod = TOD_MULT.get(phase, {})
         priority = set(ROLE_PRIORITY.get(self.role, []))
+        prophecy_mult = self._prophecy_bias(world)
 
         out: List[Tuple[State, float]] = []
         # TRANSITION_TABLE entries are (next_state, base_weight, tod_multipliers)
@@ -391,9 +406,70 @@ class Character(Agent):
                     w *= 1.0 + (factor - 1.0) * val
             if next_state in priority:
                 w *= ROLE_BONUS
+            # Prophecy bias — pending prophecies mentioning this character.
+            w *= prophecy_mult.get(next_state, 1.0)
             if w > 0:
                 out.append((next_state, w))
         return out
+
+    # Words inside a prophecy payload that hint at a state being warned against.
+    _PROPHECY_WARNINGS: Dict[str, List[State]] = {
+        "door": [State.PATROLLING, State.SHELTERING],
+        "sleep through": [State.SLEEPING, State.SHELTERING],
+        "do not sleep": [State.SLEEPING],
+        "do not pray": [State.PRAYING],
+        "stay inside": [State.PATROLLING, State.WANDERING],
+        "leave": [State.SHELTERING, State.SLEEPING],
+    }
+
+    _ROLE_HINTS: Dict[Role, List[str]] = {
+        Role.SHERIFF: ["sheriff"],
+        Role.DEPUTY: ["deputy"],
+        Role.LEADER_COLONY: ["leader", "colony"],
+        Role.ENGINEER: ["engineer"],
+        Role.CARETAKER: ["caretaker", "nurse"],
+        Role.BRIDGE: ["bridge"],
+        Role.INVESTIGATOR: ["investigator"],
+        Role.PRIEST: ["priest", "father"],
+        Role.SEER: ["seer"],
+        Role.CHILD: ["child"],
+    }
+
+    def _prophecy_bias(self, world: World) -> Dict[State, float]:
+        """Return per-state multipliers from pending prophecies that mention us.
+
+        Heuristic: any prophecy whose payload substring-matches this character's
+        name or a role keyword applies; +20% to states named in the payload,
+        -50% on states the prophecy 'warns against' (via ``_PROPHECY_WARNINGS``).
+        Does NOT consume the prophecy — Agent A's ``fire_due_prophecies`` does
+        that on the proper trigger.
+        """
+        legacy_obj = getattr(world, "legacy", None)
+        if legacy_obj is None:
+            return {}
+        prophecies = getattr(legacy_obj, "pending_prophecies", None)
+        if not prophecies:
+            return {}
+        name_lower = self.name.lower()
+        role_keywords = self._ROLE_HINTS.get(self.role, [])
+        mult: Dict[State, float] = {}
+        for p in prophecies:
+            payload = (getattr(p, "payload", "") or "").lower()
+            if not payload:
+                continue
+            mentions_me = name_lower in payload or any(k in payload for k in role_keywords)
+            if not mentions_me:
+                continue
+            # +20% on states whose name appears in the payload.
+            for s in State:
+                if s.value.lower() in payload:
+                    mult[s] = mult.get(s, 1.0) * 1.2
+            # -50% on warned-against states.
+            for trigger, states in self._PROPHECY_WARNINGS.items():
+                if trigger in payload:
+                    for s in states:
+                        mult[s] = mult.get(s, 1.0) * 0.5
+        return mult
 
     def _precondition_ok(self, s: State, world: World) -> bool:
         # Multi-agent states are entered by the social loop, not by self.tick().
@@ -549,8 +625,21 @@ def _building_xy(building_id: str) -> Tuple[float, float]:
     return (500.0, 350.0)
 
 
+def _personality_with_drift(world: World, seed: "_Seed") -> Dict[str, float]:
+    """Apply accumulated legacy drift to a seed's personality (clamped [0,1])."""
+    base = dict(seed.personality)
+    deltas = world.legacy.personality_drift.get(seed.name, {}) if world.legacy else {}
+    for trait, dv in deltas.items():
+        base[trait] = max(0.0, min(1.0, base.get(trait, 0.5) + dv))
+    return base
+
+
 def build_characters(world: World) -> None:
-    """Instantiate every seeded character and register in ``world.agents``."""
+    """Instantiate every seeded character and register in ``world.agents``.
+
+    Applies any accumulated legacy drift to each personality before
+    construction so reborn characters carry their previous-cycle scars.
+    """
     for seed in CHARACTER_SEEDS:
         x, y = _building_xy(seed.dwelling_id)
         # Small jitter so they don't all overlap at spawn.
@@ -560,7 +649,7 @@ def build_characters(world: World) -> None:
             name=seed.name,
             dwelling_id=seed.dwelling_id,
             role=seed.role,
-            personality=seed.personality,
+            personality=_personality_with_drift(world, seed),
             schedule=seed.schedule,
             x=x, y=y,
         )
@@ -571,7 +660,11 @@ def build_characters(world: World) -> None:
 
 
 def respawn_character(world: World, name: str) -> None:
-    """Re-instantiate a character at a forest intake point with status RETURNING."""
+    """Re-instantiate a character at a forest intake point with status RETURNING.
+
+    Applies any accumulated legacy drift (``world.legacy.personality_drift``) to
+    the seed personality before instantiating. Each trait is clamped to [0,1].
+    """
     seed = next((s for s in CHARACTER_SEEDS if s.name == name), None)
     if seed is None:
         return
@@ -579,11 +672,19 @@ def respawn_character(world: World, name: str) -> None:
     ix, iy = world.rng.choice(NPC_INTAKE_POINTS)
     ix += world.rng.uniform(-15.0, 15.0)
     iy += world.rng.uniform(-15.0, 15.0)
+
+    # Apply legacy drift to the seed personality.
+    personality = dict(seed.personality)
+    drift = world.legacy.personality_drift.get(name, {}) if world.legacy else {}
+    for trait, delta in drift.items():
+        cur = personality.get(trait, 0.5)
+        personality[trait] = max(0.0, min(1.0, cur + delta))
+
     c = Character(
         name=seed.name,
         dwelling_id=seed.dwelling_id,
         role=seed.role,
-        personality=seed.personality,
+        personality=personality,
         schedule=seed.schedule,
         x=ix, y=iy,
     )

--- a/from-simulation/app/agents/construction.py
+++ b/from-simulation/app/agents/construction.py
@@ -1,0 +1,182 @@
+"""
+v8 — Survivor-driven house construction.
+
+When the existing residences fill up (residents == capacity on every house in
+NPC_HOME_BUILDINGS) and at least one new arrival is homeless, the village
+needs to put up another roof. Engineers (Jim's role) and any character in
+``State.REPAIRING`` near an empty lot accumulate progress; once a lot
+crosses ``CONSTRUCTION_THRESHOLD`` it becomes a real ``Building`` and the
+homeless can claim it as ``home_id``.
+
+Pure additive module. Reads ``world.agents`` + ``world.buildings`` +
+``EMPTY_LOTS`` + ``world.construction_progress``. Writes
+``world.buildings`` and ``world.consumed_lots``. Emits
+``construction_started``, ``construction_progress``, ``house_built``.
+
+Ownership: Agent A (engine) tick this once per sim tick AFTER agents have
+moved, so the proximity check sees the latest positions.
+"""
+
+from __future__ import annotations
+
+from typing import List, Optional
+
+from contracts import (
+    AgentKind,
+    Building,
+    CONSTRUCTION_PER_TICK,
+    CONSTRUCTION_RADIUS_PX,
+    CONSTRUCTION_THRESHOLD,
+    EMPTY_LOTS,
+    Event,
+    NEW_HOUSE_CAPACITY,
+    Phase,
+    Role,
+    State,
+    Status,
+    World,
+)
+from agents.base import distance
+
+
+def _homeless_count(world: World) -> int:
+    """Living NPCs with no ``home_id`` assigned."""
+    return sum(
+        1 for a in world.agents.values()
+        if getattr(a, "kind", None) == AgentKind.NPC
+        and getattr(a, "status", Status.ACTIVE) == Status.ACTIVE
+        and getattr(a, "home_id", None) is None
+    )
+
+
+def _builders_near(world: World, x: float, y: float) -> int:
+    """Count survivors who count as 'on site' for a lot at (x, y).
+
+    Engineers (the canonical builder role) count regardless of state. Any
+    other CHARACTER in REPAIRING state also counts, so a desperate town
+    can press whoever's available into rebuilding. NPCs themselves don't
+    build — they don't have the right state machine for it.
+    """
+    n = 0
+    for a in world.agents.values():
+        if getattr(a, "kind", None) != AgentKind.CHARACTER:
+            continue
+        if getattr(a, "status", Status.ACTIVE) != Status.ACTIVE:
+            continue
+        if distance(a, type("Pt", (), {"x": x, "y": y})()) > CONSTRUCTION_RADIUS_PX:
+            continue
+        if getattr(a, "role", None) == Role.ENGINEER:
+            n += 1
+        elif getattr(a, "state", None) == State.REPAIRING:
+            n += 1
+    return n
+
+
+def _emit_progress(world: World, lot_id: str, progress: float) -> None:
+    """Emit a sparse progress event when a multiple of 20 is crossed."""
+    last = int(world.construction_progress.get(f"{lot_id}::_last_emit", 0))
+    current_bucket = int(progress // 20)
+    if current_bucket > last:
+        world.construction_progress[f"{lot_id}::_last_emit"] = float(current_bucket)
+        pct = min(100, int(progress * 100.0 / CONSTRUCTION_THRESHOLD))
+        world.emit(Event(
+            tick=world.tick_count,
+            type="construction_progress",
+            subject=lot_id,
+            detail=f"new house at {lot_id} — {pct}% complete",
+            severity="info",
+        ))
+
+
+def _convert_lot_to_building(world: World, lot_id: str, x: float, y: float) -> None:
+    """Replace an empty lot with a fresh Building in ``world.buildings``."""
+    # Pick a unique name: built_house_<seq>
+    seq = sum(
+        1 for b in world.buildings.values()
+        if b.id.startswith("built_house_")
+    ) + 1
+    bid = f"built_house_{seq}"
+    name = f"New House {seq}"
+    new_b = Building(
+        id=bid,
+        name=name,
+        x=float(x),
+        y=float(y),
+        footprint=NEW_HOUSE_CAPACITY,
+        has_talisman=False,
+        role_tag="house",
+        locked=False,
+        original_talisman=False,
+    )
+    world.buildings[bid] = new_b
+    world.consumed_lots.add(lot_id)
+    # Drop progress entries for this lot.
+    world.construction_progress.pop(lot_id, None)
+    world.construction_progress.pop(f"{lot_id}::_last_emit", None)
+
+    # Add the new building to the NPC home pool so pick_home_id will find
+    # it next tick. We splice it before the small-houses block so it gets
+    # picked up roughly proportionally.
+    try:
+        from contracts import NPC_HOME_BUILDINGS
+        if bid not in NPC_HOME_BUILDINGS:
+            NPC_HOME_BUILDINGS.append(bid)
+    except Exception:
+        pass
+
+    world.emit(Event(
+        tick=world.tick_count,
+        type="house_built",
+        subject=bid,
+        detail=f"{name} raised on lot {lot_id} — survivors carved out new room",
+        severity="info",
+    ))
+
+
+def tick_construction(world: World) -> None:
+    """Engine hook — called once per tick after agents have moved.
+
+    Construction only progresses during DAY (the village rests at night).
+    Without homeless NPCs there's no demand, so we skip the proximity
+    sweep entirely — keeps the per-tick cost down.
+    """
+    if world.time.phase != Phase.DAY:
+        return
+    homeless = _homeless_count(world)
+    if homeless <= 0:
+        return
+
+    # Pick the first lot that hasn't been consumed yet. Building one house
+    # at a time keeps the visible cadence readable.
+    target_lot: Optional[tuple] = None
+    for lot_id, lx, ly in EMPTY_LOTS:
+        if lot_id in world.consumed_lots:
+            continue
+        target_lot = (lot_id, lx, ly)
+        break
+    if target_lot is None:
+        # All lots consumed — survivors can't expand further. Hard cap.
+        return
+
+    lot_id, lx, ly = target_lot
+    builders = _builders_near(world, lx, ly)
+    if builders <= 0:
+        # No one on site. Don't emit anything; a future tick might pick up.
+        return
+
+    progress = float(world.construction_progress.get(lot_id, 0.0))
+    if progress == 0.0:
+        # First builder showed up — announce so the player notices.
+        world.emit(Event(
+            tick=world.tick_count,
+            type="construction_started",
+            subject=lot_id,
+            detail=f"construction has begun on lot {lot_id}",
+            severity="info",
+        ))
+    progress += CONSTRUCTION_PER_TICK * builders
+    world.construction_progress[lot_id] = progress
+    _emit_progress(world, lot_id, progress)
+
+    if progress >= CONSTRUCTION_THRESHOLD:
+        _convert_lot_to_building(world, lot_id, lx, ly)

--- a/from-simulation/app/agents/cooling_off.py
+++ b/from-simulation/app/agents/cooling_off.py
@@ -1,0 +1,38 @@
+"""
+House cooling-off sweep — v4 talisman repair tick.
+
+After a creature breach or a music-box-induced talisman flicker, a building's
+``cooling_off_until_tick`` is bumped forward. While ``world.tick_count`` is
+below that mark, ``Building.is_protected()`` returns False even when
+``has_talisman`` is True. This module owns the *cleanup* side: when the timer
+expires, emit ``house_cleared`` and stop reporting the building as cooling-off.
+
+The bumping is done by callers (creatures.py, music_box.py); this tick just
+clears the expired marks and updates the ``HOUSES_COOLING_OFF`` gauge.
+"""
+
+from __future__ import annotations
+
+from contracts import Event, Metric, World
+
+
+def tick_cooling_off(world: World) -> None:
+    """Sweep every building, expire stale cool-offs, emit + report gauge."""
+    now = world.tick_count
+    active = 0
+    for b in world.buildings.values():
+        if b.cooling_off_until_tick > 0 and now >= b.cooling_off_until_tick:
+            b.cooling_off_until_tick = 0
+            world.emit(
+                Event(
+                    tick=now,
+                    type="house_cleared",
+                    subject=b.id,
+                    detail="cooling-off ended",
+                    severity="info",
+                )
+            )
+        if b.cooling_off_until_tick > now:
+            active += 1
+    if world.telemetry is not None:
+        world.telemetry.gauge_set(Metric.HOUSES_COOLING_OFF, float(active))

--- a/from-simulation/app/agents/creatures.py
+++ b/from-simulation/app/agents/creatures.py
@@ -1,0 +1,259 @@
+"""
+Forest creatures.
+
+Sub-FSM (lives inside the Creature, not the global transition table):
+
+    WALKING      — moving from the spawn point toward a target building.
+    PROBING      — at the doorstep; counting down 8 ticks of "is anyone home?"
+    INTRUDING    — door was unlocked AND there was no talisman; inside, hunting.
+    HYPNOTIZING  — a child is here; freeze them.
+    RETREATING   — dawn arrived; head back to the forest and despawn.
+
+Spawning is gated to the DAY -> DUSK phase boundary so a fresh cohort steps out
+of the forest every sim-evening. Number per cohort scales lightly with day so
+later cycles feel more pressured.
+
+This file uses only ``world.rng``; agent-state writes go through the agent
+itself; world-observable changes are emitted via ``world.emit``.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Optional
+
+from contracts import (
+    Agent,
+    AgentKind,
+    Event,
+    FOREST_SPAWN_POINTS,
+    MarkerClass,
+    Phase,
+    Role,
+    State,
+    World,
+)
+from agents.base import distance, move_toward, nearest
+
+
+# Sub-state strings (kept narrow to this file; not part of the global State enum).
+_WALKING = "WALKING"
+_PROBING = "PROBING"
+_INTRUDING = "INTRUDING"
+_HYPNOTIZING = "HYPNOTIZING"
+_RETREATING = "RETREATING"
+
+_CREATURE_SPEED = 1.6
+_PROBE_DURATION_TICKS = 8
+_HYPNOSIS_DURATION_TICKS = 6
+_INTRUSION_MAX_TICKS = 40
+_DOOR_PROXIMITY = 18.0
+
+
+class Creature(Agent):
+    """A forest creature. Lives in ``world.creatures``."""
+
+    def __init__(self, creature_id: str, x: float, y: float) -> None:
+        self.id = creature_id
+        self.kind = AgentKind.CREATURE
+        self.marker_class = MarkerClass.CREATURE
+        self.x = float(x)
+        self.y = float(y)
+
+        self.substate: str = _WALKING
+        self.target_building_id: Optional[str] = None
+        self.spawn_x: float = float(x)
+        self.spawn_y: float = float(y)
+        self.tick_in_substate: int = 0
+        self.victim_id: Optional[str] = None
+
+    # ------------------------------------------------------------- helpers
+    def _pick_target(self, world: World) -> Optional[str]:
+        """Prefer the nearest building without a talisman; fall back to any."""
+        unprotected = [b for b in world.buildings.values() if not b.has_talisman]
+        if unprotected:
+            target = nearest(unprotected, self.x, self.y)
+        else:
+            target = nearest(list(world.buildings.values()), self.x, self.y)
+        return target.id if target is not None else None
+
+    def _set_substate(self, new: str) -> None:
+        if new != self.substate:
+            self.substate = new
+            self.tick_in_substate = 0
+
+    # -------------------------------------------------------- main tick
+    def tick(self, world: World) -> None:
+        self.tick_in_substate += 1
+
+        # Dawn forces retreat regardless of current substate.
+        if world.time.phase == Phase.DAWN and self.substate != _RETREATING:
+            self._set_substate(_RETREATING)
+
+        if self.substate == _WALKING:
+            self._tick_walking(world)
+        elif self.substate == _PROBING:
+            self._tick_probing(world)
+        elif self.substate == _INTRUDING:
+            self._tick_intruding(world)
+        elif self.substate == _HYPNOTIZING:
+            self._tick_hypnotizing(world)
+        elif self.substate == _RETREATING:
+            self._tick_retreating(world)
+
+    # ---- substate handlers ----
+    def _tick_walking(self, world: World) -> None:
+        if self.target_building_id is None:
+            self.target_building_id = self._pick_target(world)
+            if self.target_building_id is None:
+                self._set_substate(_RETREATING)
+                return
+        target = world.buildings.get(self.target_building_id)
+        if target is None:
+            self.target_building_id = None
+            return
+        reached = move_toward(self, target.x, target.y, _CREATURE_SPEED)
+        if reached or distance(self, target) <= _DOOR_PROXIMITY:
+            self._set_substate(_PROBING)
+
+    def _tick_probing(self, world: World) -> None:
+        target = world.buildings.get(self.target_building_id or "")
+        if target is None:
+            self._set_substate(_WALKING)
+            return
+        # Probe duration elapsed — decide what happens.
+        if self.tick_in_substate >= _PROBE_DURATION_TICKS:
+            if not target.has_talisman and not target.locked:
+                world.emit(
+                    Event(
+                        tick=world.tick_count,
+                        type="creature_breach",
+                        subject=self.id,
+                        detail=f"breached {target.name}",
+                        severity="crit",
+                    )
+                )
+                self._set_substate(_INTRUDING)
+            else:
+                # Stymied. Go retreat to the woods rather than loiter.
+                self._set_substate(_RETREATING)
+
+    def _tick_intruding(self, world: World) -> None:
+        target = world.buildings.get(self.target_building_id or "")
+        if target is None:
+            self._set_substate(_RETREATING)
+            return
+        # Look for a child currently inside — uses the building's occupant set,
+        # falling back to "any nearby CHILD agent" if occupancy isn't tracked yet.
+        child = self._find_child_in(target, world)
+        if child is not None and self.victim_id != child.id:
+            self.victim_id = child.id
+            world.emit(
+                Event(
+                    tick=world.tick_count,
+                    type="hypnosis_attempt",
+                    subject=self.id,
+                    detail=f"targeting {child.id}",
+                    severity="warn",
+                )
+            )
+            self._set_substate(_HYPNOTIZING)
+            return
+        # No victim within the timeout — leave.
+        if self.tick_in_substate >= _INTRUSION_MAX_TICKS:
+            self._set_substate(_RETREATING)
+
+    def _tick_hypnotizing(self, world: World) -> None:
+        victim = world.agents.get(self.victim_id) if self.victim_id else None
+        if victim is None:
+            self._set_substate(_INTRUDING)
+            self.victim_id = None
+            return
+        # Drag the victim's state to HYPNOTIZED for the duration. We do NOT
+        # delete the agent — Agent B's character loop sees HYPNOTIZED and
+        # decides what to do next.
+        setattr(victim, "state", State.HYPNOTIZED)
+        if self.tick_in_substate >= _HYPNOSIS_DURATION_TICKS:
+            self.victim_id = None
+            self._set_substate(_RETREATING)
+
+    def _tick_retreating(self, world: World) -> None:
+        reached = move_toward(self, self.spawn_x, self.spawn_y, _CREATURE_SPEED * 1.2)
+        if reached:
+            world.emit(
+                Event(
+                    tick=world.tick_count,
+                    type="creature_retreat",
+                    subject=self.id,
+                    detail="returned to forest",
+                    severity="info",
+                )
+            )
+            # Mark for despawn — engine prunes in maybe_spawn / simulation loop.
+            self.substate = "DESPAWN"
+
+    # ------------------------------------------------------------ utility
+    @staticmethod
+    def _find_child_in(target, world: World):
+        # 1) Try occupant set first.
+        for occ_id in target.occupants:
+            agent = world.agents.get(occ_id)
+            if agent is not None and getattr(agent, "role", None) == Role.CHILD:
+                return agent
+        # 2) Fall back to spatial check (within building footprint radius).
+        # Agent B may or may not maintain occupancy yet; this keeps behaviour
+        # working in either case.
+        radius = 40.0
+        for a in world.agents.values():
+            if getattr(a, "role", None) != Role.CHILD:
+                continue
+            if distance(a, target) <= radius:
+                return a
+        return None
+
+    def to_dict(self):
+        base = super().to_dict()
+        base.update(
+            {
+                "substate": self.substate,
+                "target": self.target_building_id,
+            }
+        )
+        return base
+
+
+# ----------------------------------------------------------- spawning
+
+
+def _spawn_count_for_day(day: int, rng) -> int:
+    """1–3 creatures on early days, scaling up gently with cycle length."""
+    base = 1 + min(3, day // 3)
+    return rng.randint(base, base + 1)
+
+
+def maybe_spawn(world: World) -> None:
+    """Spawn creatures only on the DAY -> DUSK boundary.
+
+    Also despawns creatures whose retreat is complete (substate == DESPAWN).
+    """
+    # Prune retreated creatures first so the list doesn't bloat.
+    if world.creatures:
+        world.creatures[:] = [c for c in world.creatures if getattr(c, "substate", "") != "DESPAWN"]
+
+    # Detect the DAY -> DUSK edge using last_phase (managed by simulation.py).
+    if world.last_phase == Phase.DAY and world.time.phase == Phase.DUSK:
+        n = _spawn_count_for_day(world.time.day, world.rng)
+        for _ in range(n):
+            sx, sy = world.rng.choice(FOREST_SPAWN_POINTS)
+            cid = f"creature_d{world.time.day}_c{world.tick_count}_{world.rng.randint(0, 9999)}"
+            creature = Creature(cid, sx, sy)
+            world.creatures.append(creature)
+            world.emit(
+                Event(
+                    tick=world.tick_count,
+                    type="creature_spawn",
+                    subject=cid,
+                    detail=f"emerged at ({sx:.0f},{sy:.0f})",
+                    severity="warn",
+                )
+            )

--- a/from-simulation/app/agents/creatures.py
+++ b/from-simulation/app/agents/creatures.py
@@ -20,20 +20,25 @@ itself; world-observable changes are emitted via ``world.emit``.
 from __future__ import annotations
 
 import math
-from typing import Optional
+from typing import List, Optional
 
 from contracts import (
     Agent,
     AgentKind,
+    BARN_DOWN_DEFAULT_TICKS,
+    CAVE_ENTRY_XY,
     Event,
     FOREST_SPAWN_POINTS,
     MarkerClass,
+    Metric,
     Phase,
     Role,
     State,
+    Status,
     World,
 )
 from agents.base import distance, move_toward, nearest
+import legacy as _legacy
 
 
 # Sub-state strings (kept narrow to this file; not part of the global State enum).
@@ -48,6 +53,50 @@ _PROBE_DURATION_TICKS = 8
 _HYPNOSIS_DURATION_TICKS = 6
 _INTRUSION_MAX_TICKS = 40
 _DOOR_PROXIMITY = 18.0
+
+# v6 — swarmer-tier creatures: faster, shorter probe, nuisance-level rather
+# than apex. They cluster-spawn in 3-packs from the same forest point.
+_SWARMER_SPEED = 3.5
+_SWARMER_PROBE_DURATION_TICKS = 5
+_SWARMER_HYPNOSIS_DURATION_TICKS = 3
+_SWARMER_INTRUSION_MAX_TICKS = 25
+_SWARMER_DOOR_PROXIMITY = 14.0
+_SWARMER_FRACTION = 0.45
+_SWARMERS_PER_CLUSTER = 3
+
+# v7 — creature hunting. A creature in WALKING substate looks for visible
+# characters (outside any talisman building, not SHELTERING, not SLEEPING)
+# within _HUNT_RADIUS px. If found, it pivots to chase that character instead
+# of probing a building. Catching them (within 10 px) sets them INCAPACITATED
+# and the creature retreats with the kill.
+# v9.1 — danger pass: wider hunt, slightly faster chase, larger catch box.
+_HUNT_RADIUS = 150.0
+_HUNT_CATCH_RADIUS = 14.0
+_HUNT_SPEED_BONUS = 0.6   # +0.6 px/tick when actively chasing
+# v7 — cave-dwelling spawn. During NIGHT (v9.1: also DUSK), every
+# _CAVE_SPAWN_INTERVAL ticks a new creature emerges from the cave entry.
+# Probability gates how busy the cave is on any given night.
+_CAVE_SPAWN_INTERVAL_TICKS = 60    # ~2 sim-hours (v9.1)
+_CAVE_SPAWN_PROB = 0.70            # 70% of intervals during DUSK/NIGHT spawn one
+# v7 — barn is the food store. When the barn is breached, the food economy
+# collapses for BARN_DOWN_DEFAULT_TICKS ticks unless an engineer repairs it.
+_BARN_BUILDING_ID = "barn"
+
+# v8 — buildings creatures will never target. The lighthouse is a refuge /
+# narrative artefact; having creatures wander into it broke immersion. Add
+# any building here that should be off-limits regardless of talisman state.
+_OFF_LIMITS_BUILDING_IDS = frozenset({"lighthouse"})
+
+# v8 — population-aware spawn scaling. Replaces the day-only formula. The
+# more agents on the map (chars + NPCs), the bigger the cohort that arrives
+# at dusk, so the night pressure tracks the size of the population.
+# v9.1 — danger pass: steeper scaling + higher cap so a thriving town
+# actually faces a cohort large enough to threaten it.
+_SPAWN_PER_N_AGENTS = 8         # one extra creature per 8 living agents
+_SPAWN_BASE = 2                 # always at least 2 spawn each dusk
+_SPAWN_CAP = 20                 # hard cap so the map doesn't drown
+_SPAWN_DAY_BONUS_CAP = 3        # later days add up to +3 on top of population
+_HUNT_RADIUS_OVERCROWD = 240.0  # vision range expands when overcrowded
 
 
 class Creature(Agent):
@@ -66,15 +115,53 @@ class Creature(Agent):
         self.spawn_y: float = float(y)
         self.tick_in_substate: int = 0
         self.victim_id: Optional[str] = None
+        # v9.1 — stalker multi-kill loop. After catching prey we keep
+        # hunting up to ``kill_cap`` total before retreating, which lets a
+        # single rampaging creature meaningfully thin an exposed cohort
+        # instead of one-and-done. Swarmers override kill_cap=1 below.
+        self.kills_made: int = 0
+        self.kill_cap: int = 3
 
     # ------------------------------------------------------------- helpers
     def _pick_target(self, world: World) -> Optional[str]:
-        """Prefer the nearest building without a talisman; fall back to any."""
-        unprotected = [b for b in world.buildings.values() if not b.has_talisman]
-        if unprotected:
-            target = nearest(unprotected, self.x, self.y)
-        else:
-            target = nearest(list(world.buildings.values()), self.x, self.y)
+        """Prefer the nearest building without a talisman; fall back to any.
+
+        v9 — when the Director has a non-empty ``target_bias`` (cross-cycle
+        weakness map), we trade pure nearest-neighbour for weighted choice
+        so creatures preferentially seek buildings whose talismans have
+        bent in previous cycles. Off-limits and destroyed buildings are
+        always excluded.
+        """
+        def eligible(b) -> bool:
+            if b.id in _OFF_LIMITS_BUILDING_IDS:
+                return False
+            if getattr(b, "destroyed", False):
+                return False
+            return True
+
+        candidates = [b for b in world.buildings.values() if eligible(b)]
+        if not candidates:
+            return None
+        unprotected = [b for b in candidates if not b.has_talisman]
+        pool = unprotected if unprotected else candidates
+
+        # Director bias: a soft weight that prefers historically weak spots.
+        director = getattr(world, "director", None)
+        tb = getattr(director, "target_bias", {}) or {}
+        if tb:
+            # Combine inverse-distance (closer = heavier) with the bias weight.
+            weights = []
+            for b in pool:
+                d = max(1.0, distance(self, b))
+                bias = 1.0 + 3.0 * float(tb.get(b.id, 0.0))
+                weights.append((1000.0 / d) * bias)
+            try:
+                target = world.rng.choices(pool, weights=weights, k=1)[0]
+                return target.id
+            except (ValueError, IndexError):
+                pass
+
+        target = nearest(pool, self.x, self.y)
         return target.id if target is not None else None
 
     def _set_substate(self, new: str) -> None:
@@ -103,6 +190,54 @@ class Creature(Agent):
 
     # ---- substate handlers ----
     def _tick_walking(self, world: World) -> None:
+        # v7 — first, look for a visible outside character to hunt. If one is
+        # within _HUNT_RADIUS the creature drops its building plan and chases.
+        # v9.1 — after a catch, stalkers (kill_cap > 1) can keep hunting up
+        # to ``kill_cap`` total before retreating.
+        prey = _find_prey(world, self, _HUNT_RADIUS)
+        if prey is not None:
+            reached = move_toward(
+                self, float(prey.x), float(prey.y),
+                _CREATURE_SPEED + _HUNT_SPEED_BONUS,
+            )
+            # Catch! Set the prey INCAPACITATED and possibly keep hunting.
+            if reached or distance(self, prey) <= _HUNT_CATCH_RADIUS:
+                _catch_prey(world, self, prey)
+                self.kills_made += 1
+                # v9.1 — emit a rampage event the second time a stalker
+                # catches prey in one outing. Loud signal in the event log
+                # so the user can spot it.
+                if self.kills_made >= 2:
+                    world.emit(Event(
+                        tick=world.tick_count,
+                        type="creature_kill_streak",
+                        subject=self.id,
+                        detail=f"rampage: {self.kills_made} kills this hunt",
+                        severity="warn",
+                    ))
+                # If we still have kills left in the bank, fall through so
+                # the next prey search runs immediately on the next tick
+                # (we just reset hunting emission so a fresh chase logs).
+                if self.kills_made < self.kill_cap and world.time.phase in (Phase.DUSK, Phase.NIGHT):
+                    self.victim_id = None
+                    self._hunting_emitted = False
+                    # Stay in WALKING — next tick re-acquires.
+                else:
+                    self._set_substate(_RETREATING)
+            else:
+                # Emit a hunting event at most once per chase — flag via a
+                # lazy attribute so we don't spam.
+                if getattr(self, "_hunting_emitted", False) is False:
+                    self._hunting_emitted = True
+                    world.emit(Event(
+                        tick=world.tick_count,
+                        type="creature_hunting",
+                        subject=self.id,
+                        detail=f"chasing {getattr(prey, 'name', prey.id)}",
+                        severity="warn",
+                    ))
+            return
+
         if self.target_building_id is None:
             self.target_building_id = self._pick_target(world)
             if self.target_building_id is None:
@@ -133,6 +268,13 @@ class Creature(Agent):
                         severity="crit",
                     )
                 )
+                # v7 — barn breach destroys the food store.
+                if target.id == _BARN_BUILDING_ID:
+                    _destroy_barn(world, self)
+                # v8 — every unprotected breach chips at the structure.
+                _accumulate_house_damage(world, target, self.id)
+                # v9 — Director cross-cycle memory of which buildings break.
+                _bump_failure(world, target.id, 1.0)
                 self._set_substate(_INTRUDING)
             else:
                 # Stymied. Go retreat to the woods rather than loiter.
@@ -217,18 +359,662 @@ class Creature(Agent):
             {
                 "substate": self.substate,
                 "target": self.target_building_id,
+                "victim_id": self.victim_id,
+                "intent": _intent_for(self),
+                "role": "Forest creature"
+                if not isinstance(self, SwarmerCreature)
+                else "Swarmer creature",
+                "status": _substate_label(self.substate),
             }
         )
         return base
+
+
+# ---------------------------------------------------------------------------
+# v6 — SwarmerCreature: a smaller, faster nuisance-tier creature.
+#
+# Same FSM as the apex stalker, but with reduced proximity radii, faster
+# movement, and shorter probe/hypnotize windows. They spawn in clusters of
+# three from a single forest point so visually they read as a pack.
+# ---------------------------------------------------------------------------
+
+
+class SwarmerCreature(Creature):
+    """A swarmer — small, fast, packs-of-three creature.
+
+    Inherits the parent FSM. Overrides only the timing/proximity constants and
+    the speed used in the WALKING/RETREATING handlers.
+    """
+
+    def __init__(self, creature_id: str, x: float, y: float) -> None:
+        super().__init__(creature_id, x, y)
+        self.marker_class = MarkerClass.CREATURE_SWARM
+        # v9.1 — swarmers keep single-prey behaviour; multi-kill is for
+        # the apex stalker only.
+        self.kill_cap = 1
+
+    # ---- substate handlers: replicate base behaviour but with smaller radii
+    # / faster steps. We override the three handlers that depend on the
+    # tunable constants. The HYPNOTIZING handler shares the parent path but
+    # uses the swarmer hypnosis duration via the timing check below.
+    def _tick_walking(self, world: World) -> None:
+        # v7 — swarmers hunt too, and they're faster.
+        # v9.1 — swarmers keep single-prey behaviour (kill_cap=1) but the
+        # kills_made counter is still maintained for parity with stalkers.
+        prey = _find_prey(world, self, _HUNT_RADIUS)
+        if prey is not None:
+            reached = move_toward(
+                self, float(prey.x), float(prey.y),
+                _SWARMER_SPEED + _HUNT_SPEED_BONUS,
+            )
+            if reached or distance(self, prey) <= _HUNT_CATCH_RADIUS:
+                _catch_prey(world, self, prey)
+                self.kills_made += 1
+                self._set_substate(_RETREATING)
+            else:
+                if getattr(self, "_hunting_emitted", False) is False:
+                    self._hunting_emitted = True
+                    world.emit(Event(
+                        tick=world.tick_count,
+                        type="creature_hunting",
+                        subject=self.id,
+                        detail=f"swarmer chasing {getattr(prey, 'name', prey.id)}",
+                        severity="warn",
+                    ))
+            return
+        if self.target_building_id is None:
+            self.target_building_id = self._pick_target(world)
+            if self.target_building_id is None:
+                self._set_substate(_RETREATING)
+                return
+        target = world.buildings.get(self.target_building_id)
+        if target is None:
+            self.target_building_id = None
+            return
+        reached = move_toward(self, target.x, target.y, _SWARMER_SPEED)
+        if reached or distance(self, target) <= _SWARMER_DOOR_PROXIMITY:
+            self._set_substate(_PROBING)
+
+    def _tick_probing(self, world: World) -> None:
+        target = world.buildings.get(self.target_building_id or "")
+        if target is None:
+            self._set_substate(_WALKING)
+            return
+        if self.tick_in_substate >= _SWARMER_PROBE_DURATION_TICKS:
+            if not target.has_talisman and not target.locked:
+                world.emit(
+                    Event(
+                        tick=world.tick_count,
+                        type="creature_breach",
+                        subject=self.id,
+                        detail=f"swarm breached {target.name}",
+                        severity="crit",
+                    )
+                )
+                if target.id == _BARN_BUILDING_ID:
+                    _destroy_barn(world, self)
+                # v9 — Director cross-cycle memory.
+                _bump_failure(world, target.id, 0.6)  # swarmers count for less
+                self._set_substate(_INTRUDING)
+            else:
+                self._set_substate(_RETREATING)
+
+    def _tick_intruding(self, world: World) -> None:
+        target = world.buildings.get(self.target_building_id or "")
+        if target is None:
+            self._set_substate(_RETREATING)
+            return
+        child = self._find_child_in(target, world)
+        if child is not None and self.victim_id != child.id:
+            self.victim_id = child.id
+            world.emit(
+                Event(
+                    tick=world.tick_count,
+                    type="hypnosis_attempt",
+                    subject=self.id,
+                    detail=f"swarmer targeting {child.id}",
+                    severity="warn",
+                )
+            )
+            self._set_substate(_HYPNOTIZING)
+            return
+        if self.tick_in_substate >= _SWARMER_INTRUSION_MAX_TICKS:
+            self._set_substate(_RETREATING)
+
+    def _tick_hypnotizing(self, world: World) -> None:
+        victim = world.agents.get(self.victim_id) if self.victim_id else None
+        if victim is None:
+            self._set_substate(_INTRUDING)
+            self.victim_id = None
+            return
+        setattr(victim, "state", State.HYPNOTIZED)
+        if self.tick_in_substate >= _SWARMER_HYPNOSIS_DURATION_TICKS:
+            self.victim_id = None
+            self._set_substate(_RETREATING)
+
+    def _tick_retreating(self, world: World) -> None:
+        reached = move_toward(self, self.spawn_x, self.spawn_y, _SWARMER_SPEED * 1.2)
+        if reached:
+            world.emit(
+                Event(
+                    tick=world.tick_count,
+                    type="creature_retreat",
+                    subject=self.id,
+                    detail="swarmer returned to forest",
+                    severity="info",
+                )
+            )
+            self.substate = "DESPAWN"
 
 
 # ----------------------------------------------------------- spawning
 
 
 def _spawn_count_for_day(day: int, rng) -> int:
-    """1–3 creatures on early days, scaling up gently with cycle length."""
-    base = 1 + min(3, day // 3)
-    return rng.randint(base, base + 1)
+    """Legacy day-only spawn count, kept for tests.
+
+    Formula: ``2 + min(5, day // 2) + randint(0, 2)``.
+    """
+    base = 2 + min(5, day // 2)
+    return base + rng.randint(0, 2)
+
+
+def _spawn_count(world: World) -> int:
+    """v8 — population-aware dusk spawn count.
+
+    The cohort tracks the live population so a thinned-out town gets a
+    breather and a thriving town gets aggressively culled. Hard cap so the
+    map doesn't drown.
+
+    v9 — multiplied by ``world.director.spawn_rate_mult`` so the AI Director
+    can escalate (low pressure) or hold back (high pressure) the cohort.
+    """
+    rng = world.rng
+    pop = sum(
+        1 for a in world.agents.values()
+        if getattr(a, "status", Status.ACTIVE) == Status.ACTIVE
+    )
+    pop_term = pop // _SPAWN_PER_N_AGENTS
+    day_term = min(_SPAWN_DAY_BONUS_CAP, world.time.day // 3)
+    jitter = rng.randint(0, 2)
+    base = _SPAWN_BASE + pop_term + day_term + jitter
+    director = getattr(world, "director", None)
+    mult = float(getattr(director, "spawn_rate_mult", 1.0))
+    return max(_SPAWN_BASE, min(_SPAWN_CAP, int(round(base * mult))))
+
+
+# v8 — substate → human label for the dossier card.
+_SUBSTATE_LABELS = {
+    _WALKING: "Stalking",
+    _PROBING: "Probing a door",
+    _INTRUDING: "Inside",
+    _HYPNOTIZING: "Hypnotising",
+    _RETREATING: "Retreating",
+    "DESPAWN": "Gone",
+}
+
+
+def _substate_label(substate: str) -> str:
+    return _SUBSTATE_LABELS.get(substate, substate or "?")
+
+
+def _intent_for(creature: "Creature") -> str:
+    """Build a one-line dossier intent from the creature's current substate.
+
+    Looks up the target building name on demand (best-effort — if the
+    world reference isn't available, falls back to the raw id). Always
+    returns a complete sentence so the dossier UI never shows a blank.
+    """
+    target_name = creature.target_building_id or "the village"
+    # The Creature doesn't hold a world ref, but the SocketIO inspect
+    # handler enriches with target_name via `_resolve_agent`; this string
+    # is a sensible default the user can still read on its own.
+    sub = creature.substate
+    if sub == _WALKING:
+        if getattr(creature, "_hunting_emitted", False):
+            return "Chasing a survivor in the open."
+        return f"Stalking toward {target_name}."
+    if sub == _PROBING:
+        return f"Testing the doors of {target_name}."
+    if sub == _INTRUDING:
+        return f"Inside {target_name} — looking for prey."
+    if sub == _HYPNOTIZING:
+        return f"Hypnotising {creature.victim_id or 'someone'}."
+    if sub == _RETREATING:
+        return "Falling back to the treeline."
+    if sub == "DESPAWN":
+        return "Gone — back into the forest."
+    return "Watching from the dark."
+
+
+# ---------------------------------------------------------------------------
+# v7 — hunting, cave-dwelling spawn, barn destruction
+# ---------------------------------------------------------------------------
+
+
+def _find_prey(world: World, creature: "Creature", radius: float):
+    """Return the nearest huntable agent within ``radius`` px, or None.
+
+    v8 — both characters AND NPCs are huntable. Anyone caught outside
+    when the sun goes down is fair game. An agent is "outside" if their
+    state is not one of the safe-indoors states (SLEEPING / SHELTERING /
+    IRRATIONAL means tucked in a corner / already incapacitated).
+
+    Hunting only ramps during DUSK / NIGHT. During DAY characters can
+    roam freely.
+    """
+    phase = world.time.phase
+    if phase == Phase.DAY:
+        # Creatures still wander toward buildings during DAY/DAWN but they
+        # don't actively chase prey in broad daylight.
+        return None
+
+    # Expand vision when the village is overcrowded — the population
+    # pressure mechanic the user asked for. We want a thriving town to
+    # actively be culled.
+    pop = sum(
+        1 for a in world.agents.values()
+        if getattr(a, "status", Status.ACTIVE) == Status.ACTIVE
+    )
+    effective_radius = radius
+    if pop > 60:
+        effective_radius = max(radius, _HUNT_RADIUS_OVERCROWD)
+
+    SAFE_STATES = {State.SLEEPING, State.SHELTERING, State.IRRATIONAL}
+
+    best = None
+    best_d = effective_radius
+    for a in world.agents.values():
+        kind = getattr(a, "kind", None)
+        if kind not in (AgentKind.CHARACTER, AgentKind.NPC):
+            continue
+        if getattr(a, "status", Status.ACTIVE) != Status.ACTIVE:
+            continue
+        s = getattr(a, "state", None)
+        if s in SAFE_STATES:
+            continue
+        d = distance(creature, a)
+        if d < best_d:
+            best = a
+            best_d = d
+    return best
+
+
+def _catch_prey(world: World, creature: "Creature", prey) -> None:
+    """A creature has caught an agent — incapacitate or kill, and log it.
+
+    Characters survive as INCAPACITATED so the recover/resurrection paths
+    still work. NPCs aren't core to the story — they die outright, which
+    feeds the population pressure loop the user asked for.
+    """
+    kind = getattr(prey, "kind", None)
+    pid = getattr(prey, "id", "?")
+    if kind == AgentKind.NPC:
+        try:
+            prey.status = Status.DEAD
+        except Exception:
+            pass
+        world.emit(Event(
+            tick=world.tick_count,
+            type="npc_death",
+            subject=pid,
+            detail=f"caught by {creature.id} in the open after dark",
+            severity="crit",
+        ))
+        return
+    # Default: character. Status INCAPACITATED leaves the agent on the
+    # board so the existing recovery / death pipelines fire.
+    try:
+        prey.status = Status.INCAPACITATED
+    except Exception:
+        pass
+    world.emit(Event(
+        tick=world.tick_count,
+        type="incapacitated",
+        subject=pid,
+        detail=f"caught by {creature.id} in the open",
+        severity="crit",
+    ))
+
+
+def _bump_failure(world: World, building_id: str, amount: float = 1.0) -> None:
+    """v9 — record one more unit of weakness for a building (cross-cycle).
+
+    Routes through the Director module when available so the legacy field
+    is initialised on demand; falls back to a direct write on the legacy
+    dict so a missing director module (e.g. in a unit test) doesn't break
+    persistence.
+    """
+    try:
+        from agents import director as _director
+        _director.bump_talisman_failure(world, building_id, amount)
+        return
+    except Exception:
+        pass
+    legacy = getattr(world, "legacy", None)
+    if legacy is None:
+        return
+    tfc = getattr(legacy, "talisman_failure_count", None)
+    if tfc is None:
+        return
+    tfc[str(building_id)] = float(tfc.get(str(building_id), 0.0)) + float(amount)
+
+
+def _destroy_barn(world: World, creature: "Creature") -> None:
+    """Mark the barn destroyed. Food regen collapses until repaired or timer expires.
+
+    Idempotent — if the barn is already down, this is a no-op so a second
+    breach doesn't extend the timer indefinitely.
+    """
+    if world.tick_count < int(getattr(world, "barn_destroyed_until_tick", 0)):
+        return
+    world.barn_destroyed_until_tick = world.tick_count + BARN_DOWN_DEFAULT_TICKS
+    world.barn_repair_progress = 0.0
+    world.emit(Event(
+        tick=world.tick_count,
+        type="barn_destroyed",
+        subject=creature.id,
+        detail="the barn is broken — the food store is gone",
+        severity="crit",
+    ))
+    try:
+        _legacy.record(world, "barn_destroyed")
+    except Exception:
+        pass
+    # Mark the barn building as locked so a second creature doesn't loiter on
+    # it the same tick (engine treats locked-but-no-talisman as resistant).
+    barn = world.buildings.get(_BARN_BUILDING_ID)
+    if barn is not None:
+        try:
+            barn.cooling_off_until_tick = world.barn_destroyed_until_tick
+        except Exception:
+            pass
+
+
+def tick_cave_spawn(world: World) -> None:
+    """v7 — at NIGHT (v9.1: also DUSK), periodically spawn a stalker from
+    the cave entry.
+
+    Cap the count so the cave doesn't dump unlimited creatures; only spawn
+    if the current live-creature population is below a soft ceiling. The
+    cave is the second front: while creatures from the forest probe
+    buildings, cave spawns try to ambush characters in the centre of the
+    village.
+    """
+    if world.time.phase not in (Phase.DUSK, Phase.NIGHT):
+        return
+    # v9.1 — raised from 8 to 14 so the cave can keep adding bodies even
+    # when the dusk cohort has already landed.
+    if len(world.creatures) >= 14:
+        return
+    last = int(getattr(world, "_cave_spawn_last_tick", -10_000))
+    if world.tick_count - last < _CAVE_SPAWN_INTERVAL_TICKS:
+        return
+    if world.rng.random() >= _CAVE_SPAWN_PROB:
+        # Still bump the timer so we re-roll later, not next tick.
+        world._cave_spawn_last_tick = world.tick_count
+        return
+    world._cave_spawn_last_tick = world.tick_count
+    cx, cy = CAVE_ENTRY_XY
+    # Small jitter so successive spawns don't stack.
+    jx = cx + world.rng.uniform(-8, 8)
+    jy = cy + world.rng.uniform(-8, 8)
+    cid = f"cave_d{world.time.day}_c{world.tick_count}_{world.rng.randint(0, 9999)}"
+    creature = Creature(cid, jx, jy)
+    # Skip the normal "pick a building" — cave creatures wander into town
+    # looking for prey. They'll still probe a building if no prey is visible
+    # within _HUNT_RADIUS once they reach the village edge.
+    creature.target_building_id = None
+    world.creatures.append(creature)
+    world.emit(Event(
+        tick=world.tick_count,
+        type="creature_cave_spawn",
+        subject=cid,
+        detail=f"something climbed out of the cave at ({cx:.0f},{cy:.0f})",
+        severity="warn",
+    ))
+
+
+def tick_night_wave(world: World) -> None:
+    """v9.1 — sustained NIGHT pressure.
+
+    The DAY→DUSK cohort can be wiped out, retreat after their kills, or
+    miss the town entirely; without something else, NIGHT goes quiet and
+    the village survives on inertia. This fires exactly once per simulated
+    night — at the midnight slot (``hour < 3``) — and drops half-strength
+    cohort of stalkers from the same forest spawn points. Director-
+    modulated through ``_spawn_count``, so a thriving town gets a juicier
+    wave automatically.
+    """
+    if world.time.phase != Phase.NIGHT:
+        return
+    # Midnight window: hours 0-2 sim-time. ``SimTime.hour`` is 0-23.
+    if world.time.hour >= 3:
+        return
+    # Fire at most once per sim-day. ``_night_wave_day`` is a lazy
+    # per-world cursor so we don't carry state outside of ``world``.
+    last_day = getattr(world, "_night_wave_day", None)
+    if last_day == world.time.day:
+        return
+    world._night_wave_day = world.time.day  # type: ignore[attr-defined]
+
+    cohort = max(2, int(round(_spawn_count(world) * 0.5)))
+    rng = world.rng
+    ids: List[str] = []
+    for _ in range(cohort):
+        sx, sy = rng.choice(FOREST_SPAWN_POINTS)
+        cid = (
+            f"nightwave_d{world.time.day}_c{world.tick_count}_"
+            f"{rng.randint(0, 9999)}"
+        )
+        world.creatures.append(Creature(cid, sx, sy))
+        ids.append(cid)
+    world.emit(Event(
+        tick=world.tick_count,
+        type="creature_night_wave",
+        subject=ids[0] if ids else "world",
+        detail=f"a second wave of {cohort} stepped out of the trees at midnight",
+        severity="warn",
+    ))
+    if world.telemetry is not None:
+        try:
+            world.telemetry.counter_inc(Metric.CREATURES_NIGHT_WAVES_TOTAL, 1.0)
+        except Exception:
+            pass
+
+
+def tick_barn_repair(world: World) -> None:
+    """v7 — accumulate repair progress while engineers REPAIR near the barn.
+
+    Once progress reaches BARN_REPAIR_THRESHOLD, clear the destroyed flag and
+    emit ``barn_rebuilt``.
+    """
+    from contracts import BARN_REPAIR_PER_TICK, BARN_REPAIR_THRESHOLD
+    if int(getattr(world, "barn_destroyed_until_tick", 0)) <= world.tick_count:
+        # Either never broken or already cleared / timed out.
+        if int(getattr(world, "barn_destroyed_until_tick", 0)) > 0 \
+                and world.tick_count >= world.barn_destroyed_until_tick \
+                and world.barn_repair_progress < BARN_REPAIR_THRESHOLD:
+            # Timer-based recovery: log a less heroic rebuild.
+            world.barn_destroyed_until_tick = 0
+            world.barn_repair_progress = 0.0
+            world.emit(Event(
+                tick=world.tick_count,
+                type="barn_rebuilt",
+                subject="world",
+                detail="they patched the barn back together in time",
+                severity="info",
+            ))
+        return
+    barn = world.buildings.get(_BARN_BUILDING_ID)
+    if barn is None:
+        return
+    # Look for ENGINEER characters in REPAIRING state near the barn.
+    repairing = 0
+    for a in world.agents.values():
+        if getattr(a, "kind", None) != AgentKind.CHARACTER:
+            continue
+        if getattr(a, "state", None) != State.REPAIRING:
+            continue
+        if getattr(a, "role", None) != Role.ENGINEER:
+            continue
+        if distance(a, barn) <= 30.0:
+            repairing += 1
+    if repairing > 0:
+        world.barn_repair_progress += BARN_REPAIR_PER_TICK * repairing
+        if world.barn_repair_progress >= BARN_REPAIR_THRESHOLD:
+            world.barn_destroyed_until_tick = 0
+            world.barn_repair_progress = 0.0
+            world.emit(Event(
+                tick=world.tick_count,
+                type="barn_rebuilt",
+                subject="world",
+                detail="the engineer fixed the barn",
+                severity="info",
+            ))
+
+
+# ---------------------------------------------------------------------------
+# v8 — house destruction + rebuild + talisman crack
+# ---------------------------------------------------------------------------
+
+
+def _accumulate_house_damage(world: World, target, attacker_id: str) -> None:
+    """Charge one breach of damage to a building. At threshold → destroyed.
+
+    The barn has its own destruction mechanic; we deliberately don't
+    double-book it here. Special buildings without a residential role
+    (choosing stone, pool, abandoned bus, lighthouse) are ignored since
+    creatures shouldn't have been able to target them anyway.
+    """
+    from contracts import HOUSE_DESTRUCTION_THRESHOLD
+
+    if target.id == _BARN_BUILDING_ID:
+        return
+    if target.id in _OFF_LIMITS_BUILDING_IDS:
+        return
+    if target.footprint <= 0:
+        # Not a real shelter (stones, pools, etc.) — nothing to destroy.
+        return
+
+    target.damage = int(getattr(target, "damage", 0)) + 1
+    if not getattr(target, "destroyed", False) \
+            and target.damage >= HOUSE_DESTRUCTION_THRESHOLD:
+        target.destroyed = True
+        target.rebuild_progress = 0.0
+        # Evict anyone notionally inside so they aren't ghost-occupants.
+        if target.occupants:
+            target.occupants.clear()
+        # Talisman is also gone — rebuilt houses come back bare.
+        target.has_talisman = False
+        world.emit(Event(
+            tick=world.tick_count,
+            type="house_destroyed",
+            subject=attacker_id,
+            detail=f"{target.name} has been torn apart",
+            severity="crit",
+        ))
+
+
+def tick_talisman_crack(world: World) -> None:
+    """v8 — chance per tick that an occupant cracks and breaks the talisman.
+
+    Mechanic: a building with a talisman, with at least one occupant whose
+    sanity is low AND fear is high, may have its talisman fail. When it
+    does we emit ``talisman_cracked`` and clear ``has_talisman``. The
+    building is then full-risk until rebuilt and re-warded.
+    """
+    from contracts import (
+        TALISMAN_CRACK_FEAR,
+        TALISMAN_CRACK_PROB,
+        TALISMAN_CRACK_SANITY,
+    )
+
+    rng = world.rng
+    # Only check during NIGHT — that's when fear/sanity bottoms out and the
+    # narrative beat (someone snapping in the dark) makes sense.
+    if world.time.phase != Phase.NIGHT:
+        return
+
+    for b in world.buildings.values():
+        if not b.has_talisman or getattr(b, "destroyed", False):
+            continue
+        if not b.occupants:
+            continue
+        # Find a cracking occupant.
+        cracker = None
+        for occ_id in b.occupants:
+            agent = world.agents.get(occ_id)
+            if agent is None:
+                continue
+            sanity = float(getattr(agent, "sanity", 1.0))
+            fear = float(getattr(agent, "fear", 0.0))
+            if sanity <= TALISMAN_CRACK_SANITY and fear >= TALISMAN_CRACK_FEAR:
+                cracker = agent
+                break
+        if cracker is None:
+            continue
+        if rng.random() >= TALISMAN_CRACK_PROB:
+            continue
+        # Crack — the talisman fails permanently for this building.
+        b.has_talisman = False
+        world.emit(Event(
+            tick=world.tick_count,
+            type="talisman_cracked",
+            subject=getattr(cracker, "id", b.id),
+            detail=(
+                f"{getattr(cracker, 'name', cracker.id)} cracked — the "
+                f"talisman at {b.name} no longer holds"
+            ),
+            severity="crit",
+        ))
+
+
+def tick_house_repair(world: World) -> None:
+    """v8 — survivors rebuild destroyed houses over time.
+
+    Any character in REPAIRING state within 30 px of a destroyed house
+    contributes HOUSE_REBUILD_PER_TICK toward progress. Multiple workers
+    stack. At HOUSE_REBUILD_THRESHOLD the house is rebuilt — flags clear,
+    damage zeros out, but the talisman does NOT come back (survivors
+    have to find one).
+    """
+    from contracts import HOUSE_REBUILD_PER_TICK, HOUSE_REBUILD_THRESHOLD
+
+    destroyed_houses = [
+        b for b in world.buildings.values()
+        if getattr(b, "destroyed", False) and b.id != _BARN_BUILDING_ID
+    ]
+    if not destroyed_houses:
+        return
+
+    for b in destroyed_houses:
+        repairing = 0
+        for a in world.agents.values():
+            if getattr(a, "kind", None) != AgentKind.CHARACTER:
+                continue
+            if getattr(a, "state", None) != State.REPAIRING:
+                continue
+            if distance(a, b) <= 30.0:
+                repairing += 1
+        if repairing == 0:
+            continue
+        b.rebuild_progress = float(getattr(b, "rebuild_progress", 0.0)) \
+            + HOUSE_REBUILD_PER_TICK * repairing
+        if b.rebuild_progress >= HOUSE_REBUILD_THRESHOLD:
+            b.destroyed = False
+            b.damage = 0
+            b.rebuild_progress = 0.0
+            # Talisman stays off — the rebuilt frame doesn't carry the
+            # original ward. has_talisman remains False until something
+            # else (story event) restores it.
+            world.emit(Event(
+                tick=world.tick_count,
+                type="house_rebuilt",
+                subject="world",
+                detail=f"{b.name} has been rebuilt — but it stands without a talisman",
+                severity="info",
+            ))
 
 
 def maybe_spawn(world: World) -> None:
@@ -242,10 +1028,57 @@ def maybe_spawn(world: World) -> None:
 
     # Detect the DAY -> DUSK edge using last_phase (managed by simulation.py).
     if world.last_phase == Phase.DAY and world.time.phase == Phase.DUSK:
-        n = _spawn_count_for_day(world.time.day, world.rng)
-        for _ in range(n):
-            sx, sy = world.rng.choice(FOREST_SPAWN_POINTS)
-            cid = f"creature_d{world.time.day}_c{world.tick_count}_{world.rng.randint(0, 9999)}"
+        rng = world.rng
+        total = _spawn_count(world)
+        spawned = 0
+        # v6 — roughly _SWARMER_FRACTION of the batch arrives as swarmer
+        # clusters. Each cluster is a 3-pack from one spawn point.
+        n_swarm_clusters = 0
+        n_swarmers_target = int(round(total * _SWARMER_FRACTION))
+        # Ensure at least 1 cluster fires whenever the desired count rounds up
+        # to >= half a cluster — otherwise swarms only appear on dusks with 9
+        # spawning, which is rare. Half-cluster threshold = 2 swarmers.
+        if n_swarmers_target >= max(2, _SWARMERS_PER_CLUSTER // 2):
+            n_swarm_clusters = max(1, n_swarmers_target // _SWARMERS_PER_CLUSTER)
+        for _ in range(n_swarm_clusters):
+            sx, sy = rng.choice(FOREST_SPAWN_POINTS)
+            cluster_ids = []
+            for _i in range(_SWARMERS_PER_CLUSTER):
+                # Small jitter so the three swarmers don't render on the same
+                # pixel.
+                jx = sx + rng.uniform(-6, 6)
+                jy = sy + rng.uniform(-6, 6)
+                cid = (
+                    f"swarmer_d{world.time.day}_c{world.tick_count}_"
+                    f"{rng.randint(0, 9999)}"
+                )
+                creature = SwarmerCreature(cid, jx, jy)
+                world.creatures.append(creature)
+                cluster_ids.append(cid)
+                spawned += 1
+            # One event per cluster — keeps the journal readable when the
+            # batch is large.
+            world.emit(
+                Event(
+                    tick=world.tick_count,
+                    type="creature_swarm_spawn",
+                    subject=cluster_ids[0],
+                    detail=(
+                        f"a pack of {_SWARMERS_PER_CLUSTER} emerged near "
+                        f"({sx:.0f},{sy:.0f})"
+                    ),
+                    severity="warn",
+                )
+            )
+
+        # Remaining stalkers, scattered across spawn points.
+        remaining = max(0, total - spawned)
+        for _ in range(remaining):
+            sx, sy = rng.choice(FOREST_SPAWN_POINTS)
+            cid = (
+                f"creature_d{world.time.day}_c{world.tick_count}_"
+                f"{rng.randint(0, 9999)}"
+            )
             creature = Creature(cid, sx, sy)
             world.creatures.append(creature)
             world.emit(

--- a/from-simulation/app/agents/cult.py
+++ b/from-simulation/app/agents/cult.py
@@ -1,0 +1,341 @@
+"""
+v8 — Cult faction.
+
+Story: when an NPC loses too many friends or family to creatures, paranormal
+breaks, or starvation, they crack the other way — they conclude that the
+village has invited the dark and start working *with* it. Cultists are still
+NPCs (same kind, same dot), but their ``cult_state`` flag flips to
+``CONVERTED`` and they:
+
+  * Refuse to shelter at night — they roam the village instead.
+  * Pulse fear into nearby townfolk, accelerating breaks.
+  * Recruit other low-sanity NPCs in the same surname / friend graph.
+  * If their numbers cross a critical mass, they "perform the sacrifice"
+    at NIGHT, which forces a village wipe — the same loop reset as Yellow
+    Man wins.
+
+Counter: if survivors kill or break enough cultists, the cult is suppressed
+and the village endures.
+
+Ownership: this module is purely additive. It writes ``cult_state`` /
+``cult_pressure`` on NPCs and reads/writes nothing else outside of emitting
+events. It runs after agents tick so the conversion view is up-to-date.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List
+
+from contracts import AgentKind, Event, Phase, State, Status, World
+
+
+# ---------------------------------------------------------------- tunables
+
+# How much "cult_pressure" each kind of loss adds when it happens to a
+# friend or family member of the NPC. Once cult_pressure crosses the
+# CONVERT threshold the NPC turns. SUSPECTED is just a UI / dossier flag.
+_PRESSURE_FAMILY_DEATH = 1.0
+_PRESSURE_FAMILY_BREAK = 0.5
+_PRESSURE_FRIEND_DEATH = 0.6
+_PRESSURE_FRIEND_BREAK = 0.3
+# Sanity-floor bias — an already-shaken NPC converts at lower thresholds.
+_LOW_SANITY_MULT = 1.6
+_LOW_SANITY_THRESHOLD = 35.0
+
+_SUSPECTED_THRESHOLD = 1.0
+_CONVERT_THRESHOLD = 2.0
+
+# Cultist behaviour tunables.
+_CULTIST_FEAR_RADIUS = 90.0
+_CULTIST_FEAR_PER_TICK = 0.25      # added to nearby non-cultists each tick
+_CULTIST_SPREAD_PROB = 0.0008      # tick-chance to recruit a vulnerable kin
+
+# Sacrifice / endgame.
+_SACRIFICE_THRESHOLD = 8           # number of CONVERTED to trigger the call
+_SACRIFICE_DEADLINE_TICKS = 800    # ticks the village has to suppress them
+_SACRIFICE_MIN_TICKS_BEFORE_WIPE = 600
+
+
+# ---------------------------------------------------------------- helpers
+
+
+def _friend_ids(world: World, npc_id: str) -> List[str]:
+    """NPCs / chars whose trust score with ``npc_id`` is ≥ 0.65."""
+    trust_map = getattr(world, "trust", {}) or {}
+    out: List[str] = []
+    seen = set()
+    for (a, b), s in trust_map.items():
+        if a == npc_id and b not in seen:
+            try:
+                if float(s) >= 0.65:
+                    out.append(b)
+                    seen.add(b)
+            except Exception:
+                pass
+        elif b == npc_id and a not in seen:
+            try:
+                if float(s) >= 0.65:
+                    out.append(a)
+                    seen.add(a)
+            except Exception:
+                pass
+    return out
+
+
+def _family_ids(world: World, npc) -> List[str]:
+    """Living NPCs sharing the surname (excluding the npc itself)."""
+    surname = getattr(npc, "surname", None)
+    if not surname:
+        return []
+    out = []
+    for a in world.agents.values():
+        if getattr(a, "kind", None) != AgentKind.NPC:
+            continue
+        if a.id == npc.id:
+            continue
+        if getattr(a, "status", Status.ACTIVE) != Status.ACTIVE:
+            continue
+        if getattr(a, "surname", None) == surname:
+            out.append(a.id)
+    return out
+
+
+def _is_cultist(agent) -> bool:
+    return getattr(agent, "cult_state", "NONE") == "CONVERTED"
+
+
+# ---------------------------------------------------------------- public
+
+
+def on_loss(world: World, victim_id: str, loss_kind: str) -> None:
+    """Bump cult_pressure on every NPC who is family / friend of the victim.
+
+    ``loss_kind`` is either ``"death"`` (creature kill, npc_death, char_death)
+    or ``"break"`` (paranormal_break / sanity_break). Called from event
+    consumers — kept idempotent per (victim, kind) by tagging the victim with
+    ``_cult_loss_seen`` so the same death doesn't double-bump.
+    """
+    victim = world.agents.get(victim_id) if hasattr(world, "agents") else None
+    seen_key = f"_cult_loss_seen_{loss_kind}"
+    if victim is not None:
+        if getattr(victim, seen_key, False):
+            return
+        setattr(victim, seen_key, True)
+
+    # Friends of the victim across the whole agents pool.
+    friends = set(_friend_ids(world, victim_id))
+    # Family of the victim (NPCs with the same surname).
+    family: List[str] = []
+    if victim is not None:
+        surname = getattr(victim, "surname", None)
+        if surname:
+            for a in world.agents.values():
+                if getattr(a, "surname", None) == surname and a.id != victim_id:
+                    family.append(a.id)
+
+    for kin_id in set(family) | friends:
+        kin = world.agents.get(kin_id)
+        if kin is None:
+            continue
+        if getattr(kin, "kind", None) != AgentKind.NPC:
+            continue
+        if getattr(kin, "status", Status.ACTIVE) != Status.ACTIVE:
+            continue
+        if _is_cultist(kin):
+            continue
+
+        if kin_id in family:
+            delta = (
+                _PRESSURE_FAMILY_DEATH if loss_kind == "death"
+                else _PRESSURE_FAMILY_BREAK
+            )
+        else:
+            delta = (
+                _PRESSURE_FRIEND_DEATH if loss_kind == "death"
+                else _PRESSURE_FRIEND_BREAK
+            )
+
+        if float(getattr(kin, "sanity", 100.0)) < _LOW_SANITY_THRESHOLD:
+            delta *= _LOW_SANITY_MULT
+
+        kin.cult_pressure = float(getattr(kin, "cult_pressure", 0.0)) + delta
+
+        prev_state = getattr(kin, "cult_state", "NONE")
+        if kin.cult_pressure >= _CONVERT_THRESHOLD and prev_state != "CONVERTED":
+            kin.cult_state = "CONVERTED"
+            kin.cult_converted_at_tick = world.tick_count
+            display = (
+                f"{kin.name} {kin.surname}".strip() if getattr(kin, "surname", None)
+                else getattr(kin, "name", kin.id)
+            )
+            world.emit(Event(
+                tick=world.tick_count,
+                type="cult_joined",
+                subject=kin.id,
+                detail=f"{display} joined the cult — grief turned outward",
+                severity="crit",
+            ))
+        elif kin.cult_pressure >= _SUSPECTED_THRESHOLD and prev_state == "NONE":
+            kin.cult_state = "SUSPECTED"
+
+
+def _broadcast_fear(world: World, cultist) -> None:
+    """A cultist pulses fear into nearby townfolk + chars."""
+    cx, cy = cultist.x, cultist.y
+    r2 = _CULTIST_FEAR_RADIUS * _CULTIST_FEAR_RADIUS
+    for a in world.agents.values():
+        if a.id == cultist.id:
+            continue
+        if _is_cultist(a):
+            continue
+        if getattr(a, "status", Status.ACTIVE) != Status.ACTIVE:
+            continue
+        dx = a.x - cx
+        dy = a.y - cy
+        if dx * dx + dy * dy <= r2:
+            cur = float(getattr(a, "fear", 0.0))
+            setattr(a, "fear", min(100.0, cur + _CULTIST_FEAR_PER_TICK))
+
+
+def _maybe_recruit(world: World, cultist) -> None:
+    """A cultist tries to convert one shaky kin per tick at a low chance."""
+    if world.rng.random() >= _CULTIST_SPREAD_PROB:
+        return
+    candidates = []
+    surname = getattr(cultist, "surname", None)
+    for a in world.agents.values():
+        if a.id == cultist.id:
+            continue
+        if getattr(a, "kind", None) != AgentKind.NPC:
+            continue
+        if getattr(a, "status", Status.ACTIVE) != Status.ACTIVE:
+            continue
+        if _is_cultist(a):
+            continue
+        # Family or low-sanity friend.
+        same_family = surname and getattr(a, "surname", None) == surname
+        sanity = float(getattr(a, "sanity", 100.0))
+        if same_family or sanity < _LOW_SANITY_THRESHOLD:
+            candidates.append(a)
+    if not candidates:
+        return
+    target = world.rng.choice(candidates)
+    target.cult_pressure = float(getattr(target, "cult_pressure", 0.0)) \
+        + _PRESSURE_FAMILY_DEATH
+    prev = getattr(target, "cult_state", "NONE")
+    if target.cult_pressure >= _CONVERT_THRESHOLD and prev != "CONVERTED":
+        target.cult_state = "CONVERTED"
+        target.cult_converted_at_tick = world.tick_count
+        display = (
+            f"{target.name} {target.surname}".strip()
+            if getattr(target, "surname", None)
+            else getattr(target, "name", target.id)
+        )
+        world.emit(Event(
+            tick=world.tick_count,
+            type="cult_recruited",
+            subject=target.id,
+            detail=f"{display} was whispered into the cult",
+            severity="crit",
+        ))
+
+
+def _check_sacrifice(world: World) -> None:
+    """If cult reaches critical mass, set a sacrifice deadline.
+
+    The sacrifice is announced via ``cult_sacrifice_called`` and stored on
+    ``world._cult_sacrifice_deadline``. If the deadline ticks past while
+    the cult still has critical mass at NIGHT, a ``village_wipe`` is fired
+    and Agent A's reset path bulldozes the cycle.
+    """
+    cult_count = sum(1 for a in world.agents.values() if _is_cultist(a))
+    deadline = int(getattr(world, "_cult_sacrifice_deadline", 0))
+
+    if cult_count >= _SACRIFICE_THRESHOLD and deadline == 0:
+        world._cult_sacrifice_deadline = world.tick_count + _SACRIFICE_DEADLINE_TICKS
+        world.emit(Event(
+            tick=world.tick_count,
+            type="cult_sacrifice_called",
+            subject="world",
+            detail=(
+                f"the cult has {cult_count} hands — they speak of feeding the dark"
+            ),
+            severity="crit",
+        ))
+        return
+
+    if deadline and cult_count < _SACRIFICE_THRESHOLD:
+        # The town beat them back below critical mass — call it off.
+        world._cult_sacrifice_deadline = 0
+        world.emit(Event(
+            tick=world.tick_count,
+            type="cult_suppressed",
+            subject="world",
+            detail="the cult fell apart — the sacrifice cannot happen",
+            severity="info",
+        ))
+        return
+
+    # Deadline reached + still critical mass + it's NIGHT → end the cycle.
+    if (
+        deadline
+        and world.tick_count >= deadline
+        and world.time.phase == Phase.NIGHT
+        and cult_count >= _SACRIFICE_THRESHOLD
+        and world.tick_count >= _SACRIFICE_MIN_TICKS_BEFORE_WIPE
+    ):
+        world._cult_sacrifice_deadline = 0
+        world.emit(Event(
+            tick=world.tick_count,
+            type="cult_sacrifice",
+            subject="world",
+            detail="the cult dragged the village to the dark — the cycle resets",
+            severity="crit",
+        ))
+        world.pending_reset = True
+
+
+def tick(world: World) -> None:
+    """Engine hook — call once per tick AFTER agents have ticked.
+
+    Walks the cultist roster, broadcasts fear, occasionally recruits,
+    forces wandering at night, and checks the sacrifice condition.
+    """
+    if not hasattr(world, "agents"):
+        return
+
+    # Phase 1 — every cultist does their thing.
+    cultists = [a for a in world.agents.values() if _is_cultist(a)]
+    if cultists:
+        for c in cultists:
+            # Force their state to WANDERING at night so they roam instead
+            # of sheltering at home (which is what loyalty would do).
+            if world.time.phase in (Phase.DUSK, Phase.NIGHT):
+                cur = getattr(c, "state", None)
+                if cur in (State.SHELTERING, State.SLEEPING):
+                    setattr(c, "state", State.WANDERING)
+            _broadcast_fear(world, c)
+            _maybe_recruit(world, c)
+
+    # Phase 2 — sacrifice / endgame check.
+    _check_sacrifice(world)
+
+
+def consume_events_for_pressure(world: World, events) -> None:
+    """Scan a batch of events for deaths + breaks and feed them to ``on_loss``.
+
+    Hooked from simulation.py per tick on the world's event buffer.
+    """
+    if not events:
+        return
+    for ev in events:
+        if not ev:
+            continue
+        et = getattr(ev, "type", None) or (ev.get("type") if isinstance(ev, dict) else None)
+        subj = getattr(ev, "subject", None) or (ev.get("subject") if isinstance(ev, dict) else None)
+        if not subj or not et:
+            continue
+        if et in ("npc_death", "char_death", "incapacitated"):
+            on_loss(world, subj, "death")
+        elif et in ("paranormal_break", "npc_sanity_break"):
+            on_loss(world, subj, "break")

--- a/from-simulation/app/agents/director.py
+++ b/from-simulation/app/agents/director.py
@@ -1,0 +1,327 @@
+"""
+v9 — The AI Director.
+
+A single world-level tension monitor that watches the village's recent
+state and tunes three knobs the antagonist systems read each tick:
+
+    spawn_rate_mult         creature spawn count multiplier
+    yellow_appearance_bias  added to ``cfg.yellow_imposter_prob``
+    target_bias             softmax over ``legacy.building_breach_marks``
+                            and ``legacy.talisman_failure_count`` —
+                            historically weak buildings draw more spawns.
+
+Inputs are all already on ``world``: avg fear, avg sanity, food-supply
+ratio, recent breach rate, and the yellow deadline. EWMA-smoothed so
+pressure doesn't oscillate per tick.
+
+This module is deliberately stateless across runs — the cross-cycle
+learning lives in ``world.legacy`` (which already survives wipes). The
+Director just reads those numbers.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+from typing import Dict
+
+from contracts import (
+    AgentKind,
+    Metric,
+    Phase,
+    Status,
+    World,
+    YellowMode,
+)
+
+
+# ---------------------------------------------------------------------------
+# Tunables
+# ---------------------------------------------------------------------------
+
+
+_EWMA_ALPHA = 0.2                 # weight on the newest reading
+_RECALC_EVERY_TICKS = 30          # ~15 sim-seconds at default tick_hz
+_BREACH_WINDOW_TICKS = 1200       # ~10 sim-minutes
+_PRESSURE_LOW = 0.30
+_PRESSURE_HIGH = 0.70
+_SPAWN_MULT_ESCALATE = 1.6
+_SPAWN_MULT_DEESCALATE = 0.6
+# v9.1 — population-stress cap. Once population crosses ~1.5× npc_floor, we
+# start subtracting this from the raw pressure score so a thriving town
+# actively drives spawn / yellow bias upward.
+_POP_RELIEF_CAP = 0.4
+_YELLOW_BIAS_ESCALATE = 0.10
+_YELLOW_BIAS_DEESCALATE = -0.10
+_TARGET_BIAS_TEMPERATURE = 1.5
+_CLEAN_NIGHT_DECAY = 0.5          # talisman_failure_count decay on a clean night
+
+
+@dataclass
+class DirectorState:
+    pressure: float = 0.5
+    spawn_rate_mult: float = 1.0
+    yellow_appearance_bias: float = 0.0
+    target_bias: Dict[str, float] = field(default_factory=dict)
+    last_recalc_tick: int = -10**9
+    last_clean_check_tick: int = -10**9
+    last_known_breaches: int = 0
+    # v9.1 — population-stress signal. Climbs as the town grows past
+    # ~1.5× npc_floor; subtracted from raw pressure so the Director's
+    # spawn / yellow knobs escalate as the village thrives.
+    pop_relief: float = 0.0
+
+
+# ---------------------------------------------------------------------------
+# Pressure model
+# ---------------------------------------------------------------------------
+
+
+def _recent_breaches(world: World) -> int:
+    """Count creature_breach events in the last _BREACH_WINDOW_TICKS."""
+    events = getattr(world, "events", None)
+    if events is None:
+        return 0
+    cutoff = world.tick_count - _BREACH_WINDOW_TICKS
+    n = 0
+    for e in events:
+        if e.tick < cutoff:
+            continue
+        if e.type == "creature_breach":
+            n += 1
+    return n
+
+
+def _agent_drives(world: World) -> tuple[float, float, int]:
+    """Return (avg_fear, avg_sanity, live_pop) over live characters/NPCs.
+
+    Returns (0, 100, 0) if no agents exist (fresh boot, mid-wipe).
+    """
+    fears: list[float] = []
+    sanities: list[float] = []
+    for a in world.agents.values():
+        if getattr(a, "status", Status.ACTIVE) != Status.ACTIVE:
+            continue
+        if getattr(a, "kind", None) not in (AgentKind.CHARACTER, AgentKind.NPC):
+            continue
+        fears.append(float(getattr(a, "fear", 0.0)))
+        sanities.append(float(getattr(a, "sanity", 100.0)))
+    if not fears:
+        return 0.0, 100.0, 0
+    return sum(fears) / len(fears), sum(sanities) / len(sanities), len(fears)
+
+
+def _compute_pressure(world: World) -> tuple[float, float]:
+    """Weighted sum of normalized stressors. Returns ``(pressure, pop_relief)``.
+
+    ``pop_relief`` is a non-negative signal — when the town grows past
+    ~1.5× ``npc_floor`` it climbs (capped at ``_POP_RELIEF_CAP``) and gets
+    subtracted from the raw pressure so the Director escalates spawn /
+    yellow bias as the village thrives. v9.1.
+    """
+    fear_avg, sanity_avg, pop = _agent_drives(world)
+    food_ratio = float(getattr(world, "food_supply", 100.0)) / max(
+        1.0, float(getattr(world, "food_capacity", 200.0))
+    )
+    breaches = _recent_breaches(world)
+    deadline_in = 0
+    ya = world.yellow_active
+    if ya.mode != YellowMode.DORMANT and ya.deadline_tick > 0:
+        deadline_in = max(0, ya.deadline_tick - world.tick_count)
+    # Normalize each input to [0, 1] where 1 = max stress.
+    fear_norm = min(1.0, fear_avg / 100.0)
+    sanity_stress = max(0.0, 1.0 - sanity_avg / 100.0)
+    food_stress = max(0.0, 1.0 - food_ratio)
+    breach_stress = min(1.0, breaches / 8.0)  # 8 breaches in window = max
+    deadline_stress = 0.0
+    if deadline_in > 0:
+        # Closer deadline = higher stress. Use ya.deadline_tick - started_at_tick
+        # so we don't divide by 0; fall back to a sane denominator.
+        span = max(1, world.config.yellow_deadline_ticks)
+        deadline_stress = 1.0 - (deadline_in / span)
+    # Weighted sum (weights sum to 1).
+    raw = (
+        0.30 * fear_norm
+        + 0.20 * sanity_stress
+        + 0.20 * food_stress
+        + 0.20 * breach_stress
+        + 0.10 * deadline_stress
+    )
+    # v9.1 — population-stress feedback. Anything above 1.5× npc_floor
+    # bleeds pressure downward, which causes the banded response to
+    # escalate spawns. The user wants the town's success to be its own
+    # problem rather than reducing arrivals.
+    npc_floor = max(1, int(getattr(world.config, "npc_floor", 18)))
+    pop_relief = max(
+        0.0,
+        min(_POP_RELIEF_CAP, (pop - npc_floor * 1.5) / (npc_floor * 2.0)),
+    )
+    raw = raw - pop_relief
+    return max(0.0, min(1.0, raw)), pop_relief
+
+
+def _softmax_target_bias(world: World) -> Dict[str, float]:
+    """Softmax over cross-cycle weakness signals."""
+    legacy = world.legacy
+    keys: list[str] = list(getattr(legacy, "building_breach_marks", {}).keys())
+    fail = getattr(legacy, "talisman_failure_count", {})
+    for k in fail.keys():
+        if k not in keys:
+            keys.append(k)
+    if not keys:
+        return {}
+    raw: list[float] = []
+    for k in keys:
+        score = (
+            float(getattr(legacy, "building_breach_marks", {}).get(k, 0))
+            + 2.0 * float(fail.get(k, 0.0))
+        )
+        raw.append(score)
+    # If all zero, no bias.
+    if max(raw) <= 0.0:
+        return {}
+    # Softmax (temperature controls how peaky the bias is).
+    t = _TARGET_BIAS_TEMPERATURE
+    expv = [math.exp(s / t) for s in raw]
+    z = sum(expv) or 1.0
+    return {k: v / z for k, v in zip(keys, expv)}
+
+
+# ---------------------------------------------------------------------------
+# Public entry points
+# ---------------------------------------------------------------------------
+
+
+def ensure_state(world: World) -> DirectorState:
+    """Lazily attach a DirectorState to ``world.director``."""
+    ds = getattr(world, "director", None)
+    if isinstance(ds, DirectorState):
+        return ds
+    ds = DirectorState()
+    world.director = ds
+    return ds
+
+
+def tick_director(world: World) -> None:
+    """Called once per tick from simulation._do_tick.
+
+    Recalcs pressure on a coarse cadence so we don't EWMA over noise. The
+    target_bias refresh follows the same cadence because it's a pure
+    function of legacy state.
+    """
+    ds = ensure_state(world)
+
+    # Decay talisman_failure_count on a clean night (no breaches in the window).
+    if world.time.phase == Phase.NIGHT:
+        # Check once per game-night by gating on ticks.
+        if world.tick_count - ds.last_clean_check_tick > 600:
+            ds.last_clean_check_tick = world.tick_count
+            breaches = _recent_breaches(world)
+            if breaches == 0:
+                tfc = getattr(world.legacy, "talisman_failure_count", None)
+                if isinstance(tfc, dict):
+                    for k in list(tfc.keys()):
+                        tfc[k] = max(0.0, float(tfc[k]) - _CLEAN_NIGHT_DECAY)
+                        if tfc[k] <= 0.01:
+                            del tfc[k]
+
+    if world.tick_count - ds.last_recalc_tick < _RECALC_EVERY_TICKS:
+        # Still push the cached gauges so the dashboard doesn't go stale.
+        _publish_gauges(world, ds)
+        return
+
+    raw, pop_relief = _compute_pressure(world)
+    ds.pressure = _EWMA_ALPHA * raw + (1.0 - _EWMA_ALPHA) * ds.pressure
+    ds.pop_relief = pop_relief
+
+    # Banded response.
+    if ds.pressure < _PRESSURE_LOW:
+        ds.spawn_rate_mult = _SPAWN_MULT_ESCALATE
+        ds.yellow_appearance_bias = _YELLOW_BIAS_ESCALATE
+    elif ds.pressure > _PRESSURE_HIGH:
+        ds.spawn_rate_mult = _SPAWN_MULT_DEESCALATE
+        ds.yellow_appearance_bias = _YELLOW_BIAS_DEESCALATE
+    else:
+        # Smooth blend in the middle band.
+        t = (ds.pressure - _PRESSURE_LOW) / max(1e-6, (_PRESSURE_HIGH - _PRESSURE_LOW))
+        ds.spawn_rate_mult = _SPAWN_MULT_ESCALATE + t * (
+            _SPAWN_MULT_DEESCALATE - _SPAWN_MULT_ESCALATE
+        )
+        ds.yellow_appearance_bias = _YELLOW_BIAS_ESCALATE + t * (
+            _YELLOW_BIAS_DEESCALATE - _YELLOW_BIAS_ESCALATE
+        )
+
+    ds.target_bias = _softmax_target_bias(world)
+    ds.last_recalc_tick = world.tick_count
+
+    with _span(world, "director.recalc") as span:
+        span.set_attribute("pressure", round(ds.pressure, 3))
+        span.set_attribute("spawn_rate_mult", round(ds.spawn_rate_mult, 2))
+        span.set_attribute("yellow_appearance_bias", round(ds.yellow_appearance_bias, 2))
+        span.set_attribute("pop_relief", round(ds.pop_relief, 3))
+        span.set_attribute("target_buildings", ",".join(ds.target_bias.keys())[:200])
+
+    _publish_gauges(world, ds)
+
+
+def bump_talisman_failure(world: World, building_id: str, amount: float = 1.0) -> None:
+    """Called from creatures.py whenever a breach occurs.
+
+    ``world.legacy.talisman_failure_count`` is a defaultdict-like Dict[str, float]
+    that survives wipes via the legacy persistence path.
+    """
+    tfc = getattr(world.legacy, "talisman_failure_count", None)
+    if tfc is None:
+        return
+    tfc[str(building_id)] = float(tfc.get(str(building_id), 0.0)) + float(amount)
+
+
+def get_target_weight(world: World, building_id: str) -> float:
+    """Return the bias weight for a candidate target. 0.0 when no bias."""
+    ds = getattr(world, "director", None)
+    if not isinstance(ds, DirectorState) or not ds.target_bias:
+        return 0.0
+    return float(ds.target_bias.get(str(building_id), 0.0))
+
+
+# ---------------------------------------------------------------------------
+# Telemetry helpers
+# ---------------------------------------------------------------------------
+
+
+def _publish_gauges(world: World, ds: DirectorState) -> None:
+    tele = getattr(world, "telemetry", None)
+    if tele is None:
+        return
+    try:
+        tele.gauge_set(Metric.DIRECTOR_PRESSURE, float(ds.pressure))
+        tele.gauge_set(Metric.DIRECTOR_SPAWN_MULT, float(ds.spawn_rate_mult))
+        tele.gauge_set(Metric.DIRECTOR_POP_STRESS, float(ds.pop_relief))
+    except Exception:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Tracing helper (matches mind.py's pattern; kept local to avoid imports)
+# ---------------------------------------------------------------------------
+
+
+class _NullSpan:
+    def __enter__(self) -> "_NullSpan":
+        return self
+
+    def __exit__(self, *exc) -> None:
+        return None
+
+    def set_attribute(self, *_a, **_k) -> None:
+        return None
+
+
+def _span(world: World, name: str):
+    tele = getattr(world, "telemetry", None)
+    if tele is None:
+        return _NullSpan()
+    try:
+        return tele.get_tracer().start_as_current_span(name)
+    except Exception:
+        return _NullSpan()

--- a/from-simulation/app/agents/dreams.py
+++ b/from-simulation/app/agents/dreams.py
@@ -1,0 +1,335 @@
+"""
+Dreams + prophecies — Agent A v2 engine hook.
+
+When a sanity-impaired character sleeps, this module rolls dreams. A dream
+runs for a fixed number of ticks, periodically emitting cryptic ``dream_line``
+events and queueing matching ``Prophecy`` entries on ``world.legacy``.
+
+A separate pass, ``fire_due_prophecies(world)``, scans the legacy each tick
+and fires any prophecy whose ``fires_at_cycle`` has come due and whose
+trigger condition is currently satisfied in the world. Triggers are derived
+from the prophecy line via simple substring matching — over-firing is fine,
+the show is allusive and we want resonance over precision.
+
+Entry points wired by ``simulation._do_tick``:
+    tick_dreams(world)         — between agent ticks and society tick.
+    fire_due_prophecies(world) — at the tail of the tick, before metrics.
+"""
+
+from __future__ import annotations
+
+from typing import List, Optional
+
+from contracts import (
+    Dream,
+    Event,
+    Prophecy,
+    State,
+    Status,
+    World,
+)
+
+
+# ---------------------------------------------------------------------------
+# Dream content
+# ---------------------------------------------------------------------------
+
+# Pool of cryptic prophetic one-liners. The Boy/Anghkooey/self visitor decides
+# which subset feels appropriate; for now the entire pool is shared but the
+# visitor is recorded on the Dream so the UI can flavour the rendering.
+_DREAM_LINES: List[str] = [
+    "The Sheriff will sleep through the door.",
+    "There is a way the Lighthouse opens twice.",
+    "The yellow one wore a familiar face.",
+    "A bus will come, and someone on it knows your name.",
+    "The first creature this cycle will not be the last.",
+    "Khatri prays at dawn, and dawn does not answer.",
+    "The forest learns the shape of the houses.",
+    "The boy in white walks where you cannot follow.",
+    "Count the doors. One of them is new.",
+    "The road bends back. So do the years.",
+    "What burned in the journal still burns.",
+    "Sara hears the chant before any of you.",
+    "A child will lead the wrong way home.",
+    "The talisman remembers what we have forgotten.",
+    "The dead come back wearing the wrong skin.",
+    "There is a tree that opens at the wrong hour.",
+]
+
+
+# Ticks between successive dream lines within an active dream.
+_LINE_CADENCE_TICKS = 6
+
+
+# ---------------------------------------------------------------------------
+# Trigger derivation — sloppy substring matching, on purpose.
+# ---------------------------------------------------------------------------
+
+
+def _derive_trigger(line: str) -> str:
+    """Pick a canonical pseudo-event key for this prophecy line.
+
+    Loose substring match — biased toward over-firing so dreams feel like
+    they "come true" often. Order matters: first match wins.
+    """
+    low = line.lower()
+    if "creature" in low or "forest learns" in low:
+        return "first_creature_spawn"
+    if "lighthouse" in low:
+        return "lighthouse_enter"
+    if "yellow" in low or "imposter" in low:
+        return "yellow_appearance"
+    if "bus" in low or "comes" in low:
+        return "bus_arrival"
+    if "khatri" in low or "prays" in low or "dawn" in low:
+        return "khatri_prays_dawn"
+    if "boy" in low or "white" in low:
+        return "boy_in_white"
+    if "tree" in low or "portal" in low or "chant" in low:
+        return "faraway_portal"
+    if "journal" in low or "burned" in low or "remembers" in low:
+        return "journal_page_burns"
+    if "dead" in low or "back" in low or "home" in low:
+        return "homecoming"
+    if "door" in low:
+        return "creature_breach"
+    return "any"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _character_for_id(world: World, char_id: str):
+    return world.agents.get(char_id)
+
+
+def _already_dreaming(world: World, char_id: str) -> bool:
+    return any(d.character_id == char_id for d in world.active_dreams)
+
+
+def _pick_visitor(world: World) -> str:
+    r = world.rng.random()
+    if r < 0.45:
+        return "boy_in_white"
+    if r < 0.80:
+        return "anghkooey"
+    return "self"
+
+
+def _generate_lines(world: World, count: int) -> List[str]:
+    # Choose ``count`` distinct lines from the pool.
+    pool = list(_DREAM_LINES)
+    world.rng.shuffle(pool)
+    return pool[: max(1, count)]
+
+
+# ---------------------------------------------------------------------------
+# Public: dream lifecycle tick
+# ---------------------------------------------------------------------------
+
+
+def tick_dreams(world: World) -> None:
+    """Drive dream begin/line/end events and queue prophecies.
+
+    Called once per sim tick from ``simulation._do_tick`` — after the agent
+    ticks (so sleeping characters have already been processed by their own
+    FSM this tick) and before ``tick_societies`` (so B observes the
+    DREAMING transitions when it runs).
+    """
+    cfg = world.config
+    rng = world.rng
+
+    # 1) Roll new dreams for sleeping low-sanity characters not already dreaming.
+    for agent in list(world.agents.values()):
+        state = getattr(agent, "state", None)
+        if state != State.SLEEPING:
+            continue
+        status = getattr(agent, "status", Status.ACTIVE)
+        if status != Status.ACTIVE:
+            continue
+        sanity = float(getattr(agent, "sanity", 100.0))
+        if sanity >= cfg.dream_trigger_sanity_threshold:
+            continue
+        if _already_dreaming(world, agent.id):
+            continue
+        if rng.random() >= cfg.dream_trigger_prob:
+            continue
+
+        visitor = _pick_visitor(world)
+        n_lines = rng.randint(2, 4)
+        lines = _generate_lines(world, n_lines)
+        dream = Dream(
+            character_id=agent.id,
+            started_at_tick=world.tick_count,
+            duration=int(cfg.dream_duration_ticks),
+            lines=lines,
+            visitor=visitor,
+        )
+        world.active_dreams.append(dream)
+        # Flip the character into DREAMING — Agent B watches for this.
+        try:
+            setattr(agent, "state", State.DREAMING)
+        except Exception:
+            pass
+        world.emit(
+            Event(
+                tick=world.tick_count,
+                type="dream_begin",
+                subject=agent.id,
+                detail=f"{visitor} visits ({n_lines} lines)",
+                severity="info",
+            )
+        )
+
+    # 2) Progress each active dream: emit the next line on cadence, end on
+    #    duration. Iterate over a snapshot since we may mutate the list.
+    cur_cycle = world.legacy.cycles_witnessed + 1
+    for dream in list(world.active_dreams):
+        elapsed = world.tick_count - dream.started_at_tick
+
+        # End-of-dream takedown.
+        if elapsed >= dream.duration:
+            char = _character_for_id(world, dream.character_id)
+            if char is not None:
+                # Only restore if they're still mid-dream — defensive against
+                # B/C having already moved them on (e.g. died in their sleep).
+                if getattr(char, "state", None) == State.DREAMING:
+                    try:
+                        setattr(char, "state", State.SLEEPING)
+                    except Exception:
+                        pass
+            world.emit(
+                Event(
+                    tick=world.tick_count,
+                    type="dream_end",
+                    subject=dream.character_id,
+                    detail=f"{dream.visitor} dream ends",
+                    severity="info",
+                )
+            )
+            try:
+                world.active_dreams.remove(dream)
+            except ValueError:
+                pass
+            continue
+
+        # Mid-dream: emit next queued line every ~6 ticks. We use the count of
+        # lines already spoken (tracked by how many we've popped) — but lines
+        # aren't popped, we just index by elapsed // cadence.
+        line_idx = elapsed // _LINE_CADENCE_TICKS
+        # Only fire on the exact tick the new index opens up, and only if the
+        # dream still has a line at that index.
+        if elapsed > 0 and elapsed % _LINE_CADENCE_TICKS == 0 and line_idx <= len(dream.lines):
+            idx = line_idx - 1 if line_idx > 0 else 0
+            if 0 <= idx < len(dream.lines):
+                line = dream.lines[idx]
+                world.emit(
+                    Event(
+                        tick=world.tick_count,
+                        type="dream_line",
+                        subject=dream.character_id,
+                        detail=line,
+                        severity="info",
+                    )
+                )
+                # Queue a prophecy on the legacy. It fires next cycle.
+                prophecy = Prophecy(
+                    set_at_cycle=cur_cycle,
+                    fires_at_cycle=cur_cycle + 1,
+                    trigger=_derive_trigger(line),
+                    payload=line,
+                )
+                world.legacy.pending_prophecies.append(prophecy)
+                world.emit(
+                    Event(
+                        tick=world.tick_count,
+                        type="prophecy_set",
+                        subject=dream.character_id,
+                        detail=f"[{prophecy.trigger}] {line}",
+                        severity="info",
+                    )
+                )
+
+
+# ---------------------------------------------------------------------------
+# Public: fire prophecies whose moment has come.
+# ---------------------------------------------------------------------------
+
+
+def _creature_spawn_this_tick(world: World) -> bool:
+    """Did a creature_spawn event hit the buffer at the current tick?"""
+    if world.events is None:
+        return False
+    for evt in reversed(list(world.events)):
+        if evt.tick != world.tick_count:
+            return False  # buffer is roughly time-ordered
+        if evt.type == "creature_spawn":
+            return True
+    return False
+
+
+def _event_type_this_tick(world: World, event_type: str) -> bool:
+    if world.events is None:
+        return False
+    for evt in reversed(list(world.events)):
+        if evt.tick != world.tick_count:
+            return False
+        if evt.type == event_type:
+            return True
+    return False
+
+
+def _khatri_praying_at_dawn(world: World) -> bool:
+    if world.time.phase.value != "DAWN":
+        return False
+    for agent in world.agents.values():
+        name = (getattr(agent, "name", "") or "").lower()
+        if "khatri" not in name:
+            continue
+        state = getattr(agent, "state", None)
+        if state == State.PRAYING:
+            return True
+    return False
+
+
+def _trigger_met(world: World, trigger: str) -> bool:
+    """Decide whether ``trigger`` is currently satisfied. Loose by design."""
+    if trigger == "any":
+        return True
+    if trigger == "first_creature_spawn":
+        return _creature_spawn_this_tick(world)
+    if trigger == "khatri_prays_dawn":
+        return _khatri_praying_at_dawn(world)
+    # All other triggers are direct event types — fire if the event hit this tick.
+    return _event_type_this_tick(world, trigger)
+
+
+def fire_due_prophecies(world: World) -> None:
+    """Emit ``prophecy_fired`` for any pending prophecy whose moment has come.
+
+    A prophecy is "due" once ``fires_at_cycle <= current cycle`` AND its
+    trigger condition holds in the world this tick. Fired prophecies are
+    removed from ``world.legacy.pending_prophecies``.
+    """
+    cur_cycle = world.legacy.cycles_witnessed + 1
+    if not world.legacy.pending_prophecies:
+        return
+
+    survivors: List[Prophecy] = []
+    for prop in world.legacy.pending_prophecies:
+        if prop.fires_at_cycle <= cur_cycle and _trigger_met(world, prop.trigger):
+            world.emit(
+                Event(
+                    tick=world.tick_count,
+                    type="prophecy_fired",
+                    subject="world",
+                    detail=f"[{prop.trigger}] {prop.payload}",
+                    severity="warn",
+                )
+            )
+            # Do not retain — it has come true.
+            continue
+        survivors.append(prop)
+    world.legacy.pending_prophecies = survivors

--- a/from-simulation/app/agents/dreams.py
+++ b/from-simulation/app/agents/dreams.py
@@ -109,18 +109,44 @@ def _already_dreaming(world: World, char_id: str) -> bool:
     return any(d.character_id == char_id for d in world.active_dreams)
 
 
+_BALLERINA_LINES: List[str] = [
+    "The ballerina turned and her mouth was full of worms.",
+    "She danced, and the music wound back to its beginning.",
+    "Twirl me, said the ballerina.",
+    "The cicadas were already inside the dream.",
+    "She told me the rhyme was older than the town.",
+]
+
+
 def _pick_visitor(world: World) -> str:
-    r = world.rng.random()
-    if r < 0.45:
-        return "boy_in_white"
-    if r < 0.80:
-        return "anghkooey"
-    return "self"
+    # When the Music Box is awake, the ballerina haunts dreams alongside the
+    # boy/anghkooey/self options. She gets a flat 50% slice of the pool when
+    # active; otherwise she's 0%.
+    ballerina_active = getattr(world, "music_box_phase", "DORMANT") != "DORMANT"
+    weights = [
+        ("boy_in_white", 0.45),
+        ("anghkooey", 0.35),
+        ("self", 0.20),
+    ]
+    if ballerina_active:
+        # Renormalise the original three to share the remaining 50%, ballerina = 50%.
+        weights = [
+            ("boy_in_white", 0.225),
+            ("anghkooey", 0.175),
+            ("self", 0.100),
+            ("ballerina", 0.500),
+        ]
+    options = [v for v, _ in weights]
+    probs = [w for _, w in weights]
+    return world.rng.choices(options, weights=probs, k=1)[0]
 
 
-def _generate_lines(world: World, count: int) -> List[str]:
-    # Choose ``count`` distinct lines from the pool.
-    pool = list(_DREAM_LINES)
+def _generate_lines(world: World, count: int, visitor: str = "self") -> List[str]:
+    # Choose ``count`` distinct lines from the pool. Ballerina has her own pool.
+    if visitor == "ballerina":
+        pool = list(_BALLERINA_LINES)
+    else:
+        pool = list(_DREAM_LINES)
     world.rng.shuffle(pool)
     return pool[: max(1, count)]
 
@@ -159,7 +185,7 @@ def tick_dreams(world: World) -> None:
 
         visitor = _pick_visitor(world)
         n_lines = rng.randint(2, 4)
-        lines = _generate_lines(world, n_lines)
+        lines = _generate_lines(world, n_lines, visitor)
         dream = Dream(
             character_id=agent.id,
             started_at_tick=world.tick_count,
@@ -182,6 +208,16 @@ def tick_dreams(world: World) -> None:
                 severity="info",
             )
         )
+        if visitor == "ballerina":
+            world.emit(
+                Event(
+                    tick=world.tick_count,
+                    type="ballerina_vision",
+                    subject=agent.id,
+                    detail=f"the ballerina enters {agent.id}'s dream",
+                    severity="warn",
+                )
+            )
 
     # 2) Progress each active dream: emit the next line on cadence, end on
     #    duration. Iterate over a snapshot since we may mutate the list.

--- a/from-simulation/app/agents/dreams.py
+++ b/from-simulation/app/agents/dreams.py
@@ -287,6 +287,17 @@ def tick_dreams(world: World) -> None:
                         severity="info",
                     )
                 )
+                # v5 — record the prophecy as a character memory row so it
+                # can later bias the dreamer's behaviour through recall.
+                if world.memory is not None:
+                    try:
+                        world.memory.record_character_memory(
+                            world, dream.character_id, "prophecy_heard",
+                            subject="ruins",
+                            detail=dream.lines[0] if dream.lines else line,
+                        )
+                    except Exception:
+                        pass
 
 
 # ---------------------------------------------------------------------------

--- a/from-simulation/app/agents/expedition.py
+++ b/from-simulation/app/agents/expedition.py
@@ -1,0 +1,277 @@
+"""
+Food expeditions into the forest.
+
+Agent B owns this module. Driven by ``characters.tick_societies(world)``.
+
+Lifecycle:
+
+* When ``world.expedition_authorised`` is set (only the social loop sets it,
+  from a successful ``food_supply`` meeting outcome), pick a leader from the
+  brave/leader-personality pool (Boyd, Donna, or Jim by default) and recruit
+  2-4 brave characters present in town.
+* Walk the party to a random interior forest point, well away from the spawn
+  ring.
+* Mill ~80 ticks. If the mill extends past DUSK, fear ramps up sharply and
+  there's a chance one party member dies (their ``status`` is set to ``DEAD``
+  — ``resurrection.py`` picks them up next tick).
+* Return to town, deposit food, restore states, emit ``expedition_returned``.
+
+Events emitted: ``expedition_called`` (when authorised), ``expedition_departed``,
+``expedition_returned``.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+from typing import List, Optional, Tuple
+
+from contracts import (
+    Event,
+    Phase,
+    Role,
+    State,
+    Status,
+    World,
+)
+
+from agents.characters import Character
+
+
+EXPEDITION_MILL_TICKS = 80
+FOREST_TARGET_RING = (0.85, 0.95)  # fraction of map dimensions for interior point
+FOOD_REWARD = 60.0
+DEPART_SPEED = 3.5
+
+
+@dataclass
+class _Expedition:
+    leader_id: str
+    member_ids: List[str] = field(default_factory=list)
+    departed_tick: int = 0
+    target: Tuple[float, float] = (0.0, 0.0)
+    home: Tuple[float, float] = (500.0, 350.0)
+    phase: str = "departing"  # departing | milling | returning | done
+    mill_start_tick: int = 0
+
+
+def _get_expedition(world: World) -> Optional[_Expedition]:
+    return getattr(world, "_active_expedition", None)
+
+
+def _set_expedition(world: World, exp: Optional[_Expedition]) -> None:
+    world._active_expedition = exp  # type: ignore[attr-defined]
+
+
+def _eligible(c: Character) -> bool:
+    if c.status != Status.ACTIVE:
+        return False
+    if c.state in (State.SLEEPING, State.HYPNOTIZED, State.IRRATIONAL,
+                   State.MEETING, State.ARGUING):
+        return False
+    return True
+
+
+def _pick_leader(world: World) -> Optional[Character]:
+    candidates: List[Tuple[Character, float]] = []
+    for a in world.agents.values():
+        if not isinstance(a, Character):
+            continue
+        if a.role not in (Role.SHERIFF, Role.LEADER_COLONY, Role.ENGINEER):
+            continue
+        if not _eligible(a):
+            continue
+        weight = (
+            0.5 * a.personality.get("leader", 0.3)
+            + 0.5 * a.personality.get("brave", 0.4)
+        )
+        candidates.append((a, max(0.1, weight)))
+    if not candidates:
+        return None
+    pool, weights = zip(*candidates)
+    return world.rng.choices(pool, weights=weights, k=1)[0]
+
+
+def _pick_party(world: World, leader: Character) -> List[Character]:
+    pool = [
+        a for a in world.agents.values()
+        if isinstance(a, Character) and a.id != leader.id and _eligible(a)
+    ]
+    # Prefer brave folk.
+    pool.sort(key=lambda c: c.personality.get("brave", 0.4), reverse=True)
+    n = world.rng.randint(2, min(4, max(2, len(pool))))
+    return pool[:n]
+
+
+def _forest_target(world: World) -> Tuple[float, float]:
+    # Map viewBox is 1000 x 700. Interior forest sits between the building cluster
+    # and the spawn ring. Pick somewhere on a corner-ish ring.
+    angle = world.rng.uniform(0, 2 * math.pi)
+    rx = world.rng.uniform(FOREST_TARGET_RING[0], FOREST_TARGET_RING[1])
+    cx, cy = 500.0, 350.0
+    tx = cx + rx * 380.0 * math.cos(angle)
+    ty = cy + rx * 270.0 * math.sin(angle)
+    # Clamp inside the map margin (avoid the very edge spawn points).
+    tx = max(60.0, min(940.0, tx))
+    ty = max(60.0, min(640.0, ty))
+    return (tx, ty)
+
+
+def _walk_party(world: World, exp: _Expedition, dest: Tuple[float, float],
+                speed: float) -> bool:
+    """Move all members one step toward dest. Returns True when all arrived."""
+    all_arrived = True
+    for mid in [exp.leader_id, *exp.member_ids]:
+        ch = world.agents.get(mid)
+        if not isinstance(ch, Character) or ch.status not in (Status.ACTIVE,):
+            continue
+        dx = dest[0] - ch.x
+        dy = dest[1] - ch.y
+        d = math.hypot(dx, dy)
+        if d <= speed:
+            ch.x, ch.y = dest
+        else:
+            ch.x += speed * dx / d
+            ch.y += speed * dy / d
+            all_arrived = False
+    return all_arrived
+
+
+def _pin_party(world: World, exp: _Expedition) -> None:
+    for mid in [exp.leader_id, *exp.member_ids]:
+        ch = world.agents.get(mid)
+        if isinstance(ch, Character) and ch.status == Status.ACTIVE:
+            ch.state = State.EXPEDITION
+            ch.state_since_tick = world.tick_count
+            ch.expedition_role = "leader" if mid == exp.leader_id else "member"
+
+
+def _release_party(world: World, exp: _Expedition) -> None:
+    for mid in [exp.leader_id, *exp.member_ids]:
+        ch = world.agents.get(mid)
+        if isinstance(ch, Character) and ch.status == Status.ACTIVE:
+            ch.state = State.WANDERING
+            ch.state_since_tick = world.tick_count
+            ch.expedition_role = None
+            ch.target = None
+
+
+def tick_expeditions(world: World) -> None:
+    exp = _get_expedition(world)
+
+    # ------------------------------------------------ kick off a new expedition
+    if exp is None:
+        if not world.expedition_authorised:
+            return
+        leader = _pick_leader(world)
+        if leader is None:
+            # Authorised but nobody available — drop the flag, try again later.
+            world.expedition_authorised = False
+            return
+        party = _pick_party(world, leader)
+        if len(party) < 2:
+            world.expedition_authorised = False
+            return
+        # Town centre as home base for the return leg.
+        home = (leader.x, leader.y)
+        target = _forest_target(world)
+        exp = _Expedition(
+            leader_id=leader.id,
+            member_ids=[c.id for c in party],
+            departed_tick=world.tick_count,
+            target=target,
+            home=home,
+            phase="departing",
+        )
+        _set_expedition(world, exp)
+        _pin_party(world, exp)
+        for mid in [leader.id, *exp.member_ids]:
+            ch = world.agents.get(mid)
+            if isinstance(ch, Character):
+                ch.target = target
+        world.expedition_authorised = False
+        world.expedition_active = True
+        world.emit(Event(
+            tick=world.tick_count, type="expedition_called",
+            subject=leader.id,
+            detail=f"led by {leader.name} ({len(party)} members)",
+        ))
+        world.emit(Event(
+            tick=world.tick_count, type="expedition_departed",
+            subject=leader.id,
+            detail=f"heading to ({target[0]:.0f},{target[1]:.0f})",
+        ))
+        return
+
+    # ------------------------------------------------ drive existing expedition
+    if exp.phase == "departing":
+        arrived = _walk_party(world, exp, exp.target, DEPART_SPEED)
+        if arrived:
+            exp.phase = "milling"
+            exp.mill_start_tick = world.tick_count
+        return
+
+    if exp.phase == "milling":
+        # Add tension during the mill: small fear bump every ~10 ticks.
+        if (world.tick_count - exp.mill_start_tick) % 10 == 0:
+            for mid in [exp.leader_id, *exp.member_ids]:
+                ch = world.agents.get(mid)
+                if isinstance(ch, Character) and ch.status == Status.ACTIVE:
+                    ch.fear = min(100.0, ch.fear + 1.0)
+        # Past DUSK: sharp fear, chance of death.
+        if world.time.phase in (Phase.DUSK, Phase.NIGHT):
+            for mid in [exp.leader_id, *exp.member_ids]:
+                ch = world.agents.get(mid)
+                if isinstance(ch, Character) and ch.status == Status.ACTIVE:
+                    ch.fear = min(100.0, ch.fear + 3.0)
+                    ch.sanity = max(0.0, ch.sanity - 0.5)
+            # 1.5% chance per tick after dusk for one member to die.
+            if world.time.phase == Phase.NIGHT and world.rng.random() < 0.015:
+                # Don't kill the leader as the first casualty.
+                pool = [world.agents[mid] for mid in exp.member_ids
+                        if isinstance(world.agents.get(mid), Character)
+                        and world.agents[mid].status == Status.ACTIVE]
+                if pool:
+                    victim = world.rng.choice(pool)
+                    victim.status = Status.DEAD
+                    world.emit(Event(
+                        tick=world.tick_count, type="char_death",
+                        subject=victim.id,
+                        detail=f"lost on expedition with {exp.leader_id}",
+                        severity="crit",
+                    ))
+        # Mill is done.
+        if world.tick_count - exp.mill_start_tick >= EXPEDITION_MILL_TICKS:
+            exp.phase = "returning"
+            for mid in [exp.leader_id, *exp.member_ids]:
+                ch = world.agents.get(mid)
+                if isinstance(ch, Character) and ch.status == Status.ACTIVE:
+                    ch.target = exp.home
+        return
+
+    if exp.phase == "returning":
+        arrived = _walk_party(world, exp, exp.home, DEPART_SPEED)
+        if arrived:
+            # Survivors deposit food.
+            survivors = [
+                world.agents[mid] for mid in [exp.leader_id, *exp.member_ids]
+                if isinstance(world.agents.get(mid), Character)
+                and world.agents[mid].status == Status.ACTIVE
+            ]
+            haul = FOOD_REWARD * (len(survivors) / max(1, 1 + len(exp.member_ids)))
+            # We do not own world.food_supply, but the brief implies we may raise it
+            # when an expedition completes. Cap by capacity.
+            try:
+                world.food_supply = min(world.food_capacity, world.food_supply + haul)
+            except Exception:
+                pass
+            _release_party(world, exp)
+            world.emit(Event(
+                tick=world.tick_count, type="expedition_returned",
+                subject=exp.leader_id,
+                detail=f"survivors={len(survivors)} food+={haul:.0f}",
+                severity="info" if len(survivors) == 1 + len(exp.member_ids) else "warn",
+            ))
+            _set_expedition(world, None)
+            world.expedition_active = False
+        return

--- a/from-simulation/app/agents/expedition.py
+++ b/from-simulation/app/agents/expedition.py
@@ -30,6 +30,7 @@ from contracts import (
     Event,
     Phase,
     Role,
+    RUINS_XY,
     State,
     Status,
     World,
@@ -43,6 +44,10 @@ FOREST_TARGET_RING = (0.85, 0.95)  # fraction of map dimensions for interior poi
 FOOD_REWARD = 60.0
 DEPART_SPEED = 3.5
 
+# v4: music-box destruction run.
+MUSIC_BOX_RENDEZVOUS_RADIUS = 30.0   # leader-to-carrier adjacency threshold
+MUSIC_BOX_DESTROY_RADIUS = 40.0      # close enough to RUINS for A's tick to fire
+
 
 @dataclass
 class _Expedition:
@@ -51,8 +56,10 @@ class _Expedition:
     departed_tick: int = 0
     target: Tuple[float, float] = (0.0, 0.0)
     home: Tuple[float, float] = (500.0, 350.0)
-    phase: str = "departing"  # departing | milling | returning | done
+    phase: str = "departing"  # departing | milling | returning | done | rendezvous | ruins
     mill_start_tick: int = 0
+    # v4 — set when this is a music-box destruction expedition.
+    is_music_box: bool = False
 
 
 def _get_expedition(world: World) -> Optional[_Expedition]:
@@ -156,6 +163,34 @@ def _release_party(world: World, exp: _Expedition) -> None:
             ch.target = None
 
 
+def _pick_music_box_leader(world: World) -> Optional[Character]:
+    """Prefer Boyd (SHERIFF); fall back to any worm-infected character.
+
+    The infected carrier is a sensible second choice because they're already
+    bonded to the box and will accept the trip without argument.
+    """
+    boyd = world.agents.get("Boyd")
+    if isinstance(boyd, Character) and _eligible(boyd):
+        return boyd
+    # SHERIFF role fallback (in case Boyd is incapacitated/dead).
+    for a in world.agents.values():
+        if (isinstance(a, Character) and a.role == Role.SHERIFF
+                and _eligible(a) and a.id != "Boyd"):
+            return a
+    # Worm-infected carrier fallback.
+    worms = getattr(world, "worms_infected", set()) or set()
+    carrier_id = getattr(world, "music_box_carrier", None)
+    if carrier_id and carrier_id in world.agents:
+        ch = world.agents[carrier_id]
+        if isinstance(ch, Character) and _eligible(ch):
+            return ch
+    for wid in worms:
+        ch = world.agents.get(wid)
+        if isinstance(ch, Character) and _eligible(ch):
+            return ch
+    return None
+
+
 def tick_expeditions(world: World) -> None:
     exp = _get_expedition(world)
 
@@ -163,6 +198,67 @@ def tick_expeditions(world: World) -> None:
     if exp is None:
         if not world.expedition_authorised:
             return
+
+        is_music_box = bool(getattr(world, "_expedition_is_music_box", False))
+
+        if is_music_box:
+            leader = _pick_music_box_leader(world)
+            if leader is None:
+                # Nobody available — drop both flags, try again later.
+                world.expedition_authorised = False
+                world._expedition_is_music_box = False  # type: ignore[attr-defined]
+                return
+            # Music-box runs are smaller: leader + 0-2 companions optional.
+            party = _pick_party(world, leader)[:2]
+            home = (leader.x, leader.y)
+            # Initial target depends on whether a carrier exists.
+            carrier_id = getattr(world, "music_box_carrier", None)
+            carrier = world.agents.get(carrier_id) if carrier_id else None
+            if isinstance(carrier, Character) and carrier.id != leader.id:
+                target = (carrier.x, carrier.y)
+                phase = "rendezvous"
+            else:
+                # No carrier or leader IS the carrier — head straight to ruins.
+                # If no carrier at all, make the leader the carrier.
+                if carrier_id is None or not isinstance(carrier, Character):
+                    world.music_box_carrier = leader.id
+                    try:
+                        leader.state = State.CARRYING_BOX
+                    except Exception:
+                        pass
+                target = RUINS_XY
+                phase = "ruins"
+            exp = _Expedition(
+                leader_id=leader.id,
+                member_ids=[c.id for c in party],
+                departed_tick=world.tick_count,
+                target=target,
+                home=home,
+                phase=phase,
+                is_music_box=True,
+            )
+            _set_expedition(world, exp)
+            _pin_party(world, exp)
+            for mid in [leader.id, *exp.member_ids]:
+                ch = world.agents.get(mid)
+                if isinstance(ch, Character):
+                    ch.target = target
+            world.expedition_authorised = False
+            world.expedition_active = True
+            world.emit(Event(
+                tick=world.tick_count, type="expedition_called",
+                subject=leader.id,
+                detail=f"destroy music box — led by {leader.name}",
+                severity="warn",
+            ))
+            world.emit(Event(
+                tick=world.tick_count, type="expedition_departed",
+                subject=leader.id,
+                detail=f"to the ruins at ({RUINS_XY[0]:.0f},{RUINS_XY[1]:.0f})",
+                severity="warn",
+            ))
+            return
+
         leader = _pick_leader(world)
         if leader is None:
             # Authorised but nobody available — drop the flag, try again later.
@@ -201,6 +297,104 @@ def tick_expeditions(world: World) -> None:
             subject=leader.id,
             detail=f"heading to ({target[0]:.0f},{target[1]:.0f})",
         ))
+        return
+
+    # ------------------------------------------------ music-box destruction run
+    if exp.is_music_box:
+        leader = world.agents.get(exp.leader_id)
+        if not isinstance(leader, Character) or leader.status != Status.ACTIVE:
+            # Lost the leader mid-run — abort cleanly.
+            _release_party(world, exp)
+            _set_expedition(world, None)
+            world.expedition_active = False
+            world._expedition_is_music_box = False  # type: ignore[attr-defined]
+            return
+
+        carrier_id = getattr(world, "music_box_carrier", None)
+        carrier = world.agents.get(carrier_id) if carrier_id else None
+
+        if exp.phase == "rendezvous":
+            # Leader walks to the carrier. If the carrier is gone (dropped /
+            # died / vanished), the leader becomes the carrier.
+            if not isinstance(carrier, Character) or carrier.status != Status.ACTIVE:
+                world.music_box_carrier = leader.id
+                try:
+                    leader.state = State.CARRYING_BOX
+                except Exception:
+                    pass
+                exp.target = RUINS_XY
+                exp.phase = "ruins"
+                for mid in [exp.leader_id, *exp.member_ids]:
+                    ch = world.agents.get(mid)
+                    if isinstance(ch, Character):
+                        ch.target = RUINS_XY
+                return
+            # Step toward the carrier's current position.
+            target = (carrier.x, carrier.y)
+            exp.target = target
+            for mid in [exp.leader_id, *exp.member_ids]:
+                ch = world.agents.get(mid)
+                if isinstance(ch, Character):
+                    ch.target = target
+            _walk_party(world, exp, target, DEPART_SPEED)
+            d = math.hypot(leader.x - carrier.x, leader.y - carrier.y)
+            if d <= MUSIC_BOX_RENDEZVOUS_RADIUS:
+                # Leader joins the carrier. From here both head to the ruins.
+                exp.phase = "ruins"
+                exp.target = RUINS_XY
+                # Make sure carrier is part of the marching party.
+                if carrier.id != leader.id and carrier.id not in exp.member_ids:
+                    exp.member_ids.append(carrier.id)
+                    try:
+                        carrier.state = State.EXPEDITION  # pin alongside leader
+                        carrier.expedition_role = "carrier"
+                        carrier.state_since_tick = world.tick_count
+                    except Exception:
+                        pass
+                for mid in [exp.leader_id, *exp.member_ids]:
+                    ch = world.agents.get(mid)
+                    if isinstance(ch, Character):
+                        ch.target = RUINS_XY
+            return
+
+        if exp.phase == "ruins":
+            # Walk the carrier (and leader) to RUINS_XY. Agent A's
+            # tick_music_box handles the actual destruction when within
+            # MUSIC_BOX_DESTROY_RADIUS of the ruins.
+            ref = carrier if isinstance(carrier, Character) and carrier.status == Status.ACTIVE else leader
+            _walk_party(world, exp, RUINS_XY, DEPART_SPEED)
+            d = math.hypot(ref.x - RUINS_XY[0], ref.y - RUINS_XY[1])
+            if d <= MUSIC_BOX_DESTROY_RADIUS:
+                # Arrived. Hold for one tick to let A's destroyer fire.
+                # When the carrier is cleared by A, fold the expedition.
+                if world.music_box_carrier is None or world.music_box_phase == "DORMANT":
+                    exp.phase = "returning"
+                    for mid in [exp.leader_id, *exp.member_ids]:
+                        ch = world.agents.get(mid)
+                        if isinstance(ch, Character) and ch.status == Status.ACTIVE:
+                            ch.target = exp.home
+            return
+
+        if exp.phase == "returning":
+            arrived = _walk_party(world, exp, exp.home, DEPART_SPEED)
+            if arrived:
+                _release_party(world, exp)
+                world.emit(Event(
+                    tick=world.tick_count, type="expedition_returned",
+                    subject=exp.leader_id,
+                    detail="music box destroyed; party home",
+                    severity="info",
+                ))
+                _set_expedition(world, None)
+                world.expedition_active = False
+                world._expedition_is_music_box = False  # type: ignore[attr-defined]
+            return
+
+        # Unknown music-box phase — recover by bailing out.
+        _release_party(world, exp)
+        _set_expedition(world, None)
+        world.expedition_active = False
+        world._expedition_is_music_box = False  # type: ignore[attr-defined]
         return
 
     # ------------------------------------------------ drive existing expedition

--- a/from-simulation/app/agents/expedition.py
+++ b/from-simulation/app/agents/expedition.py
@@ -28,6 +28,7 @@ from typing import List, Optional, Tuple
 
 from contracts import (
     Event,
+    Item,
     Phase,
     Role,
     RUINS_XY,
@@ -365,6 +366,15 @@ def tick_expeditions(world: World) -> None:
             _walk_party(world, exp, RUINS_XY, DEPART_SPEED)
             d = math.hypot(ref.x - RUINS_XY[0], ref.y - RUINS_XY[1])
             if d <= MUSIC_BOX_DESTROY_RADIUS:
+                # v5 — once the carrier has reached the ruins, decrement their
+                # inventory so memory + UI see the box leaving them. Music box
+                # destruction itself is handled by Agent A. Guarded so we only
+                # decrement once per arrival.
+                if isinstance(ref, Character) and ref._inv_has(Item.MUSIC_BOX.value):
+                    try:
+                        ref._inv_add(Item.MUSIC_BOX.value, -1, world)
+                    except Exception:
+                        pass
                 # Arrived. Hold for one tick to let A's destroyer fire.
                 # When the carrier is cleared by A, fold the expedition.
                 if world.music_box_carrier is None or world.music_box_phase == "DORMANT":
@@ -453,6 +463,19 @@ def tick_expeditions(world: World) -> None:
                 and world.agents[mid].status == Status.ACTIVE
             ]
             haul = FOOD_REWARD * (len(survivors) / max(1, 1 + len(exp.member_ids)))
+            # v5 — route the haul through the leader's inventory so the memory
+            # layer sees a pickup/drop pair (interpreted as a "delivery"). We
+            # then bump the engine-owned ``food_supply`` directly. The k value
+            # is the integer haul; any rounding residue is dropped on the
+            # floor since food_supply already holds the float.
+            leader = world.agents.get(exp.leader_id)
+            k = max(0, int(round(haul)))
+            if isinstance(leader, Character) and k > 0:
+                try:
+                    leader._inv_add(Item.FOOD.value, +k, world)
+                    leader._inv_add(Item.FOOD.value, -k, world)
+                except Exception:
+                    pass
             # We do not own world.food_supply, but the brief implies we may raise it
             # when an expedition completes. Cap by capacity.
             try:

--- a/from-simulation/app/agents/fear.py
+++ b/from-simulation/app/agents/fear.py
@@ -1,0 +1,219 @@
+"""
+Fear propagation + paranormal break outcomes.
+
+Per tick:
+
+  1. Every agent within ~120 px of a creature has their ``fear`` raised, scaled
+     by ``1 - brave`` (so brave agents resist). Distance falloff is linear.
+  2. Once ``fear > 90``, the agent rolls a per-tick chance to "break". On a
+     break we set their state to IRRATIONAL, emit ``paranormal_break``, and
+     drop a transient glitch marker (Faraway-Tree-style sprite) at their feet.
+  3. An agent who has been IRRATIONAL for ``N`` ticks samples an outcome from
+     a small table:
+        * unlock_door    — unlock the door of the nearest building
+        * run_outside    — wander away from the nearest shelter
+        * attack_neighbour — set a nearby agent to INCAPACITATED
+        * silent_collapse — set themselves to INCAPACITATED
+     The agent stays IRRATIONAL for a few more ticks of "stunned" before
+     fear drains.
+
+We never *delete* agents here — we set their ``status`` and let the owner slice
+(Agent B for characters, Agent C for NPCs) sweep them up on the next tick.
+"""
+
+from __future__ import annotations
+
+from typing import List, Optional
+
+from contracts import Agent, Event, State, Status, World
+from agents.base import distance, nearest
+from agents import supernatural as _supernatural
+
+
+# Tunables
+_PROX_RADIUS = 120.0
+_FEAR_PER_TICK_AT_ZERO = 6.0    # raw fear gain at point-blank from a creature
+_BREAK_THRESHOLD = 90.0
+_BREAK_PROB_PER_TICK = 0.05
+_IRRATIONAL_OUTCOME_TICKS = 12
+_IRRATIONAL_TOTAL_TICKS = 30
+_FEAR_DRAIN_AFTER_BREAK = 60.0
+
+
+def _fear_gain(agent_brave: float, dist_to_creature: float) -> float:
+    """Linear falloff inside ``_PROX_RADIUS`` scaled by ``(1 - brave)``."""
+    if dist_to_creature >= _PROX_RADIUS:
+        return 0.0
+    falloff = 1.0 - (dist_to_creature / _PROX_RADIUS)
+    bravery = max(0.0, min(1.0, float(agent_brave)))
+    return _FEAR_PER_TICK_AT_ZERO * falloff * (1.0 - bravery)
+
+
+def _eligible_agents(world: World) -> List[Agent]:
+    """Active, non-dead agents who can feel fear."""
+    out: List[Agent] = []
+    for a in world.agents.values():
+        status = getattr(a, "status", Status.ACTIVE)
+        if status in (Status.DEAD, Status.INCAPACITATED, Status.ABSENT):
+            continue
+        out.append(a)
+    return out
+
+
+def _maybe_break(world: World, agent: Agent) -> None:
+    """Roll a paranormal break. On hit, switch agent to IRRATIONAL + emit."""
+    if getattr(agent, "state", None) == State.IRRATIONAL:
+        return
+    fear = float(getattr(agent, "fear", 0.0))
+    if fear <= _BREAK_THRESHOLD:
+        return
+    if world.rng.random() >= _BREAK_PROB_PER_TICK:
+        return
+    setattr(agent, "state", State.IRRATIONAL)
+    setattr(agent, "irrational_since_tick", world.tick_count)
+    world.emit(
+        Event(
+            tick=world.tick_count,
+            type="paranormal_break",
+            subject=agent.id,
+            detail=f"snapped (fear={fear:.1f})",
+            severity="crit",
+        )
+    )
+    _supernatural.spawn_glitch_marker(world, agent)
+
+
+def _resolve_outcome(world: World, agent: Agent) -> None:
+    """Sample an outcome once the agent has been IRRATIONAL long enough."""
+    outcomes = ("unlock_door", "run_outside", "attack_neighbour", "silent_collapse")
+    # Light weighting: silent_collapse rarer, others roughly even.
+    weights = (3.0, 3.0, 3.0, 1.5)
+    outcome = world.rng.choices(outcomes, weights=weights, k=1)[0]
+
+    if outcome == "unlock_door":
+        target = nearest(list(world.buildings.values()), agent.x, agent.y)
+        if target is not None:
+            target.locked = False
+            world.emit(
+                Event(
+                    tick=world.tick_count,
+                    type="irrational_act",
+                    subject=agent.id,
+                    detail=f"unlocked {target.name}",
+                    severity="warn",
+                )
+            )
+    elif outcome == "run_outside":
+        # Pick a building, then "shove" the agent away from it.
+        shelter = nearest(list(world.buildings.values()), agent.x, agent.y)
+        if shelter is not None:
+            dx = agent.x - shelter.x
+            dy = agent.y - shelter.y
+            d = max(1.0, (dx * dx + dy * dy) ** 0.5)
+            agent.x = float(agent.x + (dx / d) * 60.0)
+            agent.y = float(agent.y + (dy / d) * 60.0)
+        world.emit(
+            Event(
+                tick=world.tick_count,
+                type="irrational_act",
+                subject=agent.id,
+                detail="bolted outside",
+                severity="warn",
+            )
+        )
+    elif outcome == "attack_neighbour":
+        neighbours = [
+            n for n in _eligible_agents(world)
+            if n.id != agent.id and distance(n, agent) <= 60.0
+        ]
+        if neighbours:
+            victim = world.rng.choice(neighbours)
+            setattr(victim, "status", Status.INCAPACITATED)
+            world.emit(
+                Event(
+                    tick=world.tick_count,
+                    type="incapacitated",
+                    subject=victim.id,
+                    detail=f"attacked by {agent.id}",
+                    severity="crit",
+                )
+            )
+        else:
+            world.emit(
+                Event(
+                    tick=world.tick_count,
+                    type="irrational_act",
+                    subject=agent.id,
+                    detail="lashed out at empty air",
+                    severity="info",
+                )
+            )
+    else:  # silent_collapse
+        setattr(agent, "status", Status.INCAPACITATED)
+        world.emit(
+            Event(
+                tick=world.tick_count,
+                type="incapacitated",
+                subject=agent.id,
+                detail="silent collapse",
+                severity="warn",
+            )
+        )
+
+    setattr(agent, "outcome_resolved", True)
+
+
+def _tick_irrational(world: World, agent: Agent) -> None:
+    """State machine inside IRRATIONAL — outcome + recovery."""
+    since = int(getattr(agent, "irrational_since_tick", world.tick_count))
+    elapsed = world.tick_count - since
+    if elapsed == _IRRATIONAL_OUTCOME_TICKS and not getattr(agent, "outcome_resolved", False):
+        _resolve_outcome(world, agent)
+    if elapsed >= _IRRATIONAL_TOTAL_TICKS:
+        # Recover (unless the outcome was a self-collapse).
+        if getattr(agent, "status", Status.ACTIVE) == Status.ACTIVE:
+            setattr(agent, "state", State.WANDERING)
+            setattr(agent, "fear", max(0.0, float(getattr(agent, "fear", 0.0)) - _FEAR_DRAIN_AFTER_BREAK))
+            setattr(agent, "outcome_resolved", False)
+            world.emit(
+                Event(
+                    tick=world.tick_count,
+                    type="recovered",
+                    subject=agent.id,
+                    detail="returned to senses",
+                    severity="info",
+                )
+            )
+
+
+# ----------------------------------------------------------------- public
+
+
+def propagate(world: World) -> None:
+    """One tick of fear propagation + irrational follow-up."""
+    creatures = world.creatures
+    eligible = _eligible_agents(world)
+
+    if creatures:
+        for agent in eligible:
+            brave = float(getattr(agent, "brave", 0.5))
+            # Closest creature drives the gain (avoid stacking multiplicatively).
+            min_d = None
+            for c in creatures:
+                d = distance(agent, c)
+                if min_d is None or d < min_d:
+                    min_d = d
+            if min_d is None:
+                continue
+            gain = _fear_gain(brave, min_d)
+            if gain > 0.0:
+                current = float(getattr(agent, "fear", 0.0))
+                setattr(agent, "fear", min(100.0, current + gain))
+
+    # Always run break + irrational follow-up (gives agents who broke a creature
+    # back a chance to recover even after the creature has retreated).
+    for agent in eligible:
+        if getattr(agent, "state", None) == State.IRRATIONAL:
+            _tick_irrational(world, agent)
+        else:
+            _maybe_break(world, agent)

--- a/from-simulation/app/agents/fear.py
+++ b/from-simulation/app/agents/fear.py
@@ -25,7 +25,7 @@ from __future__ import annotations
 
 from typing import List, Optional
 
-from contracts import Agent, Event, State, Status, World
+from contracts import Agent, Event, Phase, State, Status, World
 from agents.base import distance, nearest
 from agents import supernatural as _supernatural
 
@@ -84,11 +84,31 @@ def _maybe_break(world: World, agent: Agent) -> None:
 
 
 def _resolve_outcome(world: World, agent: Agent) -> None:
-    """Sample an outcome once the agent has been IRRATIONAL long enough."""
+    """Sample an outcome once the agent has been IRRATIONAL long enough.
+
+    v9 — when the agent has beliefs about local danger (``house_weak:X``
+    nearby) or a specific suspect (``yellow_suspect:Y``), the outcome
+    distribution skews accordingly: distrust the shelter and bolt outside,
+    or lash out at the perceived villain.
+    """
     outcomes = ("unlock_door", "run_outside", "attack_neighbour", "silent_collapse")
     # Light weighting: silent_collapse rarer, others roughly even.
-    weights = (3.0, 3.0, 3.0, 1.5)
-    outcome = world.rng.choices(outcomes, weights=weights, k=1)[0]
+    w = [3.0, 3.0, 3.0, 1.5]
+    mind = getattr(agent, "mind", None)
+    if mind is not None:
+        # Find the nearest building id for "house_weak" lookups.
+        nearest_b = nearest(list(world.buildings.values()), agent.x, agent.y)
+        if nearest_b is not None:
+            hw = mind.beliefs.get(f"house_weak:{nearest_b.id}")
+            if hw is not None and hw.confidence > 0.4:
+                w[1] += 2.5 * hw.confidence   # +run_outside (don't trust this shelter)
+                w[0] += 1.0 * hw.confidence   # +unlock_door (something to escape from)
+        # Any active suspicion tips toward attack_neighbour.
+        for key, belief in mind.beliefs.items():
+            if key.startswith("yellow_suspect:") and belief.confidence > 0.5:
+                w[2] += 2.0 * belief.confidence
+                break
+    outcome = world.rng.choices(outcomes, weights=w, k=1)[0]
 
     if outcome == "unlock_door":
         target = nearest(list(world.buildings.values()), agent.x, agent.y)
@@ -127,7 +147,24 @@ def _resolve_outcome(world: World, agent: Agent) -> None:
             if n.id != agent.id and distance(n, agent) <= 60.0
         ]
         if neighbours:
-            victim = world.rng.choice(neighbours)
+            # v9 — if any neighbour is the subject of an active yellow_suspect
+            # belief, the agent lashes at THEM specifically (the "I knew it
+            # was you" moment). Otherwise uniform random.
+            suspect_id: Optional[str] = None
+            mind = getattr(agent, "mind", None)
+            if mind is not None:
+                for key, belief in mind.beliefs.items():
+                    if key.startswith("yellow_suspect:") and belief.confidence > 0.5:
+                        suspect_id = key.split(":", 1)[1]
+                        break
+            if suspect_id is not None:
+                preferred = [n for n in neighbours if n.id == suspect_id]
+                if preferred:
+                    victim = preferred[0]
+                else:
+                    victim = world.rng.choice(neighbours)
+            else:
+                victim = world.rng.choice(neighbours)
             setattr(victim, "status", Status.INCAPACITATED)
             world.emit(
                 Event(
@@ -194,21 +231,61 @@ def propagate(world: World) -> None:
     creatures = world.creatures
     eligible = _eligible_agents(world)
 
+    # Find the nearest creature for each agent in a single pass; reused for
+    # both fear gain and the decay path so a hidden agent decays even with
+    # creatures nearby.
+    nearest_dist: dict = {}
     if creatures:
         for agent in eligible:
-            brave = float(getattr(agent, "brave", 0.5))
-            # Closest creature drives the gain (avoid stacking multiplicatively).
             min_d = None
             for c in creatures:
                 d = distance(agent, c)
                 if min_d is None or d < min_d:
                     min_d = d
+            nearest_dist[id(agent)] = min_d
+
+    if creatures:
+        for agent in eligible:
+            brave = float(getattr(agent, "brave", 0.5))
+            min_d = nearest_dist.get(id(agent))
             if min_d is None:
                 continue
             gain = _fear_gain(brave, min_d)
             if gain > 0.0:
                 current = float(getattr(agent, "fear", 0.0))
                 setattr(agent, "fear", min(100.0, current + gain))
+
+    # Fear decay: every tick, fear drifts back toward 0. Sheltering / sleeping
+    # in a protected building drains it fast; otherwise a small idle drain.
+    # Without this, a single creature night strands the whole village in
+    # FLEEING forever — observed in the live snapshot before this fix.
+    phase = world.time.phase
+    for agent in eligible:
+        cur = float(getattr(agent, "fear", 0.0))
+        if cur <= 0.0:
+            continue
+        state = getattr(agent, "state", None)
+        in_safe_shelter = False
+        dwelling_id = getattr(agent, "dwelling_id", None) or getattr(agent, "home_id", None)
+        if dwelling_id and dwelling_id in world.buildings:
+            b = world.buildings[dwelling_id]
+            if b.is_protected(world.tick_count):
+                in_safe_shelter = True
+        # Skip decay if a creature is within meaningful range (60 px) — that's
+        # active terror, fear should not regenerate downward.
+        min_d = nearest_dist.get(id(agent))
+        if min_d is not None and min_d < 60.0:
+            continue
+        if state == State.SLEEPING and in_safe_shelter:
+            drain = 1.20
+        elif state == State.SHELTERING and in_safe_shelter:
+            drain = 0.80
+        elif phase == Phase.DAY:
+            drain = 0.30
+        else:
+            drain = 0.10
+        new = max(0.0, cur - drain)
+        setattr(agent, "fear", new)
 
     # Always run break + irrational follow-up (gives agents who broke a creature
     # back a chance to recover even after the creature has retreated).

--- a/from-simulation/app/agents/food.py
+++ b/from-simulation/app/agents/food.py
@@ -1,0 +1,102 @@
+"""
+Food + farm tick loop.
+
+Owned by Agent A (engine). Per tick:
+
+  * Drain ``world.food_supply`` proportional to the number of "active" agents
+    (ACTIVE / RETURNING status — DEAD / INCAPACITATED don't consume).
+  * During DAY, when no farm disaster is active, regenerate food at a rate
+    scaled by ``world.farm_health``.
+  * Roll farm disasters (very rare per tick — ~1% per sim-day worth of ticks).
+    A disaster knocks ``farm_health`` down to 0.2..0.5 for ~1500 ticks
+    (~12.5 sim-minutes at 2 Hz) and emits ``farm_disaster``.
+  * When ``food_supply`` drops below the "low" threshold and we haven't
+    recently signalled, emit ``food_low`` and flip a transient
+    ``world.food_shortage`` signal flag for Agent B's society loop to read.
+
+Authorising an expedition is NOT done here — Agent B owns that. We just raise
+the flag.
+"""
+
+from __future__ import annotations
+
+from contracts import Event, Phase, Status, World
+
+
+# Tunables (could be lifted into Config later if we want them at runtime).
+_PER_AGENT_DRAIN = 0.02
+_REGEN_FACTOR = 0.15
+_LOW_THRESHOLD_FRAC = 0.25         # signal when food < 25% of capacity
+_LOW_REARM_FRAC = 0.45             # rearm only after food climbs above 45%
+_DISASTER_PROB_PER_TICK = 0.000417  # ~1% per sim-day worth of ticks (24 * 60 ticks at 2 Hz)
+_DISASTER_DURATION_TICKS = 1500
+
+
+def _active_agents(world: World) -> int:
+    """Count agents that still consume food."""
+    return sum(
+        1
+        for a in world.agents.values()
+        if getattr(a, "status", Status.ACTIVE) in (Status.ACTIVE, Status.RETURNING)
+    )
+
+
+def tick(world: World) -> None:
+    """One tick of the food / farm subsystem.
+
+    Side effects on World (all engine-owned fields):
+      * ``food_supply``
+      * ``farm_health``
+      * ``farm_disaster_until_tick``
+      * ``food_shortage`` (transient flag — created lazily as an attribute;
+        Agent B reads ``getattr(world, "food_shortage", False)``)
+    """
+    # Drain
+    drain = _active_agents(world) * _PER_AGENT_DRAIN
+    world.food_supply = max(0.0, world.food_supply - drain)
+
+    in_disaster = world.tick_count < world.farm_disaster_until_tick
+
+    # Regen during DAY when farm is healthy.
+    if world.time.phase == Phase.DAY and not in_disaster:
+        regen = max(0.0, world.farm_health) * _REGEN_FACTOR
+        world.food_supply = min(world.food_capacity, world.food_supply + regen)
+
+    # Disaster roll
+    if not in_disaster and world.rng.random() < _DISASTER_PROB_PER_TICK:
+        world.farm_health = world.rng.uniform(0.2, 0.5)
+        world.farm_disaster_until_tick = world.tick_count + _DISASTER_DURATION_TICKS
+        world.emit(
+            Event(
+                tick=world.tick_count,
+                type="farm_disaster",
+                subject="world",
+                detail=f"farm crippled (health={world.farm_health:.2f})",
+                severity="warn",
+            )
+        )
+
+    # Recovery once disaster expires.
+    if not in_disaster and world.farm_health < 1.0 and world.tick_count >= world.farm_disaster_until_tick:
+        # Gradual recovery toward full health.
+        world.farm_health = min(1.0, world.farm_health + 0.001)
+
+    # Low-food signalling. We use a "rearm" hysteresis so we don't spam events.
+    low_thresh = world.food_capacity * _LOW_THRESHOLD_FRAC
+    rearm_thresh = world.food_capacity * _LOW_REARM_FRAC
+    armed = getattr(world, "_food_low_signal_armed", True)
+    if armed and world.food_supply < low_thresh:
+        setattr(world, "food_shortage", True)
+        setattr(world, "_food_low_signal_armed", False)
+        world.emit(
+            Event(
+                tick=world.tick_count,
+                type="food_low",
+                subject="world",
+                detail=f"food_supply={world.food_supply:.1f}/{world.food_capacity:.0f}",
+                severity="warn",
+            )
+        )
+    elif not armed and world.food_supply >= rearm_thresh:
+        setattr(world, "food_shortage", False)
+        setattr(world, "_food_low_signal_armed", True)

--- a/from-simulation/app/agents/food.py
+++ b/from-simulation/app/agents/food.py
@@ -5,14 +5,16 @@ Owned by Agent A (engine). Per tick:
 
   * Drain ``world.food_supply`` proportional to the number of "active" agents
     (ACTIVE / RETURNING status — DEAD / INCAPACITATED don't consume).
-  * During DAY, when no farm disaster is active, regenerate food at a rate
-    scaled by ``world.farm_health``.
-  * Roll farm disasters (very rare per tick — ~1% per sim-day worth of ticks).
-    A disaster knocks ``farm_health`` down to 0.2..0.5 for ~1500 ticks
-    (~12.5 sim-minutes at 2 Hz) and emits ``farm_disaster``.
-  * When ``food_supply`` drops below the "low" threshold and we haven't
-    recently signalled, emit ``food_low`` and flip a transient
-    ``world.food_shortage`` signal flag for Agent B's society loop to read.
+  * During DAY, regenerate food. Regen scales with both the active population
+    and ``world.farm_health`` — so as NPCs accumulate across cycles, food
+    production scales up with the mouths to feed.
+  * v6+: the **barn** is the food store. While the barn is destroyed
+    (``world.barn_destroyed_until_tick``), regen is throttled to 15% of normal
+    and the food_shortage flag latches on so society pushes characters into
+    FORAGING runs at the windmill / lake until the structure is rebuilt.
+  * Roll farm disasters rarely. A disaster knocks farm_health down for a
+    couple of sim-days.
+  * Signal ``food_shortage`` to Agent B when supply is low (hysteresis).
 
 Authorising an expedition is NOT done here — Agent B owns that. We just raise
 the flag.
@@ -23,12 +25,52 @@ from __future__ import annotations
 from contracts import Event, Phase, Status, World
 
 
-# Tunables (could be lifted into Config later if we want them at runtime).
-_PER_AGENT_DRAIN = 0.02
-_REGEN_FACTOR = 0.15
-_LOW_THRESHOLD_FRAC = 0.25         # signal when food < 25% of capacity
-_LOW_REARM_FRAC = 0.45             # rearm only after food climbs above 45%
-_DISASTER_PROB_PER_TICK = 0.000417  # ~1% per sim-day worth of ticks (24 * 60 ticks at 2 Hz)
+# ------------------------------------------------------------------ tunables
+
+# Drain per active agent per tick. Lower than v5 (0.02 → 0.006 → 0.005) so a
+# stable village with regen-equal-to-drain holds at full larder; only a
+# disaster or a barn breach causes real pressure.
+_PER_AGENT_DRAIN = 0.005
+
+# v8 — food-shortage anxiety. When the larder runs low everyone loses
+# sanity and gains fear, not just the characters who run hunger meters.
+# These rates are per-agent, per-tick, multiplied by ``severity`` ∈ [0, 1]
+# where severity == (1 - food_supply / SHORTAGE_THRESHOLD). At the
+# threshold (severity=0) nothing happens; at zero food (severity=1) the
+# full rate fires.
+_SHORTAGE_THRESHOLD_FRAC = 0.35   # below 35% larder triggers anxiety
+_SHORTAGE_FEAR_PER_TICK = 0.08    # 0.0..0.08 per tick scaled by severity
+_SHORTAGE_SANITY_PER_TICK = 0.05  # 0.0..0.05 per tick scaled by severity
+
+# Regen scales with active agents so production keeps pace as NPCs arrive. At
+# farm_health=1.0 the regen factor is the multiplier on per-agent contribution.
+# Tuned so net day-cycle change is moderately positive (food climbs) and the
+# whole cycle (day+night) is roughly neutral, leaving slack for disasters.
+_REGEN_PER_AGENT = 0.013          # × active agents × farm_health × phase factor
+_REGEN_FLOOR = 0.10                # always at least this much during DAY
+# Phase multiplier on regen. DAY is full. DAWN/DUSK get partial credit so the
+# transitions don't feel like cliffs.
+_REGEN_PHASE_MULT = {
+    Phase.DAY: 1.0,
+    Phase.DAWN: 0.5,
+    Phase.DUSK: 0.3,
+    Phase.NIGHT: 0.0,
+}
+
+# Barn-destroyed regen multiplier. While the barn is down the village can't
+# store harvest — most of what's grown spoils. The forage mechanic in
+# characters.py picks up the slack by sending crews to the windmill/lake.
+_BARN_BROKEN_REGEN_MULT = 0.15
+
+# Low-food signalling thresholds.
+_LOW_THRESHOLD_FRAC = 0.30          # signal when food < 30% of capacity
+_LOW_REARM_FRAC = 0.55              # rearm only after food climbs above 55%
+
+# Farm disaster cadence. v5's 0.000417/tick = ~30%/sim-day was producing a
+# disaster roughly every other sim-day; the village spent most cycles in
+# disaster mode. Drop to ~0.00010/tick = ~7%/sim-day, so a healthy run
+# stretches several days between disasters.
+_DISASTER_PROB_PER_TICK = 0.00010
 _DISASTER_DURATION_TICKS = 1500
 
 
@@ -41,28 +83,39 @@ def _active_agents(world: World) -> int:
     )
 
 
-def tick(world: World) -> None:
-    """One tick of the food / farm subsystem.
+def _barn_broken(world: World) -> bool:
+    """True while the barn (food store) is out of action.
 
-    Side effects on World (all engine-owned fields):
-      * ``food_supply``
-      * ``farm_health``
-      * ``farm_disaster_until_tick``
-      * ``food_shortage`` (transient flag — created lazily as an attribute;
-        Agent B reads ``getattr(world, "food_shortage", False)``)
+    Field is lazily attached in agents/creatures.py the first time a creature
+    breaches the barn. Cleared when reset_world wipes the cycle.
     """
-    # Drain
-    drain = _active_agents(world) * _PER_AGENT_DRAIN
+    until = int(getattr(world, "barn_destroyed_until_tick", 0))
+    return until > 0 and world.tick_count < until
+
+
+def tick(world: World) -> None:
+    """One tick of the food / farm subsystem."""
+    active = _active_agents(world)
+
+    # ---- Drain
+    drain = active * _PER_AGENT_DRAIN
     world.food_supply = max(0.0, world.food_supply - drain)
 
     in_disaster = world.tick_count < world.farm_disaster_until_tick
+    barn_broken = _barn_broken(world)
 
-    # Regen during DAY when farm is healthy.
-    if world.time.phase == Phase.DAY and not in_disaster:
-        regen = max(0.0, world.farm_health) * _REGEN_FACTOR
+    # ---- Regen
+    phase_mult = _REGEN_PHASE_MULT.get(world.time.phase, 0.0)
+    if phase_mult > 0 and not in_disaster:
+        # Population-scaled regen plus a small floor so a village with very
+        # few survivors doesn't immediately starve.
+        regen = (active * _REGEN_PER_AGENT + _REGEN_FLOOR) * float(world.farm_health)
+        regen *= phase_mult
+        if barn_broken:
+            regen *= _BARN_BROKEN_REGEN_MULT
         world.food_supply = min(world.food_capacity, world.food_supply + regen)
 
-    # Disaster roll
+    # ---- Disaster roll (rare)
     if not in_disaster and world.rng.random() < _DISASTER_PROB_PER_TICK:
         world.farm_health = world.rng.uniform(0.2, 0.5)
         world.farm_disaster_until_tick = world.tick_count + _DISASTER_DURATION_TICKS
@@ -76,12 +129,12 @@ def tick(world: World) -> None:
             )
         )
 
-    # Recovery once disaster expires.
+    # ---- Disaster recovery
     if not in_disaster and world.farm_health < 1.0 and world.tick_count >= world.farm_disaster_until_tick:
-        # Gradual recovery toward full health.
         world.farm_health = min(1.0, world.farm_health + 0.001)
 
-    # Low-food signalling. We use a "rearm" hysteresis so we don't spam events.
+    # ---- Low-food signalling. The hysteresis prevents repeated
+    # food_low spam when the supply hovers around the threshold.
     low_thresh = world.food_capacity * _LOW_THRESHOLD_FRAC
     rearm_thresh = world.food_capacity * _LOW_REARM_FRAC
     armed = getattr(world, "_food_low_signal_armed", True)
@@ -100,3 +153,22 @@ def tick(world: World) -> None:
     elif not armed and world.food_supply >= rearm_thresh:
         setattr(world, "food_shortage", False)
         setattr(world, "_food_low_signal_armed", True)
+
+    # ---- v8 — food-shortage anxiety pings every active agent. Characters
+    # already have their own hunger → sanity coupling; this adds a global
+    # layer so NPCs (which don't track hunger) also feel the squeeze.
+    shortage_thresh = world.food_capacity * _SHORTAGE_THRESHOLD_FRAC
+    if world.food_supply < shortage_thresh and shortage_thresh > 0:
+        severity = max(0.0, min(1.0, 1.0 - world.food_supply / shortage_thresh))
+        fear_gain = _SHORTAGE_FEAR_PER_TICK * severity
+        sanity_loss = _SHORTAGE_SANITY_PER_TICK * severity
+        for a in world.agents.values():
+            if getattr(a, "status", Status.ACTIVE) not in (Status.ACTIVE, Status.RETURNING):
+                continue
+            try:
+                cur_fear = float(getattr(a, "fear", 0.0))
+                setattr(a, "fear", min(100.0, cur_fear + fear_gain))
+                cur_sanity = float(getattr(a, "sanity", 100.0))
+                setattr(a, "sanity", max(0.0, cur_sanity - sanity_loss))
+            except Exception:
+                pass

--- a/from-simulation/app/agents/forage.py
+++ b/from-simulation/app/agents/forage.py
@@ -1,0 +1,104 @@
+"""
+v7 — foraging mechanic.
+
+When ``world.barn_destroyed_until_tick > world.tick_count``, the colony's
+food store is gone and characters in ``State.FORAGING`` walk to one of the
+``FORAGE_ZONES`` (windmill, lakeside river, western pond), gather for
+``FORAGE_TICKS_TO_GATHER`` ticks, then return food directly to
+``world.food_supply``.
+
+Lifecycle:
+  1. Agent B picks FORAGING via the transition table (boosted when the barn
+     is down or food is low). Agent's ``target_x/target_y`` is set to a
+     forage zone in ``_target_for_role_and_state``.
+  2. ``tick_forage`` watches every FORAGING agent each tick:
+     - If they're > 20 px from the chosen zone, do nothing (they're walking).
+     - If within 20 px, increment ``forage_progress`` and emit a one-time
+       ``forage_started`` event.
+     - When progress hits ``FORAGE_TICKS_TO_GATHER`` add ``FORAGE_FOOD_PAYOFF``
+       food to the larder, emit ``forage_returned``, clear progress, snap
+       back to WANDERING so they walk home and re-enter the FSM normally.
+
+Wiring: ``simulation._do_tick`` calls ``tick_forage(world)`` after the
+character FSM has run (so state changes settle) and before food.tick (so any
+returned food is counted in this tick's drain calc).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from contracts import (
+    Event,
+    FORAGE_FOOD_PAYOFF,
+    FORAGE_TICKS_TO_GATHER,
+    FORAGE_ZONES,
+    State,
+    Status,
+    World,
+)
+
+
+_AT_ZONE_RADIUS_PX = 22.0
+
+
+def _at_forage_zone(agent: Any) -> bool:
+    chosen = getattr(agent, "_forage_zone", None)
+    if chosen is None:
+        return False
+    dx = float(agent.x) - chosen[0]
+    dy = float(agent.y) - chosen[1]
+    return (dx * dx + dy * dy) ** 0.5 <= _AT_ZONE_RADIUS_PX
+
+
+def tick_forage(world: World) -> None:
+    """Advance every FORAGING character's gather progress + emit on completion."""
+    for agent in list(world.agents.values()):
+        if getattr(agent, "state", None) != State.FORAGING:
+            # Drop any stale progress if they left the state for any reason.
+            if getattr(agent, "forage_progress", 0):
+                setattr(agent, "forage_progress", 0)
+            continue
+        if getattr(agent, "status", Status.ACTIVE) != Status.ACTIVE:
+            continue
+        if not _at_forage_zone(agent):
+            continue
+
+        progress = int(getattr(agent, "forage_progress", 0)) + 1
+        setattr(agent, "forage_progress", progress)
+
+        # First tick of progress — emit a started event so the journal /
+        # event log records the trip.
+        if progress == 1:
+            world.emit(Event(
+                tick=world.tick_count,
+                type="forage_started",
+                subject=getattr(agent, "id", "?"),
+                detail=(
+                    f"{getattr(agent, 'name', agent.id)} began foraging at "
+                    f"({getattr(agent, '_forage_zone', (0,0))[0]:.0f},"
+                    f"{getattr(agent, '_forage_zone', (0,0))[1]:.0f})"
+                ),
+                severity="info",
+            ))
+
+        if progress >= FORAGE_TICKS_TO_GATHER:
+            world.food_supply = min(
+                world.food_capacity,
+                world.food_supply + FORAGE_FOOD_PAYOFF,
+            )
+            world.emit(Event(
+                tick=world.tick_count,
+                type="forage_returned",
+                subject=getattr(agent, "id", "?"),
+                detail=(
+                    f"{getattr(agent, 'name', agent.id)} brought back "
+                    f"{FORAGE_FOOD_PAYOFF:.0f} food"
+                ),
+                severity="info",
+            ))
+            setattr(agent, "forage_progress", 0)
+            setattr(agent, "_forage_zone", None)
+            # Drop back to WANDERING so the regular FSM resumes; they'll walk
+            # home or pick a new state next tick.
+            agent.state = State.WANDERING

--- a/from-simulation/app/agents/lighthouse.py
+++ b/from-simulation/app/agents/lighthouse.py
@@ -26,7 +26,9 @@ from typing import Optional
 import legacy as _legacy
 from contracts import (
     Event,
+    LIGHTHOUSE_XY,
     Phase,
+    State,
     Status,
     World,
 )
@@ -56,9 +58,70 @@ _VOICE_LINES = [
 # inside the same tick by using a module-local set indexed by cycle.
 _called_cycles: set = set()
 
+# v6 — module-local set of cycles for which we've already emitted
+# ``lighthouse_walking``. Once we've biased the called character toward the
+# lighthouse, we don't want to keep re-emitting the same "started walking"
+# event every tick.
+_walking_emitted_cycles: set = set()
+
 
 def _find_lighthouse(world: World):
     return world.buildings.get("lighthouse")
+
+
+def _maybe_pull_called(world: World) -> None:
+    """v6 — explicit-targeting override.
+
+    Replaces the old "called character happens to wander within 30 px"
+    approach. When a call is active AND it's DUSK or NIGHT AND the called
+    character is still ACTIVE, we set ``state = State.CALLED`` and seed
+    ``target_x``/``target_y`` with the lighthouse coordinates. ``characters.py``
+    honours CALLED as a hard override and walks them straight there.
+
+    A single ``lighthouse_walking`` event is emitted on the first transition
+    so the activity feed has a clear "X is walking to the lighthouse" beat.
+    """
+    if world.lighthouse_called is None:
+        return
+    if world.time.phase not in (Phase.DUSK, Phase.NIGHT):
+        return
+    char = world.agents.get(world.lighthouse_called)
+    if char is None:
+        return
+    if getattr(char, "status", Status.ACTIVE) != Status.ACTIVE:
+        return
+
+    lx, ly = LIGHTHOUSE_XY
+
+    # First-transition guard: only emit the walking event once per cycle.
+    cycle = world.cycle_number
+    prev_state = getattr(char, "state", None)
+    if prev_state != State.CALLED and cycle not in _walking_emitted_cycles:
+        _walking_emitted_cycles.add(cycle)
+        name = getattr(char, "name", char.id)
+        world.emit(
+            Event(
+                tick=world.tick_count,
+                type="lighthouse_walking",
+                subject=char.id,
+                detail=f"{name} began walking toward the Lighthouse",
+                severity="warn",
+            )
+        )
+
+    # Hard override every tick a call is active during the night phases.
+    try:
+        char.state = State.CALLED
+    except Exception:
+        pass
+    try:
+        setattr(char, "target_x", float(lx))
+        setattr(char, "target_y", float(ly))
+        # Also write into the ``target`` tuple if the character uses one.
+        if hasattr(char, "target"):
+            char.target = (float(lx), float(ly))
+    except Exception:
+        pass
 
 
 def _maybe_call(world: World) -> None:
@@ -74,7 +137,11 @@ def _maybe_call(world: World) -> None:
     if tick_today < call_tick:
         return
 
-    # Find a callable target: highest sanity, ACTIVE character.
+    # Find a callable target. Originally always the highest-sanity character,
+    # but that made Boyd-the-sheriff the perennial pilgrim. v7: weight each
+    # candidate by sanity, then sample. The high-sanity ones are still more
+    # likely but every active character has a real shot, so the lighthouse
+    # rotates organically across cycles.
     candidates = [
         a for a in world.agents.values()
         if getattr(a, "status", Status.ACTIVE) == Status.ACTIVE
@@ -83,7 +150,8 @@ def _maybe_call(world: World) -> None:
     ]
     if not candidates:
         return
-    target = max(candidates, key=lambda a: float(getattr(a, "sanity", 100.0)))
+    weights = [max(1.0, float(getattr(a, "sanity", 50.0))) for a in candidates]
+    target = world.rng.choices(candidates, weights=weights, k=1)[0]
     world.lighthouse_called = target.id
     try:
         setattr(target, "called", True)
@@ -106,7 +174,9 @@ def _maybe_enter(world: World) -> None:
         return  # already inside
     if world.lighthouse_called is None:
         return
-    if world.time.phase != Phase.NIGHT:
+    # v6 — accept DUSK as well as NIGHT, since the character is now actively
+    # walking toward the lighthouse rather than wandering into it by accident.
+    if world.time.phase not in (Phase.DUSK, Phase.NIGHT):
         return
     char = world.agents.get(world.lighthouse_called)
     if char is None:
@@ -191,8 +261,14 @@ def tick_lighthouse(world: World) -> None:
     # Cycle wipes invalidate our memo: keep the set bounded.
     if len(_called_cycles) > 64:
         _called_cycles.clear()
+    if len(_walking_emitted_cycles) > 64:
+        _walking_emitted_cycles.clear()
 
     _sweep_removals(world)
     _maybe_call(world)
+    # v6 — pull the called character toward the lighthouse explicitly. Must
+    # run BEFORE _maybe_enter so the override applies on the same tick the
+    # character first becomes eligible.
+    _maybe_pull_called(world)
     _maybe_enter(world)
     _maybe_voice(world)

--- a/from-simulation/app/agents/lighthouse.py
+++ b/from-simulation/app/agents/lighthouse.py
@@ -1,0 +1,198 @@
+"""
+Lighthouse — Agent A v2 engine hook.
+
+Three responsibilities, all driven from ``tick_lighthouse(world)``:
+
+1. **Calling.** Once per cycle, at the tick corresponding to
+   ``int(lighthouse_call_tick_frac * 720)``, pick the highest-sanity ACTIVE
+   character and "call" them. We record the id on ``world.lighthouse_called``
+   and tag the character with ``called=True``. We do NOT change their state —
+   biasing toward LIGHTHOUSE is Agent B's concern.
+
+2. **Entering.** Each tick, check whether the called character has wandered
+   within 30 px of the lighthouse building at NIGHT. If so, the lighthouse
+   "swallows" them: voice activates, character becomes ABSENT and is queued
+   for removal next tick, a journal fragment is recorded.
+
+3. **Voice.** While ``world.lighthouse_voice_active`` is True, broadcast a
+   cryptic ``lighthouse_voice`` line about every 40 ticks. Lines are pulled
+   from a small template pool.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import legacy as _legacy
+from contracts import (
+    Event,
+    Phase,
+    Status,
+    World,
+)
+from agents.base import distance
+
+
+# One sim-day = 720 ticks at the configured cadence (12h * 60min / 2min step).
+_TICKS_PER_DAY = 720
+_ENTER_RADIUS_PX = 30.0
+_VOICE_CADENCE_TICKS = 40
+
+
+_VOICE_LINES = [
+    "It is colder where I am.",
+    "There are doors here you have not seen.",
+    "The roads loop. So do we.",
+    "You are not the first to answer.",
+    "The light is not for finding. It is for keeping.",
+    "Listen for the tone beneath the wind.",
+    "I see you from the bottom of the stairs.",
+    "Hold onto the names you still know.",
+]
+
+
+# Cycle-keyed memo for "did we already make the call this cycle?". Reset by
+# checking the call-tick equality but we also guard against duplicate emission
+# inside the same tick by using a module-local set indexed by cycle.
+_called_cycles: set = set()
+
+
+def _find_lighthouse(world: World):
+    return world.buildings.get("lighthouse")
+
+
+def _maybe_call(world: World) -> None:
+    cfg = world.config
+    call_tick = int(cfg.lighthouse_call_tick_frac * _TICKS_PER_DAY)
+    cycle = world.cycle_number
+    if cycle in _called_cycles:
+        return
+
+    # Tick-within-the-sim-day: SimTime advances 2 min per tick at TIME_SCALE=1,
+    # so dividing minutes-today by 2 recovers the tick index of the day.
+    tick_today = world.time.minutes_today // 2
+    if tick_today < call_tick:
+        return
+
+    # Find a callable target: highest sanity, ACTIVE character.
+    candidates = [
+        a for a in world.agents.values()
+        if getattr(a, "status", Status.ACTIVE) == Status.ACTIVE
+        and getattr(a, "kind", None) is not None
+        and getattr(a.kind, "value", "") == "character"
+    ]
+    if not candidates:
+        return
+    target = max(candidates, key=lambda a: float(getattr(a, "sanity", 100.0)))
+    world.lighthouse_called = target.id
+    try:
+        setattr(target, "called", True)
+    except Exception:
+        pass
+    _called_cycles.add(cycle)
+    world.emit(
+        Event(
+            tick=world.tick_count,
+            type="lighthouse_call",
+            subject=target.id,
+            detail="the Lighthouse has chosen you",
+            severity="warn",
+        )
+    )
+
+
+def _maybe_enter(world: World) -> None:
+    if world.lighthouse_voice_active:
+        return  # already inside
+    if world.lighthouse_called is None:
+        return
+    if world.time.phase != Phase.NIGHT:
+        return
+    char = world.agents.get(world.lighthouse_called)
+    if char is None:
+        return
+    house = _find_lighthouse(world)
+    if house is None:
+        return
+    if distance(char, house) > _ENTER_RADIUS_PX:
+        return
+
+    # Swallow the character.
+    world.lighthouse_voice_active = True
+    name = getattr(char, "name", char.id)
+    try:
+        setattr(char, "status", Status.ABSENT)
+    except Exception:
+        pass
+    # Mark for removal — Agent B's society pass and our own removal sweep
+    # both watch this flag. We don't pop from world.agents mid-iteration; we
+    # remove on the next tick at the top.
+    try:
+        setattr(char, "_remove_next_tick", True)
+    except Exception:
+        pass
+
+    world.emit(
+        Event(
+            tick=world.tick_count,
+            type="lighthouse_enter",
+            subject=char.id,
+            detail=f"{name} walked into the Lighthouse",
+            severity="crit",
+        )
+    )
+    _legacy.record(world, "lighthouse_enter", name=name)
+
+
+def _maybe_voice(world: World) -> None:
+    if not world.lighthouse_voice_active:
+        return
+    if world.tick_count <= 0:
+        return
+    if world.tick_count % _VOICE_CADENCE_TICKS != 0:
+        return
+    line = world.rng.choice(_VOICE_LINES)
+    speaker = world.lighthouse_called or "lighthouse"
+    world.emit(
+        Event(
+            tick=world.tick_count,
+            type="lighthouse_voice",
+            subject=speaker,
+            detail=line,
+            severity="info",
+        )
+    )
+
+
+def _sweep_removals(world: World) -> None:
+    """Drop any agents marked ``_remove_next_tick`` last tick."""
+    to_remove = [
+        aid for aid, a in world.agents.items()
+        if getattr(a, "_remove_next_tick", False)
+    ]
+    for aid in to_remove:
+        try:
+            del world.agents[aid]
+        except KeyError:
+            pass
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+def tick_lighthouse(world: World) -> None:
+    """Drive call/enter/voice for the Lighthouse subsystem.
+
+    Wired into ``simulation._do_tick`` after ``tick_yellow`` so a wipe-in-
+    progress can't race a lighthouse call.
+    """
+    # Cycle wipes invalidate our memo: keep the set bounded.
+    if len(_called_cycles) > 64:
+        _called_cycles.clear()
+
+    _sweep_removals(world)
+    _maybe_call(world)
+    _maybe_enter(world)
+    _maybe_voice(world)

--- a/from-simulation/app/agents/mind.py
+++ b/from-simulation/app/agents/mind.py
@@ -1,0 +1,734 @@
+"""
+v9 — Mind: the per-agent cognitive layer.
+
+Four layers sit between the existing weighted FSM and the existing LLM
+decider; they bias the menu, never replace it. The weighted-FSM choice
+in characters.py still runs last, so determinism with SEED holds.
+
+    Layer 1 — Memory Stream
+        Pulls rows out of ``world.memory`` (the SQLite character_memory
+        table) and scores them by recency × importance × structural
+        relevance (Jaccard over kind/subject tags). No embeddings,
+        no LLM — deterministic retrieval.
+
+    Layer 2 — Beliefs
+        On a reflection pass (every ``mind_reflect_every_ticks``), cluster
+        recent memories by ``(kind, subject)`` and emit at most three
+        beliefs per pass. Beliefs are persisted as ``character_memory``
+        rows with ``kind = "belief"`` so they survive process restarts.
+
+    Layer 3 — Goals
+        A deterministic rule table maps beliefs (and a few raw drives)
+        to one active ``Goal``. One goal at a time per agent.
+
+    Layer 4 — Plan / Intentions
+        ``shape_menu`` translates the active goal into additive weight
+        deltas on the existing FSM menu. ``goal_context`` produces a
+        one-line string for the optional LLM decider's extra_context.
+
+The ``NpcMind`` subclass is lighter — no LLM, no reflection by default,
+just the deterministic goal-from-drives rule table. NPCs that have been
+promoted to sub-mains opt into the full Mind via ``Mind`` directly.
+
+Telemetry: each cognitive op opens a child span when an OTel tracer is
+attached to ``world.telemetry``; metrics for active goals / beliefs are
+emitted from ``Mind.maybe_emit_gauges`` (called by the world's gauge
+sweep, not here).
+"""
+
+from __future__ import annotations
+
+import enum
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Tuple
+
+from contracts import (
+    Metric,
+    Phase,
+    Role,
+    State,
+    World,
+)
+
+
+# ---------------------------------------------------------------------------
+# Constants — kept module-local so they're discoverable next to the logic.
+# ---------------------------------------------------------------------------
+
+
+# Importance score per persisted event kind. Higher = more memorable.
+# Anything not listed gets a baseline of 1 so it still scores recency / relevance.
+_IMPORTANCE_TABLE: Dict[str, float] = {
+    "village_wipe": 10.0,
+    "char_death": 9.0,
+    "npc_death": 7.0,
+    "imposter_banished": 8.0,
+    "creature_breach": 7.0,
+    "meeting_outcome": 5.0,
+    "trust_shift": 4.0,
+    "homecoming": 4.0,
+    "journal_entry": 3.0,
+    "lighthouse_enter": 3.0,
+    "music_box_destroyed": 6.0,
+    "sub_main_died": 6.0,
+    "item_picked_up": 1.0,
+}
+
+# Half-life for the recency component, in ticks. ~1 sim-hour at default tick_hz.
+_RECENCY_HALF_LIFE_TICKS = 7200
+
+# All persisted event kinds the Mind can reflect over.
+_REFLECT_KINDS = tuple(_IMPORTANCE_TABLE.keys()) + ("belief", "reflection", "goal_open", "goal_closed")
+
+# How many top memories the retrieval returns at most.
+_RECALL_K = 8
+
+# How many beliefs a single reflection pass may emit.
+_REFLECT_BELIEFS_PER_PASS = 3
+
+# Decay multiplier applied to existing belief confidence every reflection pass.
+_BELIEF_DECAY = 0.98
+
+# Drop a belief when confidence falls below this.
+_BELIEF_MIN_CONF = 0.1
+
+
+# ---------------------------------------------------------------------------
+# Data classes
+# ---------------------------------------------------------------------------
+
+
+class GoalKind(str, enum.Enum):
+    PROTECT_X = "protect"          # bias SHELTERING + standing near X
+    INVESTIGATE_X = "investigate"  # bias INVESTIGATING + path to X
+    REVENGE_X = "revenge"          # bias MEETING + pushes argument states
+    FLEE_TO_Y = "flee"             # bias FLEEING toward Y
+    FIND_ITEM_Z = "find_item"      # bias WANDERING/FORAGING
+
+
+@dataclass
+class Belief:
+    key: str                       # e.g. "yellow_suspect:npc_07"
+    confidence: float              # 0..1
+    polarity: float                # -1..+1 (negative = denial)
+    source_event_ids: List[int] = field(default_factory=list)
+    created_tick: int = 0
+    last_seen_tick: int = 0
+    note: str = ""                 # one-line rationale (optional LLM flavour)
+
+    def decay(self) -> None:
+        self.confidence *= _BELIEF_DECAY
+
+
+@dataclass
+class Goal:
+    kind: GoalKind
+    target: str
+    priority: float                # 0..1
+    expires_at_tick: int
+    origin_belief_key: Optional[str] = None
+    opened_tick: int = 0
+
+
+# ---------------------------------------------------------------------------
+# Tracing helper — keeps spans optional so a missing tracer never crashes.
+# ---------------------------------------------------------------------------
+
+
+class _NullSpan:
+    def __enter__(self) -> "_NullSpan":
+        return self
+
+    def __exit__(self, *exc: Any) -> None:
+        return None
+
+    def set_attribute(self, *_a: Any, **_k: Any) -> None:
+        return None
+
+
+def _span(world: World, name: str):
+    """Start a child span if a tracer is attached; otherwise a no-op."""
+    tele = getattr(world, "telemetry", None)
+    if tele is None:
+        return _NullSpan()
+    try:
+        tracer = tele.get_tracer()
+        return tracer.start_as_current_span(name)
+    except Exception:
+        return _NullSpan()
+
+
+# ---------------------------------------------------------------------------
+# Mind
+# ---------------------------------------------------------------------------
+
+
+class Mind:
+    """Per-agent cognitive state. Cheap to construct; heavy work is gated."""
+
+    def __init__(self, agent_id: str) -> None:
+        self.agent_id = agent_id
+        self.beliefs: Dict[str, Belief] = {}
+        self.active_goal: Optional[Goal] = None
+        self.last_reflect_tick: int = -10**9
+        self.reflections_count: int = 0
+        self.last_recall_rows: int = 0  # for telemetry
+
+    # ------------------------------------------------------------- L1 recall
+    def recall(
+        self,
+        world: World,
+        kinds: Tuple[str, ...] = _REFLECT_KINDS,
+        lookback_ticks: Optional[int] = None,
+        query_tags: Optional[Tuple[str, ...]] = None,
+    ) -> List[Dict[str, Any]]:
+        """Return up to ``_RECALL_K`` scored memory rows for this agent.
+
+        score = mean(recency, importance, relevance) — all three in [0, 1].
+        Relevance is Jaccard overlap of ``(kind, subject)`` tags between the
+        query and the row. Falls back to an empty list when memory is off.
+        """
+        mem = getattr(world, "memory", None)
+        if mem is None:
+            return []
+        lookback = int(lookback_ticks or world.config.memory_recall_window_ticks * 12)
+        with _span(world, "mind.recall") as span:
+            span.set_attribute("actor", self.agent_id)
+            span.set_attribute("kinds", ",".join(kinds))
+            try:
+                rows = mem.recall_for(world, self.agent_id, kinds, lookback)
+            except Exception:
+                rows = []
+            scored = []
+            tags = set(query_tags or ())
+            now = int(world.tick_count)
+            for r in rows:
+                tick = int(r.get("tick", 0))
+                kind = str(r.get("kind", ""))
+                subject = str(r.get("subject", ""))
+                # Recency: exp half-life.
+                dt = max(0, now - tick)
+                recency = 0.5 ** (dt / _RECENCY_HALF_LIFE_TICKS)
+                # Importance: from the deterministic table, normalised.
+                importance = _IMPORTANCE_TABLE.get(kind, 1.0) / 10.0
+                # Relevance: Jaccard over row tags vs query tags. Empty query
+                # gives a neutral 0.5 so recency + importance carry the weight.
+                row_tags = {kind, subject} - {""}
+                if not tags:
+                    relevance = 0.5
+                else:
+                    inter = len(row_tags & tags)
+                    union = len(row_tags | tags) or 1
+                    relevance = inter / union
+                score = (recency + importance + relevance) / 3.0
+                scored.append((score, r))
+            scored.sort(key=lambda kv: kv[0], reverse=True)
+            top = [r for _, r in scored[:_RECALL_K]]
+            self.last_recall_rows = len(top)
+            span.set_attribute("rows_returned", len(top))
+            return top
+
+    # -------------------------------------------------------- L2 reflection
+    def maybe_reflect(self, world: World, agent: Any) -> None:
+        """Run reflection if the cadence has elapsed since the last pass."""
+        every = max(60, int(getattr(world.config, "mind_reflect_every_ticks", 600)))
+        if world.tick_count - self.last_reflect_tick < every:
+            # Still decay existing beliefs at a much cheaper cadence.
+            return
+        self._reflect(world, agent)
+        self.last_reflect_tick = world.tick_count
+
+    def _reflect(self, world: World, agent: Any) -> None:
+        with _span(world, "mind.reflect") as span:
+            span.set_attribute("actor", self.agent_id)
+            # 1) Decay existing beliefs uniformly so stale ones fall off.
+            for b in list(self.beliefs.values()):
+                b.decay()
+                if b.confidence < _BELIEF_MIN_CONF:
+                    self.beliefs.pop(b.key, None)
+            # 2) Pull up to top-50 (we use recall_for directly here to avoid
+            #    the recall scoring overhead — clustering wants raw rows).
+            mem = getattr(world, "memory", None)
+            if mem is None:
+                span.set_attribute("clusters", 0)
+                span.set_attribute("beliefs_emitted", 0)
+                return
+            try:
+                rows = mem.recall_for(
+                    world,
+                    self.agent_id,
+                    _REFLECT_KINDS,
+                    int(world.config.memory_recall_window_ticks * 12),
+                )
+            except Exception:
+                rows = []
+            # 3) Cluster by (kind, subject); count + sum-importance.
+            clusters: Dict[Tuple[str, str], Dict[str, Any]] = {}
+            for r in rows:
+                kind = str(r.get("kind", ""))
+                subject = str(r.get("subject", ""))
+                if not subject or kind in ("belief", "reflection", "goal_open", "goal_closed"):
+                    continue
+                key = (kind, subject)
+                c = clusters.setdefault(
+                    key, {"hits": 0, "imp": 0.0, "ticks": [], "last_tick": 0}
+                )
+                c["hits"] += 1
+                c["imp"] += _IMPORTANCE_TABLE.get(kind, 1.0)
+                c["last_tick"] = max(int(c["last_tick"]), int(r.get("tick", 0)))
+            # 4) Promote clusters into beliefs via the deterministic naming rules.
+            emitted = 0
+            for (kind, subject), c in clusters.items():
+                if emitted >= _REFLECT_BELIEFS_PER_PASS:
+                    break
+                if c["hits"] < 3 and c["imp"] < 12.0:
+                    continue
+                belief = self._belief_for_cluster(kind, subject, c, world.tick_count)
+                if belief is None:
+                    continue
+                # Bump confidence on existing belief instead of re-creating.
+                existing = self.beliefs.get(belief.key)
+                if existing is not None:
+                    existing.confidence = min(1.0, existing.confidence + 0.2 * belief.confidence)
+                    existing.last_seen_tick = world.tick_count
+                else:
+                    self.beliefs[belief.key] = belief
+                emitted += 1
+                self._persist_belief(world, belief)
+            span.set_attribute("clusters", len(clusters))
+            span.set_attribute("beliefs_emitted", emitted)
+            self.reflections_count += 1
+            # Telemetry: counter for reflection rate.
+            tele = getattr(world, "telemetry", None)
+            if tele is not None:
+                try:
+                    tele.counter_inc(
+                        Metric.MIND_REFLECTIONS_TOTAL, 1.0, {"actor": self.agent_id}
+                    )
+                except Exception:
+                    pass
+            # 5) Re-evaluate goal after new beliefs may have landed.
+            self.regoal(world, agent)
+
+    def _belief_for_cluster(
+        self,
+        kind: str,
+        subject: str,
+        cluster: Dict[str, Any],
+        tick: int,
+    ) -> Optional[Belief]:
+        hits = int(cluster["hits"])
+        conf = min(1.0, hits / 5.0)
+        # Deterministic naming. Subject is usually a building id or an actor id.
+        if kind == "creature_breach":
+            key = f"house_weak:{subject}"
+            return Belief(
+                key=key, confidence=conf, polarity=+1.0,
+                created_tick=tick, last_seen_tick=tick,
+                note=f"breaches at {subject} ×{hits}",
+            )
+        if kind == "trust_shift":
+            # If subject's trust shifted negatively often, mark them suspect.
+            key = f"yellow_suspect:{subject}"
+            return Belief(
+                key=key, confidence=conf, polarity=+1.0,
+                created_tick=tick, last_seen_tick=tick,
+                note=f"trust shifted around {subject} ×{hits}",
+            )
+        if kind == "meeting_outcome" and "imposter" in subject.lower():
+            key = f"council_distrust:{subject}"
+            return Belief(
+                key=key, confidence=conf, polarity=+1.0,
+                created_tick=tick, last_seen_tick=tick,
+                note=f"contested vote on {subject} ×{hits}",
+            )
+        if kind in ("char_death", "npc_death", "sub_main_died"):
+            key = f"loss:{subject}"
+            return Belief(
+                key=key, confidence=conf, polarity=+1.0,
+                created_tick=tick, last_seen_tick=tick,
+                note=f"loss of {subject}",
+            )
+        if kind == "imposter_banished":
+            key = f"yellow_resolved:{subject}"
+            return Belief(
+                key=key, confidence=conf, polarity=-1.0,
+                created_tick=tick, last_seen_tick=tick,
+                note=f"imposter banished: {subject}",
+            )
+        return None
+
+    def _persist_belief(self, world: World, belief: Belief) -> None:
+        mem = getattr(world, "memory", None)
+        if mem is None:
+            return
+        try:
+            mem.record_character_memory(
+                world,
+                self.agent_id,
+                "belief",
+                belief.key,
+                belief.note,
+                {
+                    "confidence": belief.confidence,
+                    "polarity": belief.polarity,
+                    "importance": 6,  # beliefs are mid-importance themselves
+                },
+            )
+        except Exception:
+            pass
+
+    # --------------------------------------------------------- L3 goals
+    def regoal(self, world: World, agent: Any) -> None:
+        """Evaluate beliefs + drives, possibly open or replace the active goal."""
+        with _span(world, "mind.regoal") as span:
+            span.set_attribute("actor", self.agent_id)
+            old = self.active_goal
+            # Expire stale goals.
+            if old is not None and world.tick_count >= old.expires_at_tick:
+                self._close_goal(world, old, reason="expired")
+                old = None
+            new = self._pick_goal(world, agent)
+            if new is None:
+                self.active_goal = old
+                span.set_attribute("old_goal", _goal_label(old))
+                span.set_attribute("new_goal", _goal_label(old))
+                return
+            # Only swap if the new goal is meaningfully higher priority.
+            if old is None or new.priority > old.priority + 0.05 or old.kind == new.kind and old.target != new.target:
+                if old is not None:
+                    self._close_goal(world, old, reason="replaced")
+                self.active_goal = new
+                self._open_goal(world, new)
+            span.set_attribute("old_goal", _goal_label(old))
+            span.set_attribute("new_goal", _goal_label(self.active_goal))
+
+    def _pick_goal(self, world: World, agent: Any) -> Optional[Goal]:
+        """Deterministic generator. One active goal at a time, picked by
+        highest priority among satisfied triggers."""
+        ttl = int(world.config.mind_goal_ttl_ticks)
+        candidates: List[Goal] = []
+        # PROTECT_X: house_weak:X with conf>0.6 + agent role is CARETAKER / SHERIFF / LEADER_COLONY
+        role = getattr(agent, "role", None)
+        protector = role in (Role.CARETAKER, Role.SHERIFF, Role.LEADER_COLONY, Role.PRIEST)
+        for key, b in self.beliefs.items():
+            if not key.startswith("house_weak:") or b.confidence < 0.6:
+                continue
+            target = key.split(":", 1)[1]
+            if not protector:
+                continue
+            candidates.append(Goal(
+                kind=GoalKind.PROTECT_X,
+                target=target,
+                priority=0.7 * b.confidence,
+                expires_at_tick=world.tick_count + ttl,
+                origin_belief_key=key,
+            ))
+        # REVENGE_X: yellow_suspect:Y with conf>0.5 — anyone can carry it.
+        for key, b in self.beliefs.items():
+            if not key.startswith("yellow_suspect:") or b.confidence < 0.5:
+                continue
+            target = key.split(":", 1)[1]
+            candidates.append(Goal(
+                kind=GoalKind.REVENGE_X,
+                target=target,
+                priority=0.8 * b.confidence,
+                expires_at_tick=world.tick_count + ttl,
+                origin_belief_key=key,
+            ))
+        # FIND_ITEM_Z: low food supply + a forager-shaped agent.
+        food_low = float(getattr(world, "food_supply", 100.0)) < 30.0
+        if food_low and role in (Role.ENGINEER, Role.BRIDGE, Role.INVESTIGATOR, Role.DEPUTY):
+            candidates.append(Goal(
+                kind=GoalKind.FIND_ITEM_Z,
+                target="food",
+                priority=0.6,
+                expires_at_tick=world.tick_count + ttl,
+                origin_belief_key=None,
+            ))
+        # INVESTIGATE_X: awareness[any_npc] > 0.7.
+        aware = getattr(agent, "awareness", None) or {}
+        if isinstance(aware, dict):
+            for npc_id, score in aware.items():
+                try:
+                    s = float(score)
+                except (TypeError, ValueError):
+                    continue
+                if s <= 0.7:
+                    continue
+                candidates.append(Goal(
+                    kind=GoalKind.INVESTIGATE_X,
+                    target=str(npc_id),
+                    priority=0.65 * min(1.0, s),
+                    expires_at_tick=world.tick_count + ttl,
+                    origin_belief_key=None,
+                ))
+                break  # one investigation is plenty
+        # FLEE_TO_Y: high fear and not yet home.
+        fear = float(getattr(agent, "fear", 0.0))
+        if fear > 70.0:
+            home_id = getattr(agent, "dwelling_id", None) or getattr(agent, "home_id", None)
+            if home_id:
+                candidates.append(Goal(
+                    kind=GoalKind.FLEE_TO_Y,
+                    target=str(home_id),
+                    priority=0.9,
+                    expires_at_tick=world.tick_count + ttl // 2,
+                    origin_belief_key=None,
+                ))
+        if not candidates:
+            return None
+        candidates.sort(key=lambda g: g.priority, reverse=True)
+        chosen = candidates[0]
+        chosen.opened_tick = world.tick_count
+        return chosen
+
+    def _open_goal(self, world: World, goal: Goal) -> None:
+        mem = getattr(world, "memory", None)
+        if mem is not None:
+            try:
+                mem.record_character_memory(
+                    world,
+                    self.agent_id,
+                    "goal_open",
+                    str(goal.kind.value),
+                    str(goal.target),
+                    {
+                        "priority": goal.priority,
+                        "origin_belief": goal.origin_belief_key or "",
+                        "importance": 5,
+                    },
+                )
+            except Exception:
+                pass
+        tele = getattr(world, "telemetry", None)
+        if tele is not None:
+            try:
+                tele.get_logger().info(
+                    "mind.goal_open actor=%s kind=%s target=%s priority=%.2f",
+                    self.agent_id, goal.kind.value, goal.target, goal.priority,
+                )
+            except Exception:
+                pass
+
+    def _close_goal(self, world: World, goal: Goal, *, reason: str) -> None:
+        mem = getattr(world, "memory", None)
+        if mem is not None:
+            try:
+                mem.record_character_memory(
+                    world,
+                    self.agent_id,
+                    "goal_closed",
+                    str(goal.kind.value),
+                    str(goal.target),
+                    {"reason": reason, "importance": 3},
+                )
+            except Exception:
+                pass
+
+    # ------------------------------------------------------- L4 plan / bias
+    def shape_menu(
+        self,
+        world: World,
+        agent: Any,
+        menu: List[Tuple[State, float]],
+    ) -> List[Tuple[State, float]]:
+        """Apply goal-derived additive weight deltas to the candidate menu.
+
+        Returns a NEW list — never mutates the caller's. Unknown states in
+        the goal's target table are silently ignored.
+        """
+        if not menu:
+            return menu
+        goal = self.active_goal
+        if goal is None:
+            return menu
+        with _span(world, "mind.shape_menu") as span:
+            span.set_attribute("actor", self.agent_id)
+            span.set_attribute("goal", _goal_label(goal))
+            deltas = self._menu_deltas(world, agent, goal)
+            span.set_attribute("weight_deltas", _deltas_label(deltas))
+            if not deltas:
+                return menu
+            out: List[Tuple[State, float]] = []
+            for s, w in menu:
+                out.append((s, max(0.0, float(w) + deltas.get(s, 0.0))))
+            return out
+
+    def _menu_deltas(
+        self, world: World, agent: Any, goal: Goal
+    ) -> Dict[State, float]:
+        d: Dict[State, float] = {}
+        if goal.kind == GoalKind.PROTECT_X:
+            d[State.SHELTERING] = 0.8
+            d[State.PATROLLING] = 0.4
+        elif goal.kind == GoalKind.REVENGE_X:
+            d[State.MEETING] = 1.5
+            d[State.ARGUING] = 0.4
+        elif goal.kind == GoalKind.INVESTIGATE_X:
+            d[State.INVESTIGATING] = 0.7
+            d[State.PATROLLING] = 0.3
+        elif goal.kind == GoalKind.FLEE_TO_Y:
+            d[State.FLEEING] = 1.4
+            d[State.SHELTERING] = 0.6
+        elif goal.kind == GoalKind.FIND_ITEM_Z:
+            # If the barn is down, FORAGING is the right verb; otherwise SCAVENGING.
+            if int(getattr(world, "barn_destroyed_until_tick", 0)) > world.tick_count:
+                d[State.FORAGING] = 1.0
+            else:
+                d[State.SCAVENGING] = 0.6
+                d[State.WANDERING] = 0.3
+        return d
+
+    def goal_context(self) -> str:
+        """A ≤140-char string passed as ``extra_context`` to the LLM decider."""
+        g = self.active_goal
+        if g is None:
+            return ""
+        return f"Goal: {g.kind.value}({g.target}) priority={g.priority:.2f}"
+
+    # ------------------------------------------------------------ snapshot
+    def to_snapshot(self) -> Dict[str, Any]:
+        """For the dossier endpoint. Not on the broadcast snapshot."""
+        top = sorted(
+            self.beliefs.values(), key=lambda b: b.confidence, reverse=True
+        )[:3]
+        return {
+            "active_goal": (
+                {
+                    "kind": self.active_goal.kind.value,
+                    "target": self.active_goal.target,
+                    "priority": round(self.active_goal.priority, 2),
+                    "origin_belief": self.active_goal.origin_belief_key or "",
+                    "opened_tick": self.active_goal.opened_tick,
+                }
+                if self.active_goal is not None
+                else None
+            ),
+            "beliefs": [
+                {
+                    "key": b.key,
+                    "confidence": round(b.confidence, 2),
+                    "polarity": int(b.polarity),
+                    "note": b.note,
+                    "last_seen_tick": b.last_seen_tick,
+                }
+                for b in top
+            ],
+            "reflections_count": self.reflections_count,
+            "last_reflect_tick": (
+                self.last_reflect_tick if self.last_reflect_tick > -10**8 else None
+            ),
+        }
+
+
+# ---------------------------------------------------------------------------
+# NpcMind — lighter cognitive layer for NPCs.
+# ---------------------------------------------------------------------------
+
+
+class NpcMind(Mind):
+    """No reflection; deterministic goal table only. Cheap per tick."""
+
+    def maybe_reflect(self, world: World, agent: Any) -> None:
+        # NPCs don't reflect by default. Only the deterministic goal path runs.
+        self.regoal(world, agent)
+
+    def _pick_goal(self, world: World, agent: Any) -> Optional[Goal]:
+        ttl = int(world.config.mind_goal_ttl_ticks)
+        candidates: List[Goal] = []
+        # FLEE_TO_Y: high fear, has a home, dusk/night.
+        fear = float(getattr(agent, "fear", 0.0))
+        phase = world.time.phase
+        home_id = getattr(agent, "home_id", None)
+        if fear > 60.0 and home_id and phase in (Phase.DUSK, Phase.NIGHT):
+            candidates.append(Goal(
+                kind=GoalKind.FLEE_TO_Y, target=str(home_id),
+                priority=0.8, expires_at_tick=world.tick_count + ttl // 3,
+            ))
+        # FIND_ITEM_Z: food crisis + barn down → forage.
+        barn_down = int(getattr(world, "barn_destroyed_until_tick", 0)) > world.tick_count
+        food_low = float(getattr(world, "food_supply", 100.0)) < 30.0
+        if food_low and barn_down:
+            candidates.append(Goal(
+                kind=GoalKind.FIND_ITEM_Z, target="food",
+                priority=0.55, expires_at_tick=world.tick_count + ttl // 2,
+            ))
+        if not candidates:
+            return None
+        candidates.sort(key=lambda g: g.priority, reverse=True)
+        chosen = candidates[0]
+        chosen.opened_tick = world.tick_count
+        return chosen
+
+    def _menu_deltas(self, world: World, agent: Any, goal: Goal) -> Dict[State, float]:
+        # NPC menu states are narrower: WORKING, SOCIALIZING, SHELTERING, FLEEING, FORAGING.
+        d: Dict[State, float] = {}
+        if goal.kind == GoalKind.FLEE_TO_Y:
+            d[State.FLEEING] = 1.2
+            d[State.SHELTERING] = 0.8
+        elif goal.kind == GoalKind.FIND_ITEM_Z:
+            d[State.FORAGING] = 0.9
+            d[State.WORKING] = 0.3
+        return d
+
+
+# ---------------------------------------------------------------------------
+# Tiny helpers
+# ---------------------------------------------------------------------------
+
+
+def _goal_label(g: Optional[Goal]) -> str:
+    if g is None:
+        return "none"
+    return f"{g.kind.value}:{g.target}"
+
+
+def _deltas_label(d: Dict[State, float]) -> str:
+    if not d:
+        return ""
+    return ",".join(f"{s.value}={v:+.2f}" for s, v in d.items())
+
+
+# ---------------------------------------------------------------------------
+# World-level gauge emitter — called by simulation.py after tick.
+# ---------------------------------------------------------------------------
+
+
+def emit_mind_gauges(world: World) -> None:
+    """Walk world.agents, push two gauges:
+        from_sim_mind_beliefs_active (sum across all minds)
+        from_sim_mind_goals_active{kind} (count per goal kind)
+    """
+    tele = getattr(world, "telemetry", None)
+    if tele is None:
+        return
+    beliefs = 0
+    by_kind: Dict[str, int] = {}
+    for a in world.agents.values():
+        m = getattr(a, "mind", None)
+        if m is None:
+            continue
+        beliefs += len(m.beliefs)
+        if m.active_goal is not None:
+            k = m.active_goal.kind.value
+            by_kind[k] = by_kind.get(k, 0) + 1
+    try:
+        tele.gauge_set(Metric.MIND_BELIEFS_ACTIVE, float(beliefs))
+    except Exception:
+        pass
+    # Push a gauge per kind for cardinality-bounded label series.
+    for k, n in by_kind.items():
+        try:
+            tele.gauge_set(Metric.MIND_GOALS_ACTIVE, float(n), {"kind": k})
+        except Exception:
+            pass
+    # Push zero gauges for the kinds we didn't see so series go to 0 instead of
+    # going stale, and the kinds remain enumerable.
+    for k in (gk.value for gk in GoalKind):
+        if k in by_kind:
+            continue
+        try:
+            tele.gauge_set(Metric.MIND_GOALS_ACTIVE, 0.0, {"kind": k})
+        except Exception:
+            pass

--- a/from-simulation/app/agents/music_box.py
+++ b/from-simulation/app/agents/music_box.py
@@ -293,6 +293,15 @@ def _begin_carry(world: World, box: MusicBox, agent: Any) -> None:
         pass
     world.music_box_carrier = getattr(agent, "id", None)
     world.worms_infected.add(getattr(agent, "id", ""))
+    # v5: NPC carriers earn a big notability bump — picking up the box is
+    # the most legendary thing an unnamed villager can do. Skip mains
+    # (they keep their canon names) and outsiders.
+    if getattr(agent, "kind", None) == AgentKind.NPC:
+        try:
+            from agents.promotion import bump_notability
+            bump_notability(agent, 1.5, "picked up the music box")
+        except Exception:
+            pass
     world.music_box_phase = "TOUCH"
     world.music_box_phase_until_tick = world.tick_count + cfg.music_box_phase_ticks
     line = "They touch."
@@ -756,6 +765,14 @@ def _tick_worms_passing(world: World) -> None:
             except ValueError:
                 pass
             world.worms_infected.discard(aid)
+            # v5: NPC killers earn a notability bump — killing a creature
+            # with the worms is the kind of thing the village will remember.
+            if getattr(agent, "kind", None) == AgentKind.NPC:
+                try:
+                    from agents.promotion import bump_notability
+                    bump_notability(agent, 0.6, "killed a creature with the worms")
+                except Exception:
+                    pass
             world.emit(
                 Event(
                     tick=world.tick_count,

--- a/from-simulation/app/agents/music_box.py
+++ b/from-simulation/app/agents/music_box.py
@@ -1,0 +1,813 @@
+"""
+The Music Box Monster — v4 horror set-piece.
+
+A four-phase tragedy keyed to the Rhyme:
+
+    "They touch, they break, they steal.
+     No one here is free.
+     Here they come, they come for three,
+     unless you stop the melody."
+
+Phase machine (stored on ``world.music_box_phase``):
+
+    DORMANT   No box on the map. Periodically spawn one at NIGHT; pickup
+              detection is also live during DORMANT once a box exists.
+    TOUCH     A villager is carrying the box. Box drains sanity, slowly
+              corrupts the house they enter, and worms start hopping to
+              creatures at night. Compulsion makes most carriers unable
+              to drop it.
+    BREAK     One villager dies in their sleep within 200 px of the box.
+    STEAL     Three villagers go catatonic (``Status.STOLEN``) and a swarm
+              of cicada markers appears around them.
+    TERMINAL  All stolen villagers die. Phase resets to DORMANT, the rhyme
+              survives in the journal.
+
+Destruction: a carrier reaching ``RUINS_XY`` within ``music_box_destroy_radius``
+ends the lifecycle, restores stolen villagers, and clears the worms.
+
+Worms-passing (S2 trick): a worm-infected character within 30 px of a
+creature at NIGHT has a 20% chance to "give" the worm to the creature,
+killing it. This is an alternative way to break the curse.
+
+Engine hook: ``tick_music_box(world)`` is called by ``simulation._do_tick``
+between ``tick_population`` and ``tick_yellow``.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any, Dict, List, Optional, Tuple
+
+from contracts import (
+    Agent,
+    AgentKind,
+    Event,
+    FARAWAY_TREES,
+    MarkerClass,
+    Phase,
+    RUINS_XY,
+    State,
+    Status,
+    World,
+    YELLOW_MARCH_PATH,
+)
+from agents.base import distance, nearest
+
+import legacy
+
+
+# Phase encoding used by simulation._emit_metrics gauge.
+PHASE_NUM = {
+    "DORMANT": 0,
+    "TOUCH": 1,
+    "BREAK": 2,
+    "STEAL": 3,
+    "TERMINAL": 4,
+}
+
+
+# ---------------------------------------------------------------------------
+# Markers — MusicBox + transient Cicada swarm sprites
+# ---------------------------------------------------------------------------
+
+
+class MusicBox(Agent):
+    """The lone Music Box marker. Lives in ``world.supernaturals``.
+
+    The engine hook ``tick_music_box`` is what actually moves the box, drains
+    sanity, escalates phases, etc. The instance ``tick`` is a no-op so we can
+    sit in the supernaturals list without being double-stepped.
+    """
+
+    def __init__(self, sid: str, x: float, y: float, spawned_at_tick: int) -> None:
+        self.id = sid
+        self.kind = AgentKind.SUPERNATURAL
+        self.marker_class = MarkerClass.MUSIC_BOX
+        self.x = float(x)
+        self.y = float(y)
+        self.spawned_at_tick = int(spawned_at_tick)
+        self.last_house_id: Optional[str] = None
+        # Internal: tick at which the most recent BREAK death has fired, so we
+        # don't kill more than one villager per BREAK phase entry.
+        self._break_fired_at_tick: int = -1
+
+    def tick(self, world: World) -> None:  # pragma: no cover — driven externally
+        return None
+
+    def to_dict(self) -> Dict[str, Any]:
+        base = super().to_dict()
+        base["kind_detail"] = "music_box"
+        base["last_house"] = self.last_house_id
+        return base
+
+
+class Cicada(Agent):
+    """Transient swarm sprite — purely cosmetic decay marker."""
+
+    def __init__(self, sid: str, x: float, y: float, expires_at_tick: int) -> None:
+        self.id = sid
+        self.kind = AgentKind.SUPERNATURAL
+        self.marker_class = MarkerClass.CICADA
+        self.x = float(x)
+        self.y = float(y)
+        self.expires_at_tick = int(expires_at_tick)
+        self.alive = True
+
+    def tick(self, world: World) -> None:
+        # Drift a few pixels, expire when due.
+        self.x += world.rng.uniform(-1.2, 1.2)
+        self.y += world.rng.uniform(-1.2, 1.2)
+        if world.tick_count >= self.expires_at_tick:
+            self.alive = False
+
+    def to_dict(self) -> Dict[str, Any]:
+        base = super().to_dict()
+        base["kind_detail"] = "cicada"
+        return base
+
+
+def spawn_cicadas(
+    world: World, around_xy: Tuple[float, float], count: int, ttl: int
+) -> None:
+    """Append ``count`` cicada markers near ``around_xy`` for ``ttl`` ticks."""
+    cx, cy = around_xy
+    expires = world.tick_count + max(1, ttl)
+    for _ in range(max(0, int(count))):
+        sid = f"cicada_{world.tick_count}_{world.rng.randint(0, 10_000_000)}"
+        x = cx + world.rng.uniform(-40.0, 40.0)
+        y = cy + world.rng.uniform(-40.0, 40.0)
+        world.supernaturals.append(Cicada(sid, x, y, expires))
+
+
+# ---------------------------------------------------------------------------
+# Module-local scheduling state — survives across phase changes, NOT wipes.
+# (A v2-style reset on village_wipe could clear this; for now it self-heals
+# because DORMANT spawn checks against world.tick_count are stateless.)
+# ---------------------------------------------------------------------------
+
+
+_LAST_SPAWN_TICK: int = -10_000_000
+
+
+def _ticks_per_day(world: World) -> int:
+    scale = max(0.001, float(world.config.time_scale))
+    return max(60, int(1440.0 / scale))
+
+
+def _find_box(world: World) -> Optional[MusicBox]:
+    if world.music_box_id is None:
+        return None
+    for s in world.supernaturals:
+        if getattr(s, "id", None) == world.music_box_id and isinstance(s, MusicBox):
+            return s
+    return None
+
+
+# ---------------------------------------------------------------------------
+# DORMANT — spawning + pickup detection
+# ---------------------------------------------------------------------------
+
+
+def _pick_spawn_xy(world: World) -> Tuple[float, float]:
+    """50% near a tree, 30% near a dwelling door, 20% on a road waypoint."""
+    rng = world.rng
+    roll = rng.random()
+    if roll < 0.5 and FARAWAY_TREES:
+        tx, ty = rng.choice(FARAWAY_TREES)
+        return tx + rng.uniform(-25.0, 25.0), ty + rng.uniform(-25.0, 25.0)
+    if roll < 0.8 and world.buildings:
+        dwellings = [
+            b for b in world.buildings.values()
+            if b.role_tag in ("house", "matthews", "colony", "diner", "bar")
+        ]
+        if not dwellings:
+            dwellings = list(world.buildings.values())
+        b = rng.choice(dwellings)
+        # Drop just outside the door.
+        return b.x + rng.uniform(-15.0, 15.0), b.y + rng.uniform(20.0, 40.0)
+    # Fallback / 20% — a road waypoint.
+    if YELLOW_MARCH_PATH:
+        wx, wy = rng.choice(YELLOW_MARCH_PATH)
+        return wx + rng.uniform(-10.0, 10.0), wy + rng.uniform(-10.0, 10.0)
+    return 400.0 + rng.uniform(-40.0, 40.0), 480.0 + rng.uniform(-40.0, 40.0)
+
+
+def _spawn_box(world: World, xy: Optional[Tuple[float, float]] = None) -> MusicBox:
+    global _LAST_SPAWN_TICK
+    if xy is None:
+        x, y = _pick_spawn_xy(world)
+    else:
+        x, y = xy
+    sid = f"music_box_{world.tick_count}_{world.rng.randint(0, 10_000_000)}"
+    box = MusicBox(sid, x, y, world.tick_count)
+    world.supernaturals.append(box)
+    world.music_box_id = sid
+    _LAST_SPAWN_TICK = world.tick_count
+    world.emit(
+        Event(
+            tick=world.tick_count,
+            type="music_box_appeared",
+            subject=sid,
+            detail=f"x={round(x,1)} y={round(y,1)}",
+            severity="warn",
+        )
+    )
+    return box
+
+
+def _maybe_spawn(world: World) -> None:
+    """DORMANT-phase: drop a box at NIGHT if the cadence has elapsed."""
+    if _find_box(world) is not None:
+        return
+    if world.time.phase != Phase.NIGHT:
+        return
+    interval = max(1, world.config.music_box_interval_days) * _ticks_per_day(world)
+    if world.tick_count < _LAST_SPAWN_TICK + interval:
+        return
+    _spawn_box(world)
+
+
+def force_drop(
+    world: World, location: Optional[Tuple[float, float]] = None
+) -> Optional[MusicBox]:
+    """Force-spawn a Music Box NOW regardless of cadence.
+
+    Used by Yellow Man (or future LLM/admin hooks) to trigger the lifecycle
+    out-of-band. No-op if a box already exists. Returns the new box, or None.
+    """
+    if _find_box(world) is not None:
+        return None
+    return _spawn_box(world, location)
+
+
+def _curiosity_score(agent: Any) -> float:
+    """High score = more likely to pick up the box.
+
+    Uses ``personality`` dict if present (Character), else attribute fallbacks.
+    Defaults: social=0.4, sanity=100, paranoid=0.5. Sanity is clamped 0..100.
+    """
+    pers = getattr(agent, "personality", None)
+    if isinstance(pers, dict):
+        social = float(pers.get("social", 0.4))
+        paranoid = float(pers.get("paranoid", 0.5))
+    else:
+        social = float(getattr(agent, "social", 0.4))
+        paranoid = float(getattr(agent, "paranoid", 0.5))
+    sanity = float(getattr(agent, "sanity", 100.0))
+    sanity = max(0.0, min(100.0, sanity)) / 100.0
+    return social * 0.7 + (1.0 - sanity) * 0.3 - paranoid * 0.4
+
+
+def _pickup_detection(world: World, box: MusicBox) -> bool:
+    """Check every agent within curiosity radius. Returns True if picked up."""
+    if world.music_box_carrier is not None:
+        return False
+    cfg = world.config
+    rng = world.rng
+    candidates: List[Any] = []
+    for a in world.agents.values():
+        if getattr(a, "kind", None) not in (AgentKind.CHARACTER, AgentKind.NPC, AgentKind.OUTSIDER):
+            continue
+        if getattr(a, "status", Status.ACTIVE) != Status.ACTIVE:
+            continue
+        if distance(a, box) <= cfg.music_box_curiosity_radius:
+            candidates.append(a)
+    if not candidates:
+        return False
+    # Iterate in random order so position-in-dict bias doesn't dominate.
+    rng.shuffle(candidates)
+    for a in candidates:
+        score = _curiosity_score(a)
+        if score > rng.random():
+            _begin_carry(world, box, a)
+            return True
+    return False
+
+
+def _begin_carry(world: World, box: MusicBox, agent: Any) -> None:
+    """Transition: agent picks up the box; phase DORMANT -> TOUCH."""
+    cfg = world.config
+    try:
+        agent.state = State.CARRYING_BOX
+    except Exception:
+        pass
+    world.music_box_carrier = getattr(agent, "id", None)
+    world.worms_infected.add(getattr(agent, "id", ""))
+    world.music_box_phase = "TOUCH"
+    world.music_box_phase_until_tick = world.tick_count + cfg.music_box_phase_ticks
+    line = "They touch."
+    if line not in world.rhyme_heard:
+        world.rhyme_heard.append(line)
+    world.emit(
+        Event(
+            tick=world.tick_count,
+            type="music_box_picked_up",
+            subject=getattr(agent, "id", "?"),
+            detail=f"box={box.id}",
+            severity="warn",
+        )
+    )
+    world.emit(
+        Event(
+            tick=world.tick_count,
+            type="rhyme_line",
+            subject="world",
+            detail=line,
+            severity="info",
+        )
+    )
+
+
+# ---------------------------------------------------------------------------
+# TOUCH — carrier mechanics
+# ---------------------------------------------------------------------------
+
+
+def _compulsion_resists(agent: Any) -> bool:
+    """Return True if the agent's resolve is strong enough to *drop* the box."""
+    pers = getattr(agent, "personality", None)
+    if isinstance(pers, dict):
+        brave = float(pers.get("brave", 0.4))
+        devout = float(pers.get("devout", 0.3))
+        paranoid = float(pers.get("paranoid", 0.5))
+    else:
+        brave = float(getattr(agent, "brave", 0.4))
+        devout = float(getattr(agent, "devout", 0.3))
+        paranoid = float(getattr(agent, "paranoid", 0.5))
+    sanity = float(getattr(agent, "sanity", 100.0))
+    sanity = max(0.0, min(100.0, sanity)) / 100.0
+    # Threshold: harder to break out the more frayed they are.
+    return (brave + devout) > 1.2 + paranoid + (1.0 - sanity) * 0.5
+
+
+def _drop_box(world: World, box: MusicBox, agent: Optional[Any], reason: str) -> None:
+    if agent is not None:
+        try:
+            if agent.state == State.CARRYING_BOX:
+                agent.state = State.WANDERING
+        except Exception:
+            pass
+    world.music_box_carrier = None
+    world.emit(
+        Event(
+            tick=world.tick_count,
+            type="music_box_dropped",
+            subject=getattr(agent, "id", "?") if agent is not None else "?",
+            detail=reason,
+            severity="info",
+        )
+    )
+
+
+def _nearest_building(world: World, x: float, y: float, radius: float):
+    best = None
+    best_d = radius
+    for b in world.buildings.values():
+        d = math.hypot(b.x - x, b.y - y)
+        if d <= best_d:
+            best_d = d
+            best = b
+    return best
+
+
+def _apply_in_house(world: World, box: MusicBox, carrier: Any) -> None:
+    """Carrier inside a building: corrupt talisman, drain occupants, scare bystanders."""
+    b = _nearest_building(world, box.x, box.y, 30.0)
+    if b is None:
+        box.last_house_id = None
+        return
+    box.last_house_id = b.id
+    cfg = world.config
+    # Talisman failure roll — only meaningful for protected houses.
+    if b.has_talisman and world.rng.random() < cfg.music_box_talisman_fail_prob:
+        new_until = world.tick_count + max(50, cfg.house_cooling_off_ticks // 16)
+        if new_until > b.cooling_off_until_tick:
+            b.cooling_off_until_tick = new_until
+            world.emit(
+                Event(
+                    tick=world.tick_count,
+                    type="music_box_in_house",
+                    subject=b.id,
+                    detail=f"talisman flickers, box={box.id}",
+                    severity="warn",
+                )
+            )
+            world.emit(
+                Event(
+                    tick=world.tick_count,
+                    type="house_cooling_off",
+                    subject=b.id,
+                    detail=f"until_tick={new_until}",
+                    severity="warn",
+                )
+            )
+    # Sanity drain on occupants.
+    for occ_id in list(b.occupants):
+        occ = world.agents.get(occ_id)
+        if occ is None:
+            continue
+        s = getattr(occ, "sanity", None)
+        if s is None:
+            continue
+        try:
+            occ.sanity = max(0.0, float(s) - 0.5)
+        except Exception:
+            pass
+    # +fear on bystanders within 60 px.
+    for a in world.agents.values():
+        if a is carrier:
+            continue
+        if distance(a, box) > 60.0:
+            continue
+        f = getattr(a, "fear", None)
+        if f is None:
+            continue
+        try:
+            a.fear = min(100.0, float(f) + 2.0)
+        except Exception:
+            pass
+
+
+def _tick_touch(world: World, box: MusicBox) -> None:
+    cfg = world.config
+    carrier = world.agents.get(world.music_box_carrier) if world.music_box_carrier else None
+
+    # Carrier missing / dead -> drop and stay in TOUCH so someone else can pick up.
+    if carrier is None or getattr(carrier, "status", Status.ACTIVE) != Status.ACTIVE:
+        if world.music_box_carrier is not None:
+            _drop_box(world, box, carrier, "carrier_lost")
+        # Allow re-pickup this same tick.
+        _pickup_detection(world, box)
+        return
+
+    # Mirror box to carrier.
+    box.x = float(carrier.x)
+    box.y = float(carrier.y)
+
+    # Compulsion drop?
+    if _compulsion_resists(carrier):
+        _drop_box(world, box, carrier, "broke_compulsion")
+        return
+
+    # Worm drain.
+    s = getattr(carrier, "sanity", None)
+    if s is not None:
+        try:
+            carrier.sanity = max(0.0, float(s) - cfg.music_box_sanity_drain)
+        except Exception:
+            pass
+
+    # House mechanics.
+    _apply_in_house(world, box, carrier)
+
+    # Phase escalation.
+    if world.tick_count >= world.music_box_phase_until_tick:
+        _advance_phase(world, box, to_phase="BREAK")
+
+
+# ---------------------------------------------------------------------------
+# Phase transitions: BREAK / STEAL / TERMINAL
+# ---------------------------------------------------------------------------
+
+
+def _advance_phase(world: World, box: MusicBox, to_phase: str) -> None:
+    cfg = world.config
+    world.music_box_phase = to_phase
+    world.music_box_phase_until_tick = world.tick_count + cfg.music_box_phase_ticks
+    if to_phase == "BREAK":
+        line = "They break."
+    elif to_phase == "STEAL":
+        line = "Here they come, they come for three,"
+    elif to_phase == "TERMINAL":
+        line = "unless you stop the melody."
+    else:
+        line = ""
+    if line and line not in world.rhyme_heard:
+        world.rhyme_heard.append(line)
+        world.emit(
+            Event(
+                tick=world.tick_count,
+                type="rhyme_line",
+                subject="world",
+                detail=line,
+                severity="warn" if to_phase in ("BREAK", "STEAL") else "crit",
+            )
+        )
+    # STEAL has on-entry side effects.
+    if to_phase == "STEAL":
+        _do_steal_entry(world, box)
+
+
+def _nearby_villagers(world: World, box: MusicBox, radius: float) -> List[Any]:
+    out = []
+    for a in world.agents.values():
+        if getattr(a, "kind", None) not in (AgentKind.CHARACTER, AgentKind.NPC, AgentKind.OUTSIDER):
+            continue
+        if getattr(a, "status", Status.ACTIVE) != Status.ACTIVE:
+            continue
+        if a.id == world.music_box_carrier:
+            continue
+        if distance(a, box) <= radius:
+            out.append(a)
+    return out
+
+
+def _tick_break(world: World, box: MusicBox) -> None:
+    """One nearby villager dies in their sleep. Fires once per BREAK entry."""
+    # Mirror box to carrier if still held.
+    carrier = world.agents.get(world.music_box_carrier) if world.music_box_carrier else None
+    if carrier is not None:
+        box.x = float(carrier.x)
+        box.y = float(carrier.y)
+
+    if box._break_fired_at_tick == -1 or box._break_fired_at_tick < (
+        world.music_box_phase_until_tick - world.config.music_box_phase_ticks
+    ):
+        # Pick a victim. Prefer NPCs, then fall back to characters.
+        nearby = _nearby_villagers(world, box, 200.0)
+        npcs = [a for a in nearby if getattr(a, "kind", None) == AgentKind.NPC]
+        pool = npcs if npcs else [a for a in nearby if getattr(a, "kind", None) == AgentKind.CHARACTER]
+        if pool:
+            victim = world.rng.choice(pool)
+            try:
+                victim.status = Status.DEAD
+            except Exception:
+                pass
+            try:
+                setattr(victim, "death_cause", "music_box_break")
+            except Exception:
+                pass
+            box._break_fired_at_tick = world.tick_count
+            name = getattr(victim, "name", None) or getattr(victim, "id", "?")
+            world.emit(
+                Event(
+                    tick=world.tick_count,
+                    type="break_death",
+                    subject=getattr(victim, "id", "?"),
+                    detail=f"{name} did not wake",
+                    severity="crit",
+                )
+            )
+            try:
+                legacy.record(world, "break_death", name=name)
+            except Exception:
+                pass
+        else:
+            # No victims in range — flag the fire so we don't retry every tick.
+            box._break_fired_at_tick = world.tick_count
+
+    if world.tick_count >= world.music_box_phase_until_tick:
+        _advance_phase(world, box, to_phase="STEAL")
+
+
+def _do_steal_entry(world: World, box: MusicBox) -> None:
+    """Pick three villagers, mark STOLEN, spawn cicada swarm around each."""
+    rng = world.rng
+    nearby = _nearby_villagers(world, box, 220.0)
+    if not nearby:
+        return
+    rng.shuffle(nearby)
+    victims = nearby[:3]
+    for v in victims:
+        try:
+            v.status = Status.STOLEN
+        except Exception:
+            pass
+        vid = getattr(v, "id", "?")
+        world.emit(
+            Event(
+                tick=world.tick_count,
+                type="steal_event",
+                subject=vid,
+                detail=f"taken by the music box",
+                severity="crit",
+            )
+        )
+        n_cicadas = rng.randint(5, 8)
+        spawn_cicadas(world, (float(v.x), float(v.y)), n_cicadas, ttl=world.config.music_box_phase_ticks * 2)
+
+
+def _tick_steal(world: World, box: MusicBox) -> None:
+    # Keep box visually with the carrier if still held.
+    carrier = world.agents.get(world.music_box_carrier) if world.music_box_carrier else None
+    if carrier is not None:
+        box.x = float(carrier.x)
+        box.y = float(carrier.y)
+    if world.tick_count >= world.music_box_phase_until_tick:
+        _advance_phase(world, box, to_phase="TERMINAL")
+
+
+def _tick_terminal(world: World, box: MusicBox) -> None:
+    """All STOLEN villagers die; phase resets to DORMANT."""
+    stolen_ids = []
+    for a in list(world.agents.values()):
+        if getattr(a, "status", None) == Status.STOLEN:
+            try:
+                a.status = Status.DEAD
+            except Exception:
+                pass
+            try:
+                setattr(a, "death_cause", "music_box_terminal")
+            except Exception:
+                pass
+            stolen_ids.append(getattr(a, "id", "?"))
+    world.emit(
+        Event(
+            tick=world.tick_count,
+            type="break_death",
+            subject="world",
+            detail=f"terminal: {len(stolen_ids)} dead",
+            severity="crit",
+        )
+    )
+    # Summary event (using an existing canonical type — village_terror isn't
+    # registered yet, fall back to journal_entry so we don't get an "unknown"
+    # telemetry tag).
+    world.emit(
+        Event(
+            tick=world.tick_count,
+            type="journal_entry",
+            subject="world",
+            detail="The melody ended. Three did not return.",
+            severity="crit",
+        )
+    )
+    _reset_to_dormant(world, box, preserve_rhyme=True)
+
+
+# ---------------------------------------------------------------------------
+# Destruction at the ruins
+# ---------------------------------------------------------------------------
+
+
+def _check_destruction(world: World, box: MusicBox) -> bool:
+    """If the carrier is at the ruins, destroy the box. Returns True if destroyed."""
+    if world.music_box_carrier is None:
+        return False
+    carrier = world.agents.get(world.music_box_carrier)
+    if carrier is None:
+        return False
+    cfg = world.config
+    rx, ry = RUINS_XY
+    if math.hypot(float(carrier.x) - rx, float(carrier.y) - ry) > cfg.music_box_destroy_radius:
+        return False
+
+    carrier_name = getattr(carrier, "name", None) or getattr(carrier, "id", "?")
+
+    # Restore STOLEN -> ACTIVE.
+    for a in world.agents.values():
+        if getattr(a, "status", None) == Status.STOLEN:
+            try:
+                a.status = Status.ACTIVE
+            except Exception:
+                pass
+
+    # Remove worm from carrier.
+    cid = getattr(carrier, "id", None)
+    if cid in world.worms_infected:
+        world.worms_infected.discard(cid)
+
+    # +5 sanity to everyone.
+    for a in world.agents.values():
+        s = getattr(a, "sanity", None)
+        if s is None:
+            continue
+        try:
+            a.sanity = min(100.0, float(s) + 5.0)
+        except Exception:
+            pass
+
+    _reset_to_dormant(world, box, preserve_rhyme=True)
+
+    world.emit(
+        Event(
+            tick=world.tick_count,
+            type="music_box_destroyed",
+            subject=cid or "?",
+            detail=f"shattered at the ruins by {carrier_name}",
+            severity="info",
+        )
+    )
+    try:
+        legacy.record(world, "music_box_destroyed", carrier=carrier_name)
+    except Exception:
+        pass
+    return True
+
+
+def _reset_to_dormant(world: World, box: MusicBox, preserve_rhyme: bool) -> None:
+    """Common cleanup for TERMINAL and destruction paths."""
+    # Strip the box + all cicadas from supernaturals.
+    box_id = box.id
+    world.supernaturals[:] = [
+        s for s in world.supernaturals
+        if not (
+            getattr(s, "id", None) == box_id
+            or getattr(s, "marker_class", None) == MarkerClass.CICADA
+        )
+    ]
+    # Reset carrier state if they're still CARRYING_BOX.
+    carrier = world.agents.get(world.music_box_carrier) if world.music_box_carrier else None
+    if carrier is not None:
+        try:
+            if carrier.state == State.CARRYING_BOX:
+                carrier.state = State.WANDERING
+        except Exception:
+            pass
+    # Clear worm flags — destruction cures everyone. (TERMINAL also clears so a
+    # fresh DORMANT doesn't carry the infection forever.)
+    world.worms_infected.clear()
+    world.music_box_phase = "DORMANT"
+    world.music_box_phase_until_tick = 0
+    world.music_box_id = None
+    world.music_box_carrier = None
+    if not preserve_rhyme:
+        world.rhyme_heard.clear()
+
+
+# ---------------------------------------------------------------------------
+# Worms passing — alt cure via creature contact
+# ---------------------------------------------------------------------------
+
+
+def _tick_worms_passing(world: World) -> None:
+    """At NIGHT: infected character within 30 px of a creature -> 20% kill creature, cure carrier."""
+    if world.time.phase != Phase.NIGHT:
+        return
+    if not world.worms_infected or not world.creatures:
+        return
+    rng = world.rng
+    # Iterate over a snapshot — we may mutate world.creatures.
+    for aid in list(world.worms_infected):
+        agent = world.agents.get(aid)
+        if agent is None:
+            continue
+        # Find nearest creature within 30 px.
+        target = None
+        for c in world.creatures:
+            if distance(agent, c) <= 30.0:
+                target = c
+                break
+        if target is None:
+            continue
+        if rng.random() < 0.20:
+            try:
+                world.creatures.remove(target)
+            except ValueError:
+                pass
+            world.worms_infected.discard(aid)
+            world.emit(
+                Event(
+                    tick=world.tick_count,
+                    type="worms_passed",
+                    subject=aid,
+                    detail=f"creature={getattr(target, 'id', '?')}",
+                    severity="info",
+                )
+            )
+
+
+# ---------------------------------------------------------------------------
+# Public engine hook
+# ---------------------------------------------------------------------------
+
+
+def tick_music_box(world: World) -> None:
+    """Engine hook — call once per tick, BEFORE tick_yellow."""
+    phase = world.music_box_phase
+
+    if phase == "DORMANT":
+        _maybe_spawn(world)
+        box = _find_box(world)
+        if box is not None:
+            _pickup_detection(world, box)
+        # Worms-passing only really matters once there's been a carrier, but
+        # safe to call unconditionally — it's a no-op when worms_infected empty.
+        _tick_worms_passing(world)
+        return
+
+    # Active-phase branches need the box; if it has vanished, reset.
+    box = _find_box(world)
+    if box is None:
+        # Defensive: rebuild a dormant world if the box disappeared.
+        world.music_box_phase = "DORMANT"
+        world.music_box_phase_until_tick = 0
+        world.music_box_id = None
+        world.music_box_carrier = None
+        return
+
+    # Destruction is checked every active tick.
+    if _check_destruction(world, box):
+        return
+
+    if phase == "TOUCH":
+        _tick_touch(world, box)
+    elif phase == "BREAK":
+        _tick_break(world, box)
+    elif phase == "STEAL":
+        _tick_steal(world, box)
+    elif phase == "TERMINAL":
+        _tick_terminal(world, box)
+
+    # Worms passing runs alongside the active phase too.
+    _tick_worms_passing(world)

--- a/from-simulation/app/agents/npc_problems.py
+++ b/from-simulation/app/agents/npc_problems.py
@@ -1,0 +1,225 @@
+"""
+NPC problems — sanity breaks inside talisman houses.
+
+This file owns the night-time risk that lives *inside* a protected building.
+The Creatures slice already handles outside threats (probing the door). Here
+the threat comes from the people themselves: an NPC with low sanity and high
+fear, sheltering inside a talisman building, has a small chance per tick to
+break — they hurt the house's protection (cool-off) and the people inside.
+
+Sequence on a successful break:
+
+1. The building's talisman is treated as failed (``cooling_off_until_tick``
+   advanced by ``config.house_cooling_off_ticks``). NPCs won't pick the house
+   as a new home until cool-off clears (Agent A's ``cooling_off.py`` handles
+   the timer and ``house_cleared`` event).
+2. A ``npc_sanity_break`` event fires with the offending NPC as subject.
+3. A ``creature_breach`` event also fires so v2's legacy distillation picks up
+   the building as a hash mark.
+4. Each occupant (NPC OR character) rolls ``config.npc_breach_death_prob``;
+   on hit they die. ``npc_death`` / ``char_death`` events follow.
+5. Surviving NPC occupants are displaced — given a new ``home_id`` that
+   excludes the breached house — and shoved ~30 px toward town centre.
+   ``npc_displaced`` and ``npc_settled`` events trail each relocation.
+
+Engine wiring: call ``tick_npc_problems(world)`` once per tick from
+``simulation._do_tick``. Safe to call every tick — it's a cheap no-op outside
+NIGHT.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import List, Tuple
+
+from contracts import (
+    AgentKind,
+    Building,
+    Event,
+    Phase,
+    Status,
+    World,
+)
+import legacy
+from agents.npcs import NPC, pick_home_id
+
+
+# Town-centre reference for the "shove displaced occupants away" calculation.
+_TOWN_CENTRE: Tuple[float, float] = (465.0, 475.0)
+_DISPLACE_PX = 30.0
+
+
+def _shove_toward_centre(agent, distance_px: float = _DISPLACE_PX) -> None:
+    """Move ``agent`` ~distance_px toward the town centre from its current spot."""
+    cx, cy = _TOWN_CENTRE
+    dx = cx - agent.x
+    dy = cy - agent.y
+    d = math.hypot(dx, dy)
+    if d <= 1e-3:
+        # Already at centre — push in an arbitrary direction.
+        agent.x += distance_px
+        return
+    agent.x = agent.x + (dx / d) * distance_px
+    agent.y = agent.y + (dy / d) * distance_px
+
+
+def _emit_house_cooling_off(world: World, building: Building, reason: str) -> None:
+    world.emit(
+        Event(
+            tick=world.tick_count,
+            type="house_cooling_off",
+            subject=building.id,
+            detail=f"{building.name} cooling off ({reason})",
+            severity="warn",
+        )
+    )
+
+
+def _trigger_break(world: World, npc: NPC, building: Building) -> None:
+    """One NPC's sanity broke inside ``building`` — apply the consequences."""
+    cfg = world.config
+
+    # 1) Mark the house as cooling off (talisman fails).
+    building.cooling_off_until_tick = world.tick_count + cfg.house_cooling_off_ticks
+    _emit_house_cooling_off(world, building, "sanity break")
+
+    # 2) Emit the sanity-break event itself.
+    world.emit(
+        Event(
+            tick=world.tick_count,
+            type="npc_sanity_break",
+            subject=npc.id,
+            detail=building.id,
+            severity="crit",
+        )
+    )
+    legacy.record(world, "npc_sanity_break", npc=npc.name, building=building.name)
+
+    # 3) Emit a creature_breach so v2's hash-mark distillation picks it up.
+    world.emit(
+        Event(
+            tick=world.tick_count,
+            type="creature_breach",
+            subject=building.id,
+            detail=f"talisman failed inside {building.name}",
+            severity="crit",
+        )
+    )
+
+    # 4) Roll death for every occupant (the breaker included).
+    occupant_ids: List[str] = list(building.occupants)
+    survivors: List[str] = []
+    for occ_id in occupant_ids:
+        agent = world.agents.get(occ_id)
+        if agent is None:
+            continue
+        if getattr(agent, "status", Status.ACTIVE) == Status.DEAD:
+            continue
+        if world.rng.random() < cfg.npc_breach_death_prob:
+            agent.status = Status.DEAD
+            kind = getattr(agent, "kind", None)
+            name = getattr(agent, "name", agent.id)
+            if kind == AgentKind.NPC:
+                world.emit(
+                    Event(
+                        tick=world.tick_count,
+                        type="npc_death",
+                        subject=agent.id,
+                        detail=f"{name} died when {building.name} broke",
+                        severity="crit",
+                    )
+                )
+            elif kind == AgentKind.CHARACTER:
+                world.emit(
+                    Event(
+                        tick=world.tick_count,
+                        type="char_death",
+                        subject=agent.id,
+                        detail=f"{name} died when {building.name} broke",
+                        severity="crit",
+                    )
+                )
+                legacy.record(world, "char_death", name=name)
+            # Drop from occupants so they don't get displaced as survivors.
+            building.occupants.discard(agent.id)
+        else:
+            survivors.append(occ_id)
+
+    # 5) Displace survivors. NPCs get a new home; characters just get shoved.
+    for sid in survivors:
+        agent = world.agents.get(sid)
+        if agent is None:
+            continue
+        # Leave the broken house's occupant set.
+        building.occupants.discard(sid)
+        # Move them ~30 px toward town centre.
+        _shove_toward_centre(agent)
+
+        if getattr(agent, "kind", None) == AgentKind.NPC:
+            new_home = pick_home_id(world, exclude=[building.id])
+            agent.home_id = new_home
+            # ``_indoors`` lives on NPC; reset it so the new home isn't
+            # already considered "inside" before they arrive.
+            try:
+                agent._indoors = False  # type: ignore[attr-defined]
+            except Exception:
+                pass
+            world.emit(
+                Event(
+                    tick=world.tick_count,
+                    type="npc_displaced",
+                    subject=agent.id,
+                    detail=f"left {building.id}",
+                    severity="warn",
+                )
+            )
+            if new_home is not None:
+                world.emit(
+                    Event(
+                        tick=world.tick_count,
+                        type="npc_settled",
+                        subject=new_home,
+                        detail=f"{agent.name} re-homed to {new_home}",
+                        severity="info",
+                    )
+                )
+
+
+def tick_npc_problems(world: World) -> None:
+    """Engine hook. Roll sanity breaks for NPCs sheltering at NIGHT.
+
+    Cheap no-op outside NIGHT. Only one break per building per tick (we stop
+    iterating that building's occupants once it goes into cool-off).
+    """
+    if world.time.phase != Phase.NIGHT:
+        return
+
+    cfg = world.config
+    tick = world.tick_count
+
+    # Walk a snapshot of buildings — _trigger_break mutates occupants and the
+    # cool-off field, but we only roll on currently-protected ones.
+    for building in list(world.buildings.values()):
+        if not building.is_protected(tick):
+            continue
+        if not building.occupants:
+            continue
+        # Snapshot occupants so we don't iterate over a mutating set.
+        for occ_id in list(building.occupants):
+            agent = world.agents.get(occ_id)
+            if agent is None:
+                continue
+            if getattr(agent, "kind", None) != AgentKind.NPC:
+                continue
+            if getattr(agent, "status", Status.ACTIVE) != Status.ACTIVE:
+                continue
+            sanity = float(getattr(agent, "sanity", 100.0))
+            fear = float(getattr(agent, "fear", 0.0))
+            if sanity >= cfg.npc_sanity_break_sanity:
+                continue
+            if fear <= cfg.npc_sanity_break_fear:
+                continue
+            if world.rng.random() < cfg.npc_sanity_break_prob:
+                _trigger_break(world, agent, building)
+                # House is now in cool-off — stop processing it this tick.
+                break

--- a/from-simulation/app/agents/npc_problems.py
+++ b/from-simulation/app/agents/npc_problems.py
@@ -95,6 +95,17 @@ def _trigger_break(world: World, npc: NPC, building: Building) -> None:
     )
     legacy.record(world, "npc_sanity_break", npc=npc.name, building=building.name)
 
+    # v5: bump the breaker's notability — unlocking a talisman door is the
+    # kind of thing the village will remember, even (especially) if they
+    # don't survive the night. The promotion tick will pick this up next
+    # pass; if the death roll below kills them, that's fine — they get
+    # remembered posthumously via the sub_main_died/tombstone path.
+    try:
+        from agents.promotion import bump_notability
+        bump_notability(npc, 0.8, "unlocked the door at " + building.id)
+    except Exception:
+        pass
+
     # 3) Emit a creature_breach so v2's hash-mark distillation picks it up.
     world.emit(
         Event(

--- a/from-simulation/app/agents/npcs.py
+++ b/from-simulation/app/agents/npcs.py
@@ -75,6 +75,55 @@ def generate_npc_name(world: World) -> str:
     return f"NPC-{world.rng.randint(1000, 9999)}"
 
 
+# v8 — surname / family assignment. Each NPC gets a surname so events can read
+# "Beatrice Marsh — bolted outside" instead of an anonymous first name. About a
+# third of arrivals join an existing surname (becoming family); the rest start
+# a new household. Family ties feed the cult mechanic in agents/cult.py.
+_FAMILY_SURNAMES = [
+    "Tate", "Reyes", "Hollander", "Burke", "Akeyo", "Vasquez", "Cromwell",
+    "Okafor", "Hendrix", "Walsh", "Marsh", "Quincey", "Dover", "Linde",
+    "Stoker", "Ashby", "Pendrake", "Yates", "Galt", "Roe",
+    "Fairchild", "Whitlock", "Carrow", "Sealy", "Penmark", "Vargas",
+]
+_FAMILY_MAX_SIZE = 5
+_FAMILY_JOIN_PROB = 0.35   # chance of joining an existing surname instead of new
+
+
+def assign_family(world: World, npc_id: str) -> str:
+    """Pick a surname for a fresh NPC.
+
+    With probability ``_FAMILY_JOIN_PROB`` we join an existing surname that
+    still has room (< ``_FAMILY_MAX_SIZE`` living members); otherwise we
+    spin up a fresh family. Returns the surname string.
+    """
+    rng = world.rng
+    # Count current surname memberships among living NPCs.
+    counts: Dict[str, int] = {}
+    for a in world.agents.values():
+        if getattr(a, "kind", None) != AgentKind.NPC:
+            continue
+        if getattr(a, "status", Status.ACTIVE) != Status.ACTIVE:
+            continue
+        if a.id == npc_id:
+            continue
+        sn = getattr(a, "surname", None)
+        if sn:
+            counts[sn] = counts.get(sn, 0) + 1
+
+    if counts and rng.random() < _FAMILY_JOIN_PROB:
+        available = [sn for sn, c in counts.items() if c < _FAMILY_MAX_SIZE]
+        if available:
+            return rng.choice(available)
+    # Fresh family — pick a surname not at capacity.
+    pool = list(_FAMILY_SURNAMES)
+    rng.shuffle(pool)
+    for sn in pool:
+        if counts.get(sn, 0) < _FAMILY_MAX_SIZE:
+            return sn
+    # All saturated — accept overflow.
+    return rng.choice(pool)
+
+
 def _distance(ax: float, ay: float, bx: float, by: float) -> float:
     """Euclidean distance; small helper so we don't depend on agents.base existing yet."""
     return math.hypot(ax - bx, ay - by)
@@ -128,7 +177,61 @@ def _talisman_door(world: World, rng) -> Optional[Tuple[float, float]]:
     return (b.x + rng.uniform(-12, 12), b.y + rng.uniform(18, 28))
 
 
-def pick_home_id(world: World, exclude: Optional[List[str]] = None) -> Optional[str]:
+def residents_count(world: World, building_id: str) -> int:
+    """v8 — number of living NPCs whose home_id is this building."""
+    count = 0
+    for a in world.agents.values():
+        if getattr(a, "kind", None) != AgentKind.NPC:
+            continue
+        if getattr(a, "status", Status.ACTIVE) != Status.ACTIVE:
+            continue
+        if getattr(a, "home_id", None) == building_id:
+            count += 1
+    return count
+
+
+def building_has_resident_slot(world: World, building) -> bool:
+    """v8 — capacity check based on assigned residents, not transient
+    occupants. A house with 4 NPCs calling it home (cap 5) reads as
+    1 slot left, regardless of who happens to be inside right now.
+    """
+    if building is None or getattr(building, "destroyed", False):
+        return False
+    cap = building.capacity if hasattr(building, "capacity") else int(building.footprint)
+    if cap <= 0:
+        return False
+    return residents_count(world, building.id) < cap
+
+
+def _find_open_dwelling(world: World, npc) -> Optional["Building"]:
+    """v8 — return the nearest residential building with a free slot, or None.
+
+    Used when an NPC's assigned home is full or destroyed at NIGHT. Looks
+    only at the canonical residential pool so the NPC doesn't sneak into
+    the bar or the barn. Capacity is judged by assigned residents (home_id)
+    not by who's currently inside the footprint, so an empty-during-the-day
+    house still counts as "full" if four NPCs live there.
+    """
+    best = None
+    best_d = float("inf")
+    for bid in NPC_HOME_BUILDINGS:
+        b = world.buildings.get(bid)
+        if b is None or getattr(b, "destroyed", False):
+            continue
+        if not building_has_resident_slot(world, b):
+            continue
+        d = _distance(npc.x, npc.y, b.x, b.y)
+        if d < best_d:
+            best_d = d
+            best = b
+    return best
+
+
+def pick_home_id(
+    world: World,
+    exclude: Optional[List[str]] = None,
+    npc_id: Optional[str] = None,
+) -> Optional[str]:
     """Pick a home building id for an NPC from the talisman residential pool.
 
     Excludes buildings currently in cooling-off (failed talisman) and any caller-
@@ -137,6 +240,11 @@ def pick_home_id(world: World, exclude: Optional[List[str]] = None) -> Optional[
 
     Weighted: ``colony_house`` is 4x more likely than the smaller houses, so the
     "big house" feels populated.
+
+    v9 — when ``npc_id`` is provided and points at a sub-main NPC with a
+    persisted ``preferred_home``, that home is favoured ~60% of the time
+    so promoted survivors come back to "their" house across cycles. We
+    only prefer it when the building is still eligible by the normal rules.
     """
     exclude_set = set(exclude or [])
     tick = world.tick_count
@@ -150,10 +258,27 @@ def pick_home_id(world: World, exclude: Optional[List[str]] = None) -> Optional[
             continue
         if b.cooling_off_until_tick > tick:
             continue
+        if getattr(b, "destroyed", False):
+            continue
+        # v8 — capacity = number of NPCs already calling this building home,
+        # NOT how many are physically inside right now. So a house with 4
+        # residents (cap 5) reads as 1 slot left even during the day when
+        # everyone is out at work. When all houses are full new arrivals
+        # remain homeless and exposed → survivors must build new lots.
+        if not building_has_resident_slot(world, b):
+            continue
         candidates.append(bid)
         weights.append(4 if bid == "colony_house" else 1)
     if not candidates:
         return None
+    # v9 — sub-main preferred home: 60% chance to honour the persisted choice.
+    if npc_id and world.memory is not None and npc_id in world.sub_mains:
+        try:
+            pref = world.memory.get_sub_main_preferred_home(npc_id)
+        except Exception:
+            pref = None
+        if pref and pref in candidates and world.rng.random() < 0.6:
+            return pref
     return world.rng.choices(candidates, weights=weights, k=1)[0]
 
 
@@ -232,14 +357,47 @@ class NPC(Agent):
         # v5 — tombstone window for sub-mains. When >0, _reap_dead leaves the
         # corpse in world.agents until world.tick_count reaches it.
         self._tombstone_until_tick: int = 0
+        # v6 — short human-readable sentence describing what the NPC is doing
+        # right now. Refreshed whenever the mini-FSM state changes (or the
+        # yellow-touched-at-night override kicks in). Surfaced via to_dict()
+        # for the roster + dossier panels.
+        self.intent: str = ""
+        # Cache of the last state we generated an intent for; used to avoid
+        # recomputing the string every tick when nothing changed.
+        self._last_intent_state: Optional[State] = None
+        self._last_intent_touched_night: bool = False
+        # v8 — family + cult fields. ``surname`` is assigned via
+        # ``assign_family`` at intake and used for kinship lookups; the
+        # ``cult_state`` flips to "SUSPECTED" or "CONVERTED" once losses
+        # in the NPC's family / friend graph cross a threshold (see
+        # agents/cult.py).
+        self.surname: str = ""
+        self.cult_state: str = "NONE"        # "NONE" | "SUSPECTED" | "CONVERTED"
+        self.cult_pressure: float = 0.0      # accumulator from losses
+        self.cult_converted_at_tick: int = 0
+        # v9 — lightweight cognitive layer for NPCs (deterministic only).
+        # Created up front so a missing world handle at init time doesn't
+        # matter; tick-time logic still gates usage on cfg.mind_npc_enabled.
+        try:
+            from agents.mind import NpcMind
+            self.mind = NpcMind(self.id)
+        except Exception:
+            self.mind = None
 
     # ---------------------------------------------------------------- API
 
     def to_dict(self):
         d = super().to_dict()
+        # v8 — surface a "First Surname" display name when the NPC has one
+        # so the event log and roster show "Beatrice Marsh" not "Beatrice".
+        display_name = (
+            f"{self.name} {self.surname}" if self.surname else self.name
+        )
         d.update(
             {
-                "name": self.name,
+                "name": display_name,
+                "first_name": self.name,
+                "surname": self.surname,
                 "state": self.state.value,
                 "status": self.status.value,
                 "fear": round(self.fear, 2),
@@ -252,6 +410,14 @@ class NPC(Agent):
                 # contracts._enrich_agent ``is_sub_main`` tag).
                 "is_sub_main": self.is_sub_main,
                 "notability_score": round(self.notability_score, 2),
+                # v6 — current intent sentence (may be "" if the NPC hasn't
+                # ticked yet or is parked as a car arrival).
+                "intent": self.intent,
+                # v8 — cult faction (NONE / SUSPECTED / CONVERTED).
+                "cult_state": self.cult_state,
+                # v8 — frontend hides indoor agents so the map reads
+                # "who is outside / exposed".
+                "indoors": bool(self._indoors),
             }
         )
         return d
@@ -332,6 +498,74 @@ class NPC(Agent):
             else:
                 self.state = State.WORKING
 
+    def _home_name(self, world: World) -> str:
+        """Display name of the assigned home building, or a generic fallback."""
+        if self.home_id is not None:
+            home = world.buildings.get(self.home_id)
+            if home is not None and home.name:
+                return home.name
+        return "home"
+
+    def _near_colony(self, world: World) -> bool:
+        colony = world.buildings.get("colony_house")
+        if colony is None:
+            return False
+        return _distance(self.x, self.y, colony.x, colony.y) < 80.0
+
+    def _near_social_venue(self, world: World) -> bool:
+        for tag in ("diner", "bar"):
+            venue = world.buildings.get(tag)
+            if venue is not None and _distance(self.x, self.y, venue.x, venue.y) < 60.0:
+                return True
+        return False
+
+    def _refresh_intent(self, world: World) -> None:
+        """Recompute ``self.intent`` from the current state + phase + flags.
+
+        Called from ``tick()`` after the mini-FSM has settled for this tick.
+        Cheap to call every tick — only updates the string when something
+        meaningful changed.
+        """
+        touched_night = (
+            self.id in world.yellow_touched_npcs
+            and world.time.phase == Phase.NIGHT
+        )
+        # Skip recompute if nothing relevant has changed.
+        if (
+            self.state == self._last_intent_state
+            and touched_night == self._last_intent_touched_night
+            and self.intent
+        ):
+            return
+
+        # Yellow-touched at NIGHT trumps the regular state text — they're not
+        # really sheltering, they're loitering near doors.
+        if touched_night:
+            self.intent = f"{self.name} is loitering near a doorway."
+        elif self.state == State.WORKING:
+            if self._near_colony(world):
+                self.intent = f"{self.name} is working at the colony farm."
+            else:
+                self.intent = f"{self.name} is going about their day."
+        elif self.state == State.SOCIALIZING:
+            if self._near_social_venue(world):
+                self.intent = f"{self.name} is chatting at the diner."
+            else:
+                self.intent = f"{self.name} is going about their day."
+        elif self.state == State.SHELTERING:
+            self.intent = f"{self.name} is at home behind locked doors."
+        elif self.state == State.WANDERING:
+            self.intent = f"{self.name} is wandering near {self._home_name(world)}."
+        elif self.state == State.IRRATIONAL:
+            self.intent = f"{self.name} is not themselves."
+        else:
+            # Any other state (e.g. transient FLEEING, ABSENT) — leave the
+            # intent vague rather than blank.
+            self.intent = f"{self.name} is going about their day."
+
+        self._last_intent_state = self.state
+        self._last_intent_touched_night = touched_night
+
     def force_wander(self, until_tick: int) -> None:
         """Called by yellow_man.py when the visible march passes nearby."""
         self._wander_until_tick = max(self._wander_until_tick, until_tick)
@@ -343,20 +577,74 @@ class NPC(Agent):
         if self.status != Status.ACTIVE:
             return
 
+        # v9 — lightweight cognition: deterministic goal pick. Cheap, no LLM.
+        # Behaviour effect is small (NPCs already react to fear / food via the
+        # mini-FSM); the value is making goals visible in telemetry and giving
+        # promoted sub-mains a continuous identity across cycles.
+        if (
+            getattr(self, "mind", None) is not None
+            and getattr(world.config, "mind_npc_enabled", True)
+        ):
+            try:
+                self.mind.maybe_reflect(world, self)
+            except Exception:
+                pass
+
+        # v6 — car-arrival pin. While Agent A is animating the arrival car for
+        # this NPC, freeze the mini-FSM so the passenger doesn't try to walk
+        # while still "in" the vehicle. Once cars.py clears
+        # ``world.car_pending_npc_id`` (car has parked), we resume normally.
+        # ``getattr`` is used for safety: contracts.py defines the field, but
+        # a hot-reloaded process from before the v6 fields landed wouldn't
+        # have it.
+        if getattr(world, "car_pending_npc_id", None) == self.id:
+            self.intent = f"{self.name} just stepped off a car."
+            # Reset cache so the *next* tick after the car clears recomputes
+            # a proper state-based intent string.
+            self._last_intent_state = None
+            self._last_intent_touched_night = False
+            return
+
+        # IRRATIONAL is fear.py's sticky state — without this early-return the
+        # NPC's mini-FSM stomps over it the same tick fear.py set it, breaking
+        # the 30-tick cooldown and producing tight paranormal_break spam.
+        if self.state == State.IRRATIONAL:
+            self._refresh_intent(world)
+            return
+
         # ----- Ensure we have a home (and a personality bucket).
         if self.home_id is None:
-            self.home_id = pick_home_id(world)
+            self.home_id = pick_home_id(world, npc_id=self.id)
         if self._bucket is None:
             self._bucket = _personality_bucket(self.id)
+        # v9 — record this home as the sub-main's preferred home on first
+        # binding (so it persists across cycles). Only writes for promoted
+        # NPCs; regular NPCs are anonymous and re-roll each cycle.
+        if (
+            self.is_sub_main
+            and self.home_id is not None
+            and world.memory is not None
+            and self.id in world.sub_mains
+        ):
+            try:
+                if world.memory.get_sub_main_preferred_home(self.id) is None:
+                    world.memory.set_sub_main_preferred_home(world, self.id, self.home_id)
+            except Exception:
+                pass
 
         # If our home went into cool-off (e.g. a sanity break happened there),
-        # drop it and try to find a new one next tick.
+        # OR was destroyed by a creature, drop it and try to find a new one.
+        # Otherwise the destroyed house's resident slot blocks both us and
+        # any new arrivals from settling elsewhere.
         if self.home_id is not None:
             home = world.buildings.get(self.home_id)
-            if home is not None and home.cooling_off_until_tick > world.tick_count:
+            if home is not None and (
+                home.cooling_off_until_tick > world.tick_count
+                or getattr(home, "destroyed", False)
+            ):
                 home.occupants.discard(self.id)
                 self._indoors = False
-                self.home_id = pick_home_id(world, exclude=[self.home_id])
+                self.home_id = pick_home_id(world, exclude=[self.home_id], npc_id=self.id)
 
         phase = world.time.phase
         rng = world.rng
@@ -401,15 +689,40 @@ class NPC(Agent):
         move_toward(self, self.target_x, self.target_y, step)
         self._update_state(world)
 
-        # ----- NIGHT shelter snap.
+        # ----- NIGHT shelter snap (v8 — capacity-aware).
+        # If our home is full we don't squeeze in; we try one of the other
+        # NPC home buildings. If they're ALL full we stay outside in
+        # WANDERING and become huntable, which is the point: overcrowding
+        # forces survivors to build new houses (see tick_house_repair) or
+        # die trying.
         if phase == Phase.NIGHT and self.home_id is not None:
             home = world.buildings.get(self.home_id)
-            if home is not None and _distance(self.x, self.y, home.x, home.y) < 20.0:
+            # Already inside? Keep our seat.
+            if home is not None and self.id in home.occupants:
                 self.x = home.x
                 self.y = home.y
-                home.occupants.add(self.id)
                 self._indoors = True
                 self.state = State.SHELTERING
+            elif home is not None and _distance(self.x, self.y, home.x, home.y) < 20.0:
+                if home.has_room() and not getattr(home, "destroyed", False):
+                    self.x = home.x
+                    self.y = home.y
+                    home.occupants.add(self.id)
+                    self._indoors = True
+                    self.state = State.SHELTERING
+                else:
+                    # Door is locked / full — look for another roof.
+                    backup = _find_open_dwelling(world, self)
+                    if backup is not None:
+                        self.x = backup.x
+                        self.y = backup.y
+                        backup.occupants.add(self.id)
+                        self._indoors = True
+                        self.state = State.SHELTERING
+                    else:
+                        # Nowhere to go. Stay outside.
+                        self._indoors = False
+                        self.state = State.WANDERING
             elif self._indoors:
                 # We left home (rare — but cleanup the occupants set).
                 if home is not None:
@@ -484,6 +797,9 @@ class NPC(Agent):
                     self.sanity = max(0.0, self.sanity - 0.1)
                     self.fear = min(100.0, self.fear + 0.05)
                     break
+
+        # ----- v6: refresh the intent sentence for the dossier / roster.
+        self._refresh_intent(world)
 
     # ----- helpers used by the new tick body --------------------------------
 

--- a/from-simulation/app/agents/npcs.py
+++ b/from-simulation/app/agents/npcs.py
@@ -19,17 +19,20 @@ Population spawning and death cleanup is handled by ``population.py``.
 from __future__ import annotations
 
 import math
-from typing import Optional, Tuple
+from typing import List, Optional, Tuple
 
 from contracts import (
     Agent,
     AgentKind,
+    Event,
     MarkerClass,
+    NPC_HOME_BUILDINGS,
     Phase,
     State,
     Status,
     World,
 )
+from agents.base import move_toward
 
 
 # 40 name pool — these are deliberately generic, frontier-flavoured first names.
@@ -125,6 +128,55 @@ def _talisman_door(world: World, rng) -> Optional[Tuple[float, float]]:
     return (b.x + rng.uniform(-12, 12), b.y + rng.uniform(18, 28))
 
 
+def pick_home_id(world: World, exclude: Optional[List[str]] = None) -> Optional[str]:
+    """Pick a home building id for an NPC from the talisman residential pool.
+
+    Excludes buildings currently in cooling-off (failed talisman) and any caller-
+    supplied exclude list (used when re-homing displaced NPCs after a breach so
+    they don't pick the same broken house).
+
+    Weighted: ``colony_house`` is 4x more likely than the smaller houses, so the
+    "big house" feels populated.
+    """
+    exclude_set = set(exclude or [])
+    tick = world.tick_count
+    candidates: List[str] = []
+    weights: List[int] = []
+    for bid in NPC_HOME_BUILDINGS:
+        if bid in exclude_set:
+            continue
+        b = world.buildings.get(bid)
+        if b is None:
+            continue
+        if b.cooling_off_until_tick > tick:
+            continue
+        candidates.append(bid)
+        weights.append(4 if bid == "colony_house" else 1)
+    if not candidates:
+        return None
+    return world.rng.choices(candidates, weights=weights, k=1)[0]
+
+
+def _building_id_for_role(world: World, role_tag: str) -> Optional[str]:
+    for b in world.buildings.values():
+        if b.role_tag == role_tag:
+            return b.id
+    return None
+
+
+def _personality_bucket(npc_id: str) -> str:
+    """Stable hash bucket: 50% worker, 25% socializer, 25% wanderer."""
+    # ``hash`` differs across runs in Python 3 by default, but the salted hash
+    # is stable within a process — good enough for "this NPC has a temperament"
+    # since NPC ids are themselves regenerated each cycle.
+    bucket = (sum(ord(c) for c in npc_id)) % 4
+    if bucket < 2:
+        return "worker"
+    if bucket == 2:
+        return "socializer"
+    return "wanderer"
+
+
 class NPC(Agent):
     """Unnamed villager. Owned by Agent C."""
 
@@ -145,14 +197,32 @@ class NPC(Agent):
         self.target_x = float(x)
         self.target_y = float(y)
         self.state: State = State.WORKING
+        # v4: NPCs use the 0-100 sanity/fear scale to match characters and the
+        # ``npc_sanity_break_*`` thresholds in Config.
         self.fear: float = 0.0
-        self.sanity: float = 1.0
+        self.sanity: float = 100.0
         self.status: Status = Status.ACTIVE
         self.arrived_at_tick: int = 0
         # WANDERING is forced for a few ticks when the Yellow Man marches by.
         self._wander_until_tick: int = 0
         # Re-target cooldown so we don't thrash every tick.
         self._retarget_at_tick: int = 0
+        # v4 — home binding + daily contributions.
+        self.home_id: Optional[str] = None
+        self.contribution_this_day: float = 0.0
+        self.last_contribution_tick: int = 0
+        # ``_indoors`` is True when we're currently inside our home (snapped to
+        # the building and added to its occupant set). Tracked locally so we
+        # can clean up the occupant entry when we leave.
+        self._indoors: bool = False
+        # Stable personality bucket — set lazily on first tick once we have a
+        # home id; kept here as a cache so we don't recompute every tick.
+        self._bucket: Optional[str] = None
+        # Socializer NPCs alternate between bar and diner. Toggled on retarget.
+        self._social_pref: str = "bar"
+        # Last day we flushed the daily contribution summary, so we only emit
+        # the npc_contribution event once per sim-day.
+        self._last_summary_day: int = -1
 
     # ---------------------------------------------------------------- API
 
@@ -167,6 +237,7 @@ class NPC(Agent):
                 "sanity": round(self.sanity, 2),
                 "target_x": round(self.target_x, 2),
                 "target_y": round(self.target_y, 2),
+                "home_id": self.home_id,
             }
         )
         return d
@@ -229,7 +300,10 @@ class NPC(Agent):
 
         phase = world.time.phase
         if phase == Phase.NIGHT:
-            # If we're close to a building, count as sheltering.
+            # If we're close to home (or any dwelling), count as sheltering.
+            if self._indoors:
+                self.state = State.SHELTERING
+                return
             near = _nearest_dwelling(world, self.x, self.y)
             if near is not None and _distance(self.x, self.y, near[1], near[2]) < 35:
                 self.state = State.SHELTERING
@@ -238,7 +312,11 @@ class NPC(Agent):
         elif phase == Phase.DUSK:
             self.state = State.SOCIALIZING
         else:
-            self.state = State.WORKING
+            # DAY / DAWN — socializer bucket gets SOCIALIZING, others WORKING.
+            if (self._bucket or _personality_bucket(self.id)) == "socializer":
+                self.state = State.SOCIALIZING
+            else:
+                self.state = State.WORKING
 
     def force_wander(self, until_tick: int) -> None:
         """Called by yellow_man.py when the visible march passes nearby."""
@@ -251,34 +329,179 @@ class NPC(Agent):
         if self.status != Status.ACTIVE:
             return
 
-        # (Re)pick a target if we've arrived or our cooldown ran out.
+        # ----- Ensure we have a home (and a personality bucket).
+        if self.home_id is None:
+            self.home_id = pick_home_id(world)
+        if self._bucket is None:
+            self._bucket = _personality_bucket(self.id)
+
+        # If our home went into cool-off (e.g. a sanity break happened there),
+        # drop it and try to find a new one next tick.
+        if self.home_id is not None:
+            home = world.buildings.get(self.home_id)
+            if home is not None and home.cooling_off_until_tick > world.tick_count:
+                home.occupants.discard(self.id)
+                self._indoors = False
+                self.home_id = pick_home_id(world, exclude=[self.home_id])
+
+        phase = world.time.phase
+        rng = world.rng
+        touched = self.id in world.yellow_touched_npcs
+
+        # ----- Pick / refresh the target based on phase + bucket.
         arrived = _distance(self.x, self.y, self.target_x, self.target_y) < 3.0
         if arrived or world.tick_count >= self._retarget_at_tick:
-            tx, ty = self._pick_target(world)
-            self.target_x = tx
-            self.target_y = ty
-            # 20 - 60 ticks until we re-pick, jittered per-NPC.
-            self._retarget_at_tick = world.tick_count + world.rng.randint(20, 60)
+            # Yellow-touched bias overrides everything except going home.
+            if touched and phase == Phase.DUSK:
+                tag = rng.choice(_YELLOW_TARGET_TAGS)
+                t = _building_target(world, tag)
+                if t is not None:
+                    self.target_x = t[0] + rng.uniform(-25, 25)
+                    self.target_y = t[1] + rng.uniform(10, 35)
+                else:
+                    self.target_x, self.target_y = self._home_target(world)
+            elif touched and phase == Phase.NIGHT:
+                t = _talisman_door(world, rng)
+                if t is not None:
+                    self.target_x, self.target_y = t
+                else:
+                    self.target_x, self.target_y = self._home_target(world)
+            elif phase == Phase.NIGHT or phase == Phase.DUSK:
+                # Head home for shelter (DUSK gets a head-start so they arrive
+                # before NIGHT proper).
+                self.target_x, self.target_y = self._home_target(world)
+            else:
+                # DAY / DAWN — drive by personality bucket.
+                self.target_x, self.target_y = self._day_target(world)
+
+            self._retarget_at_tick = world.tick_count + rng.randint(20, 60)
             if arrived:
                 self.arrived_at_tick = world.tick_count
 
-        # Step toward target. NPCs are deliberately slow vs creatures.
-        step = 6.0 if self.state == State.WANDERING else 3.5
-        self.x, self.y = _move_toward(self.x, self.y, self.target_x, self.target_y, step)
-
-        # FSM state mostly follows phase + position.
+        # ----- Move and update FSM state.
+        if self.state == State.WANDERING:
+            step = 6.0
+        else:
+            step = 3.5
+        # Use the canonical move_toward so future tooling can rely on it.
+        move_toward(self, self.target_x, self.target_y, step)
         self._update_state(world)
 
-        # Yellow-touched + standing near a talisman door at NIGHT subtly drains
-        # sanity for the NPC itself (a flavour effect; Agent B reads sanity from
-        # the snapshot, so this surfaces as "this newcomer seems off").
+        # ----- NIGHT shelter snap.
+        if phase == Phase.NIGHT and self.home_id is not None:
+            home = world.buildings.get(self.home_id)
+            if home is not None and _distance(self.x, self.y, home.x, home.y) < 20.0:
+                self.x = home.x
+                self.y = home.y
+                home.occupants.add(self.id)
+                self._indoors = True
+                self.state = State.SHELTERING
+            elif self._indoors:
+                # We left home (rare — but cleanup the occupants set).
+                if home is not None:
+                    home.occupants.discard(self.id)
+                self._indoors = False
+        elif self._indoors and self.home_id is not None:
+            # Phase rolled out of NIGHT — leave the home occupant set.
+            home = world.buildings.get(self.home_id)
+            if home is not None:
+                home.occupants.discard(self.id)
+            self._indoors = False
+
+        # ----- Daytime contributions.
+        if phase == Phase.DAY:
+            colony = world.buildings.get("colony_house")
+            if (
+                self.state == State.WORKING
+                and self._bucket == "worker"
+                and colony is not None
+                and _distance(self.x, self.y, colony.x, colony.y) < 80.0
+            ):
+                delta = 0.0008
+                world.farm_health = min(1.0, world.farm_health + delta)
+                self.contribution_this_day += delta
+                self.last_contribution_tick = world.tick_count
+            elif self.state == State.SOCIALIZING and self._bucket == "socializer":
+                bar = world.buildings.get("bar")
+                diner = world.buildings.get("diner")
+                near_venue = False
+                for venue in (bar, diner):
+                    if venue is not None and _distance(self.x, self.y, venue.x, venue.y) < 60.0:
+                        near_venue = True
+                        break
+                if near_venue:
+                    delta = 0.04
+                    for other in world.agents.values():
+                        if getattr(other, "kind", None) != AgentKind.CHARACTER:
+                            continue
+                        if _distance(self.x, self.y, other.x, other.y) > 60.0:
+                            continue
+                        cur = getattr(other, "sanity", None)
+                        if cur is None:
+                            continue
+                        # Characters use 0-100 scale.
+                        setattr(other, "sanity", min(100.0, cur + delta))
+                    self.contribution_this_day += delta
+                    self.last_contribution_tick = world.tick_count
+
+        # ----- Daily summary at DUSK boundary (18:00).
         if (
-            self.id in world.yellow_touched_npcs
-            and world.time.phase == Phase.NIGHT
+            world.time.hour == 18
+            and world.time.minute == 0
+            and self._last_summary_day != world.time.day
         ):
-            # Are we hovering next to a talisman building?
+            if self.contribution_this_day > 0.0:
+                world.emit(
+                    Event(
+                        tick=world.tick_count,
+                        type="npc_contribution",
+                        subject=self.id,
+                        detail=f"contributed {self.contribution_this_day:.2f}",
+                        severity="info",
+                    )
+                )
+            self.contribution_this_day = 0.0
+            self._last_summary_day = world.time.day
+
+        # ----- Yellow-touched flavour drain (kept from v1, scaled to 0-100).
+        if touched and phase == Phase.NIGHT:
             for b in world.buildings.values():
                 if b.has_talisman and _distance(self.x, self.y, b.x, b.y) < 30:
-                    self.sanity = max(0.0, self.sanity - 0.001)
-                    self.fear = min(1.0, self.fear + 0.0005)
+                    self.sanity = max(0.0, self.sanity - 0.1)
+                    self.fear = min(100.0, self.fear + 0.05)
                     break
+
+    # ----- helpers used by the new tick body --------------------------------
+
+    def _home_target(self, world: World) -> Tuple[float, float]:
+        """Where to walk at NIGHT/DUSK — toward the assigned home with jitter."""
+        if self.home_id is None:
+            # No home yet — fall back to the nearest dwelling like v1.
+            near = _nearest_dwelling(world, self.x, self.y)
+            if near is not None:
+                _, bx, by = near
+                return (bx, by)
+            return (self.x, self.y)
+        home = world.buildings.get(self.home_id)
+        if home is None:
+            return (self.x, self.y)
+        rng = world.rng
+        return (home.x + rng.uniform(-6, 6), home.y + rng.uniform(-6, 6))
+
+    def _day_target(self, world: World) -> Tuple[float, float]:
+        """DAY target driven by the personality bucket."""
+        rng = world.rng
+        bucket = self._bucket or _personality_bucket(self.id)
+        if bucket == "worker":
+            colony = world.buildings.get("colony_house")
+            if colony is not None:
+                return (colony.x + rng.uniform(-40, 40), colony.y + rng.uniform(-20, 30))
+        if bucket == "socializer":
+            # Alternate between bar and diner so the two venues stay populated.
+            self._social_pref = "diner" if self._social_pref == "bar" else "bar"
+            venue = world.buildings.get(self._social_pref)
+            if venue is not None:
+                return (venue.x + rng.uniform(-30, 30), venue.y + rng.uniform(-20, 20))
+        # Wanderer (and any fallback): drift around town centre.
+        cx, cy = 465.0, 475.0
+        return (cx + rng.uniform(-80, 80), cy + rng.uniform(-80, 80))

--- a/from-simulation/app/agents/npcs.py
+++ b/from-simulation/app/agents/npcs.py
@@ -1,0 +1,284 @@
+"""
+NPC agents — the unnamed villagers that drift in from the forest.
+
+NPCs have a deliberately thin behavioural surface compared to the named
+characters owned by Agent B. They cycle through a three-state mini FSM:
+
+    WORKING  -> SOCIALIZING -> SHELTERING
+
+They pick targets near building entrances during the day, gossip at dusk,
+and shelter at night. NPCs in ``world.yellow_touched_npcs`` are subtly
+puppeted by the Man in Yellow: at DUSK they drift toward children-of-Matthews
+and the Sheriff house; at NIGHT they linger near talisman-protected doors,
+which slowly increases the awareness of nearby characters (Agent B reads the
+proximity from the snapshot — we just position the pieces).
+
+Population spawning and death cleanup is handled by ``population.py``.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Optional, Tuple
+
+from contracts import (
+    Agent,
+    AgentKind,
+    MarkerClass,
+    Phase,
+    State,
+    Status,
+    World,
+)
+
+
+# 40 name pool — these are deliberately generic, frontier-flavoured first names.
+# Suffixes are appended on collision (e.g. "Cora", "Cora II").
+_NAME_POOL = [
+    "Cora", "Wyatt", "Hazel", "Silas", "Mabel", "Otis", "Della", "Roscoe",
+    "Pearl", "Earl", "Edith", "Hank", "Vera", "Cletus", "Maeve", "Burl",
+    "Ida", "Floyd", "Junie", "Mort", "Nellie", "Cyrus", "Opal", "Reuben",
+    "Tess", "Asa", "Lula", "Jonas", "Greta", "Lemuel", "Bessie", "Caleb",
+    "Inez", "Dorsey", "Polly", "Eustace", "Beulah", "Wendell", "Sadie", "Orin",
+]
+
+
+def _suffix_for(n: int) -> str:
+    """Return a roman-numeral-ish suffix for the n-th re-use of a name (0-indexed)."""
+    if n <= 0:
+        return ""
+    romans = ["II", "III", "IV", "V", "VI", "VII", "VIII", "IX", "X"]
+    if n - 1 < len(romans):
+        return " " + romans[n - 1]
+    return f" {n + 1}"
+
+
+def generate_npc_name(world: World) -> str:
+    """Pick a free name out of the pool; collisions get a roman suffix."""
+    existing = {getattr(a, "name", None) for a in world.agents.values()}
+    # Random shuffle order so we don't always grab the same name.
+    pool = list(_NAME_POOL)
+    world.rng.shuffle(pool)
+    for base in pool:
+        if base not in existing:
+            return base
+    # All bases taken — sweep with suffixes.
+    for n in range(1, 50):
+        for base in pool:
+            candidate = base + _suffix_for(n)
+            if candidate not in existing:
+                return candidate
+    # Pathological fallback.
+    return f"NPC-{world.rng.randint(1000, 9999)}"
+
+
+def _distance(ax: float, ay: float, bx: float, by: float) -> float:
+    """Euclidean distance; small helper so we don't depend on agents.base existing yet."""
+    return math.hypot(ax - bx, ay - by)
+
+
+def _move_toward(
+    x: float, y: float, tx: float, ty: float, step: float
+) -> Tuple[float, float]:
+    """Move (x,y) up to ``step`` px toward (tx,ty); return new (x,y)."""
+    dx = tx - x
+    dy = ty - y
+    d = math.hypot(dx, dy)
+    if d <= step or d == 0.0:
+        return tx, ty
+    return x + dx * (step / d), y + dy * (step / d)
+
+
+# Buildings the Yellow Man likes to puppet NPCs toward at DUSK.
+_YELLOW_TARGET_TAGS = ("matthews", "sheriff")
+
+
+def _building_target(world: World, role_tag: str) -> Optional[Tuple[float, float]]:
+    for b in world.buildings.values():
+        if b.role_tag == role_tag:
+            return (b.x, b.y)
+    return None
+
+
+def _nearest_dwelling(world: World, x: float, y: float) -> Optional[Tuple[str, float, float]]:
+    """Return id+coords of the closest building tagged as a dwelling-ish role."""
+    best = None
+    best_d = float("inf")
+    # Anything other than the lighthouse counts as shelterable.
+    for b in world.buildings.values():
+        if b.role_tag == "lighthouse":
+            continue
+        d = _distance(x, y, b.x, b.y)
+        if d < best_d:
+            best_d = d
+            best = (b.id, b.x, b.y)
+    return best
+
+
+def _talisman_door(world: World, rng) -> Optional[Tuple[float, float]]:
+    """Pick a random talisman-protected building's entrance to loiter near."""
+    talismans = [b for b in world.buildings.values() if b.has_talisman]
+    if not talismans:
+        return None
+    b = rng.choice(talismans)
+    # Stand a few px south of the door (entrance side in our SVG layout).
+    return (b.x + rng.uniform(-12, 12), b.y + rng.uniform(18, 28))
+
+
+class NPC(Agent):
+    """Unnamed villager. Owned by Agent C."""
+
+    kind = AgentKind.NPC
+    marker_class = MarkerClass.NPC
+
+    def __init__(
+        self,
+        npc_id: str,
+        name: str,
+        x: float,
+        y: float,
+    ) -> None:
+        self.id = npc_id
+        self.name = name
+        self.x = float(x)
+        self.y = float(y)
+        self.target_x = float(x)
+        self.target_y = float(y)
+        self.state: State = State.WORKING
+        self.fear: float = 0.0
+        self.sanity: float = 1.0
+        self.status: Status = Status.ACTIVE
+        self.arrived_at_tick: int = 0
+        # WANDERING is forced for a few ticks when the Yellow Man marches by.
+        self._wander_until_tick: int = 0
+        # Re-target cooldown so we don't thrash every tick.
+        self._retarget_at_tick: int = 0
+
+    # ---------------------------------------------------------------- API
+
+    def to_dict(self):
+        d = super().to_dict()
+        d.update(
+            {
+                "name": self.name,
+                "state": self.state.value,
+                "status": self.status.value,
+                "fear": round(self.fear, 2),
+                "sanity": round(self.sanity, 2),
+                "target_x": round(self.target_x, 2),
+                "target_y": round(self.target_y, 2),
+            }
+        )
+        return d
+
+    # ------------------------------------------------------------ helpers
+
+    def _pick_target(self, world: World) -> Tuple[float, float]:
+        """Pick a wander/work/shelter destination based on phase + touched bias."""
+        rng = world.rng
+        phase = world.time.phase
+        touched = self.id in world.yellow_touched_npcs
+
+        # Yellow-touched bias: DUSK = drift toward Matthews/Sheriff,
+        # NIGHT = loiter near talisman doors.
+        if touched and phase == Phase.DUSK:
+            tag = rng.choice(_YELLOW_TARGET_TAGS)
+            t = _building_target(world, tag)
+            if t is not None:
+                return (t[0] + rng.uniform(-25, 25), t[1] + rng.uniform(10, 35))
+
+        if touched and phase == Phase.NIGHT:
+            t = _talisman_door(world, rng)
+            if t is not None:
+                return t
+
+        if phase == Phase.NIGHT:
+            # Head to nearest dwelling to shelter.
+            near = _nearest_dwelling(world, self.x, self.y)
+            if near is not None:
+                _, bx, by = near
+                return (bx + rng.uniform(-10, 10), by + rng.uniform(-10, 10))
+
+        if phase == Phase.DUSK:
+            # Hang around the diner/church area to socialize.
+            socials = [
+                b for b in world.buildings.values()
+                if b.role_tag in ("diner", "church")
+            ]
+            if socials:
+                b = rng.choice(socials)
+                return (b.x + rng.uniform(-30, 30), b.y + rng.uniform(-30, 30))
+
+        # DAY / DAWN — work near a random non-colony building entrance.
+        candidates = [
+            b for b in world.buildings.values()
+            if b.role_tag not in ("colony", "lighthouse")
+        ]
+        if candidates:
+            b = rng.choice(candidates)
+            return (b.x + rng.uniform(-40, 40), b.y + rng.uniform(15, 50))
+
+        # Fallback: jitter.
+        return (self.x + rng.uniform(-30, 30), self.y + rng.uniform(-30, 30))
+
+    def _update_state(self, world: World) -> None:
+        """Translate phase + position into the mini-FSM state."""
+        if world.tick_count < self._wander_until_tick:
+            self.state = State.WANDERING
+            return
+
+        phase = world.time.phase
+        if phase == Phase.NIGHT:
+            # If we're close to a building, count as sheltering.
+            near = _nearest_dwelling(world, self.x, self.y)
+            if near is not None and _distance(self.x, self.y, near[1], near[2]) < 35:
+                self.state = State.SHELTERING
+            else:
+                self.state = State.WORKING  # still trying to get home
+        elif phase == Phase.DUSK:
+            self.state = State.SOCIALIZING
+        else:
+            self.state = State.WORKING
+
+    def force_wander(self, until_tick: int) -> None:
+        """Called by yellow_man.py when the visible march passes nearby."""
+        self._wander_until_tick = max(self._wander_until_tick, until_tick)
+        self.state = State.WANDERING
+
+    # ----------------------------------------------------------------- tick
+
+    def tick(self, world: World) -> None:
+        if self.status != Status.ACTIVE:
+            return
+
+        # (Re)pick a target if we've arrived or our cooldown ran out.
+        arrived = _distance(self.x, self.y, self.target_x, self.target_y) < 3.0
+        if arrived or world.tick_count >= self._retarget_at_tick:
+            tx, ty = self._pick_target(world)
+            self.target_x = tx
+            self.target_y = ty
+            # 20 - 60 ticks until we re-pick, jittered per-NPC.
+            self._retarget_at_tick = world.tick_count + world.rng.randint(20, 60)
+            if arrived:
+                self.arrived_at_tick = world.tick_count
+
+        # Step toward target. NPCs are deliberately slow vs creatures.
+        step = 6.0 if self.state == State.WANDERING else 3.5
+        self.x, self.y = _move_toward(self.x, self.y, self.target_x, self.target_y, step)
+
+        # FSM state mostly follows phase + position.
+        self._update_state(world)
+
+        # Yellow-touched + standing near a talisman door at NIGHT subtly drains
+        # sanity for the NPC itself (a flavour effect; Agent B reads sanity from
+        # the snapshot, so this surfaces as "this newcomer seems off").
+        if (
+            self.id in world.yellow_touched_npcs
+            and world.time.phase == Phase.NIGHT
+        ):
+            # Are we hovering next to a talisman building?
+            for b in world.buildings.values():
+                if b.has_talisman and _distance(self.x, self.y, b.x, b.y) < 30:
+                    self.sanity = max(0.0, self.sanity - 0.001)
+                    self.fear = min(1.0, self.fear + 0.0005)
+                    break

--- a/from-simulation/app/agents/npcs.py
+++ b/from-simulation/app/agents/npcs.py
@@ -223,6 +223,15 @@ class NPC(Agent):
         # Last day we flushed the daily contribution summary, so we only emit
         # the npc_contribution event once per sim-day.
         self._last_summary_day: int = -1
+        # v5 — promotion to sub-main. ``is_sub_main`` flips True once the
+        # NPC crosses ``config.npc_promotion_score_threshold``; the snapshot
+        # enricher also tags any id in ``world.sub_mains`` for the frontend.
+        self.is_sub_main: bool = False
+        self.notability_score: float = 0.0
+        self._last_promotion_reason: str = ""
+        # v5 — tombstone window for sub-mains. When >0, _reap_dead leaves the
+        # corpse in world.agents until world.tick_count reaches it.
+        self._tombstone_until_tick: int = 0
 
     # ---------------------------------------------------------------- API
 
@@ -238,6 +247,11 @@ class NPC(Agent):
                 "target_x": round(self.target_x, 2),
                 "target_y": round(self.target_y, 2),
                 "home_id": self.home_id,
+                # v5 — promotion + tombstone (mostly for debug, but the
+                # frontend tombstone marker keys off the status + the
+                # contracts._enrich_agent ``is_sub_main`` tag).
+                "is_sub_main": self.is_sub_main,
+                "notability_score": round(self.notability_score, 2),
             }
         )
         return d

--- a/from-simulation/app/agents/population.py
+++ b/from-simulation/app/agents/population.py
@@ -24,13 +24,21 @@ from typing import List
 
 from contracts import (
     AgentKind,
+    CAR_PATH_IN,
+    CAR_PARK_XY,
     Event,
     Metric,
     NPC_INTAKE_POINTS,
     Status,
     World,
 )
-from agents.npcs import NPC, generate_npc_name, pick_home_id
+from agents.npcs import NPC, assign_family, generate_npc_name, pick_home_id
+from agents import cars as _cars
+
+
+# v6 — chance an NPC arrival comes by car instead of on foot. Only applies
+# when no Car is currently active in the world (one at a time).
+_CAR_ARRIVAL_PROBABILITY = 0.35
 
 
 # Numeric counter so NPC ids are stable + unique across a single cycle.
@@ -54,8 +62,53 @@ def _count_active_npcs(world: World) -> int:
 
 
 def spawn_npc(world: World) -> NPC:
-    """Spawn one NPC at a random intake point. Used by ``tick_population``."""
+    """Spawn one NPC. v6 — ~35% chance it arrives by car instead of on foot.
+
+    On a car-arrival roll the NPC is created at the car's starting waypoint
+    (the road edge), placed in ``Status.ABSENT`` so they don't tick or render
+    as walkable until the car parks, and ``cars.spawn_car`` is invoked to put
+    the actual vehicle on the map. When the car emits ``car_arrival``,
+    ``tick_population`` reads ``world.car_pending_npc_id`` and alights the
+    passenger (flipping to ACTIVE at ``CAR_PARK_XY``).
+
+    On a foot-arrival roll (the default) the NPC appears at a random intake
+    point as before.
+    """
     rng = world.rng
+
+    use_car = (
+        world.active_car_id is None
+        and rng.random() < _CAR_ARRIVAL_PROBABILITY
+    )
+
+    if use_car:
+        # Place the NPC at the car's first waypoint and mirror their position
+        # to the car's. They're ABSENT until the car parks, so the existing
+        # tick loop skips them. ``home_id`` is still bound now so the
+        # snapshot has a stable home from tick 0 if the frontend cares.
+        if CAR_PATH_IN:
+            x, y = CAR_PATH_IN[0]
+        else:
+            x, y = CAR_PARK_XY
+        npc = NPC(
+            npc_id=_next_npc_id(world),
+            name=generate_npc_name(world),
+            x=float(x),
+            y=float(y),
+        )
+        npc.arrived_at_tick = world.tick_count
+        npc.home_id = pick_home_id(world)
+        npc.surname = assign_family(world, npc.id)
+        # Hide them until the car parks. ``tick_population`` flips this back
+        # to ACTIVE when ``world.car_pending_npc_id`` matches.
+        npc.status = Status.ABSENT
+        world.agents[npc.id] = npc
+        # Spawn the car. ``spawn_car`` sets ``world.active_car_id``; the car
+        # remembers the npc id and triggers car_arrival on parking.
+        _cars.spawn_car(world, npc.id)
+        return npc
+
+    # Foot-arrival — original behaviour.
     x, y = rng.choice(NPC_INTAKE_POINTS)
     # Small jitter so they don't all stack on the exact same pixel.
     x += rng.uniform(-12, 12)
@@ -71,18 +124,58 @@ def spawn_npc(world: World) -> NPC:
     # ``pick_home_id`` may return None (every house in cool-off); the NPC's
     # own tick will retry until something opens up.
     npc.home_id = pick_home_id(world)
+    npc.surname = assign_family(world, npc.id)
     world.agents[npc.id] = npc
 
+    full_name = f"{npc.name} {npc.surname}" if npc.surname else npc.name
     world.emit(
         Event(
             tick=world.tick_count,
             type="npc_arrival",
             subject=npc.id,
-            detail=f"{npc.name} arrived from the trees",
+            detail=f"{full_name} arrived from the trees",
             severity="info",
         )
     )
     return npc
+
+
+def _alight_car_passenger(world: World) -> None:
+    """If a car has parked this tick, finalise the NPC's arrival.
+
+    The Car sets ``world.car_pending_npc_id`` from ``_transition_parked``.
+    We pop the id off the world, flip the NPC to ACTIVE, snap them to the
+    car park location, and emit the canonical ``npc_arrival`` event so
+    downstream systems (legacy journal, telemetry, intent strings) all
+    behave exactly as if the NPC walked in on foot.
+    """
+    pid = world.car_pending_npc_id
+    if pid is None:
+        return
+    world.car_pending_npc_id = None
+    npc = world.agents.get(pid)
+    if npc is None:
+        return
+    # Snap them off the car and onto the road spur.
+    try:
+        npc.x, npc.y = float(CAR_PARK_XY[0]), float(CAR_PARK_XY[1]) + 8.0
+        npc.target_x, npc.target_y = npc.x, npc.y
+    except Exception:
+        pass
+    try:
+        npc.status = Status.ACTIVE
+    except Exception:
+        pass
+    name = getattr(npc, "name", pid)
+    world.emit(
+        Event(
+            tick=world.tick_count,
+            type="npc_arrival",
+            subject=npc.id,
+            detail=f"{name} stepped out of a battered car",
+            severity="info",
+        )
+    )
 
 
 _TOMBSTONE_TICKS = 30
@@ -208,6 +301,10 @@ def tick_population(world: World) -> None:
     """Engine hook — call once per tick, after agent ticks have run."""
     # 1) Reap any newly-dead NPCs first so the floor count is honest.
     _reap_dead(world)
+
+    # 1b) v6 — if a car parked this tick, finalise the NPC's arrival
+    # (flip to ACTIVE + snap to road spur + emit npc_arrival).
+    _alight_car_passenger(world)
 
     # 2) Maybe spawn.
     active = _count_active_npcs(world)

--- a/from-simulation/app/agents/population.py
+++ b/from-simulation/app/agents/population.py
@@ -30,7 +30,7 @@ from contracts import (
     Status,
     World,
 )
-from agents.npcs import NPC, generate_npc_name
+from agents.npcs import NPC, generate_npc_name, pick_home_id
 
 
 # Numeric counter so NPC ids are stable + unique across a single cycle.
@@ -67,6 +67,10 @@ def spawn_npc(world: World) -> NPC:
         y=y,
     )
     npc.arrived_at_tick = world.tick_count
+    # v4: bind a home building on spawn so the snapshot shows it from tick 0.
+    # ``pick_home_id`` may return None (every house in cool-off); the NPC's
+    # own tick will retry until something opens up.
+    npc.home_id = pick_home_id(world)
     world.agents[npc.id] = npc
 
     world.emit(
@@ -93,6 +97,12 @@ def _reap_dead(world: World) -> int:
     for nid in dead_ids:
         agent = world.agents.pop(nid, None)
         name = getattr(agent, "name", nid) if agent is not None else nid
+        # v4: clear them from their home's occupant set.
+        home_id = getattr(agent, "home_id", None) if agent is not None else None
+        if home_id is not None:
+            building = world.buildings.get(home_id)
+            if building is not None:
+                building.occupants.discard(nid)
         # If this NPC was puppeted, drop the touch — they're gone.
         world.yellow_touched_npcs.discard(nid)
         world.emit(
@@ -137,3 +147,12 @@ def tick_population(world: World) -> None:
             Metric.NPCS_ACTIVE,
             float(_count_active_npcs(world)),
         )
+        # v4: count NPCs that have been assigned a home building.
+        homes_full = sum(
+            1
+            for a in world.agents.values()
+            if getattr(a, "kind", None) == AgentKind.NPC
+            and getattr(a, "status", Status.ACTIVE) == Status.ACTIVE
+            and getattr(a, "home_id", None) is not None
+        )
+        world.telemetry.gauge_set(Metric.NPC_HOMES_FULL, float(homes_full))

--- a/from-simulation/app/agents/population.py
+++ b/from-simulation/app/agents/population.py
@@ -85,8 +85,20 @@ def spawn_npc(world: World) -> NPC:
     return npc
 
 
+_TOMBSTONE_TICKS = 30
+
+
 def _reap_dead(world: World) -> int:
-    """Remove dead NPCs from ``world.agents``. Returns count reaped."""
+    """Remove dead NPCs from ``world.agents``. Returns count reaped.
+
+    v5: sub-mains get a 30-tick tombstone window. We mark them with
+    ``_tombstone_until_tick`` on the first sighting (firing ``sub_main_died``
+    + memory hook + clearing the home's occupants); subsequent reap passes
+    skip them until the tick clock catches up, at which point they're fully
+    removed. ``world.sub_mains`` is NEVER cleared — the lookup must survive
+    so the snapshot's ``is_sub_main: True`` tag still applies for any
+    retroactive debug/inspection.
+    """
     dead_ids: List[str] = []
     for a in world.agents.values():
         if getattr(a, "kind", None) != AgentKind.NPC:
@@ -94,10 +106,73 @@ def _reap_dead(world: World) -> int:
         if getattr(a, "status", Status.ACTIVE) == Status.DEAD:
             dead_ids.append(a.id)
 
+    reaped = 0
     for nid in dead_ids:
+        agent = world.agents.get(nid)
+        if agent is None:
+            continue
+        is_sub_main = nid in world.sub_mains
+        tombstone = int(getattr(agent, "_tombstone_until_tick", 0) or 0)
+
+        # First-pass handling for any death.
+        if is_sub_main and tombstone == 0:
+            # Start the 30-tick tombstone. Fire sub_main_died + clear home,
+            # but DO NOT remove from world.agents — the frontend will render
+            # the fading marker until the window elapses.
+            name = getattr(agent, "name", nid)
+            cause = getattr(agent, "death_cause", "unknown")
+            try:
+                agent._tombstone_until_tick = world.tick_count + _TOMBSTONE_TICKS
+            except Exception:
+                pass
+            home_id = getattr(agent, "home_id", None)
+            if home_id is not None:
+                building = world.buildings.get(home_id)
+                if building is not None:
+                    building.occupants.discard(nid)
+            world.yellow_touched_npcs.discard(nid)
+            # Memory hook — best-effort. Memory swallows its own errors but we
+            # still guard so a missing attribute doesn't blow up the reap.
+            if world.memory is not None:
+                try:
+                    world.memory.mark_sub_main_dead(world, nid, cause)
+                except Exception:
+                    pass
+            world.emit(
+                Event(
+                    tick=world.tick_count,
+                    type="sub_main_died",
+                    subject=nid,
+                    detail=f"{name} died ({cause})",
+                    severity="crit",
+                )
+            )
+            try:
+                from agents.promotion import _record_sub_main_death
+                _record_sub_main_death(1)
+            except Exception:
+                pass
+            # Still emit npc_death so existing consumers (legacy hash marks,
+            # creature attribution, etc.) keep working.
+            world.emit(
+                Event(
+                    tick=world.tick_count,
+                    type="npc_death",
+                    subject=nid,
+                    detail=f"{name} did not survive the night",
+                    severity="warn",
+                )
+            )
+            # NB: NOT removed from world.agents — wait for the tombstone tick.
+            continue
+
+        if is_sub_main and world.tick_count < tombstone:
+            # Still inside the tombstone window — leave the corpse on the map.
+            continue
+
+        # Regular (non-sub-main) death OR sub-main whose tombstone has elapsed.
         agent = world.agents.pop(nid, None)
         name = getattr(agent, "name", nid) if agent is not None else nid
-        # v4: clear them from their home's occupant set.
         home_id = getattr(agent, "home_id", None) if agent is not None else None
         if home_id is not None:
             building = world.buildings.get(home_id)
@@ -105,16 +180,20 @@ def _reap_dead(world: World) -> int:
                 building.occupants.discard(nid)
         # If this NPC was puppeted, drop the touch — they're gone.
         world.yellow_touched_npcs.discard(nid)
-        world.emit(
-            Event(
-                tick=world.tick_count,
-                type="npc_death",
-                subject=nid,
-                detail=f"{name} did not survive the night",
-                severity="warn",
+        if not is_sub_main:
+            # Sub-mains already emitted npc_death + sub_main_died on the first
+            # pass; don't double-emit when the tombstone clears.
+            world.emit(
+                Event(
+                    tick=world.tick_count,
+                    type="npc_death",
+                    subject=nid,
+                    detail=f"{name} did not survive the night",
+                    severity="warn",
+                )
             )
-        )
-    return len(dead_ids)
+        reaped += 1
+    return reaped
 
 
 def clear_npcs(world: World) -> None:

--- a/from-simulation/app/agents/population.py
+++ b/from-simulation/app/agents/population.py
@@ -1,0 +1,139 @@
+"""
+Population management for unnamed NPCs.
+
+Spawns new arrivals from the forest edge and reaps the dead. Runs once per
+sim-tick from the engine loop via ``tick_population(world)``.
+
+Spawn rule:
+    * If active NPC count drops below ``config.npc_floor`` -> spawn one.
+    * Otherwise a flat ~1/600 random chance per tick -> spawn one.
+
+A spawn picks a random ``NPC_INTAKE_POINTS`` entry, generates a fresh name,
+emits ``npc_arrival``, and adds the NPC to ``world.agents``.
+
+Death rule:
+    * Anything in ``world.agents`` that is an NPC and whose ``status`` is
+      ``Status.DEAD`` gets removed from the dict, with an ``npc_death`` event.
+
+The NPC gauge ``from_sim_npcs_active`` is set every tick.
+"""
+
+from __future__ import annotations
+
+from typing import List
+
+from contracts import (
+    AgentKind,
+    Event,
+    Metric,
+    NPC_INTAKE_POINTS,
+    Status,
+    World,
+)
+from agents.npcs import NPC, generate_npc_name
+
+
+# Numeric counter so NPC ids are stable + unique across a single cycle.
+# A reset clears world.agents; we also clear this on reset via clear_npcs().
+_NPC_COUNTER = {"n": 0}
+
+
+def _next_npc_id(world: World) -> str:
+    _NPC_COUNTER["n"] += 1
+    # Encode the cycle number so ids never collide across resets either.
+    return f"npc_{world.cycle_number}_{_NPC_COUNTER['n']}"
+
+
+def _count_active_npcs(world: World) -> int:
+    return sum(
+        1
+        for a in world.agents.values()
+        if getattr(a, "kind", None) == AgentKind.NPC
+        and getattr(a, "status", Status.ACTIVE) == Status.ACTIVE
+    )
+
+
+def spawn_npc(world: World) -> NPC:
+    """Spawn one NPC at a random intake point. Used by ``tick_population``."""
+    rng = world.rng
+    x, y = rng.choice(NPC_INTAKE_POINTS)
+    # Small jitter so they don't all stack on the exact same pixel.
+    x += rng.uniform(-12, 12)
+    y += rng.uniform(-12, 12)
+    npc = NPC(
+        npc_id=_next_npc_id(world),
+        name=generate_npc_name(world),
+        x=x,
+        y=y,
+    )
+    npc.arrived_at_tick = world.tick_count
+    world.agents[npc.id] = npc
+
+    world.emit(
+        Event(
+            tick=world.tick_count,
+            type="npc_arrival",
+            subject=npc.id,
+            detail=f"{npc.name} arrived from the trees",
+            severity="info",
+        )
+    )
+    return npc
+
+
+def _reap_dead(world: World) -> int:
+    """Remove dead NPCs from ``world.agents``. Returns count reaped."""
+    dead_ids: List[str] = []
+    for a in world.agents.values():
+        if getattr(a, "kind", None) != AgentKind.NPC:
+            continue
+        if getattr(a, "status", Status.ACTIVE) == Status.DEAD:
+            dead_ids.append(a.id)
+
+    for nid in dead_ids:
+        agent = world.agents.pop(nid, None)
+        name = getattr(agent, "name", nid) if agent is not None else nid
+        # If this NPC was puppeted, drop the touch — they're gone.
+        world.yellow_touched_npcs.discard(nid)
+        world.emit(
+            Event(
+                tick=world.tick_count,
+                type="npc_death",
+                subject=nid,
+                detail=f"{name} did not survive the night",
+                severity="warn",
+            )
+        )
+    return len(dead_ids)
+
+
+def clear_npcs(world: World) -> None:
+    """Drop every NPC from ``world.agents``. Called by reset hook."""
+    npc_ids = [a.id for a in world.agents.values() if getattr(a, "kind", None) == AgentKind.NPC]
+    for nid in npc_ids:
+        world.agents.pop(nid, None)
+    _NPC_COUNTER["n"] = 0
+
+
+def tick_population(world: World) -> None:
+    """Engine hook — call once per tick, after agent ticks have run."""
+    # 1) Reap any newly-dead NPCs first so the floor count is honest.
+    _reap_dead(world)
+
+    # 2) Maybe spawn.
+    active = _count_active_npcs(world)
+    floor = world.config.npc_floor
+    rng = world.rng
+    should_spawn = active < floor or rng.random() < (1.0 / 600.0)
+    # Soft ceiling so we don't pile up NPCs forever in long-running cycles.
+    ceiling = max(floor + 12, floor * 2)
+    if should_spawn and active < ceiling:
+        spawn_npc(world)
+
+    # 3) Update the active gauge.
+    if world.telemetry is not None:
+        # Recount in case we just spawned.
+        world.telemetry.gauge_set(
+            Metric.NPCS_ACTIVE,
+            float(_count_active_npcs(world)),
+        )

--- a/from-simulation/app/agents/promotion.py
+++ b/from-simulation/app/agents/promotion.py
@@ -1,0 +1,193 @@
+"""
+NPC promotion to "sub-main" status — v5.
+
+Some unnamed villagers do something the village will remember. When an NPC's
+``notability_score`` crosses ``config.npc_promotion_score_threshold`` we promote
+them: they get a surname (becoming e.g. "Cora Tate"), join ``world.sub_mains``,
+and from that tick the snapshot enricher tags them ``is_sub_main: True``.
+
+Notable events (each calls ``bump_notability`` at the corresponding site):
+
+  =============================================  =====  ==========================
+  Reason                                          Score  Site
+  =============================================  =====  ==========================
+  unlocked the door at <building.id>              0.8    agents/npc_problems.py
+  picked up the music box                         1.5    agents/music_box.py
+  killed a creature with the worms                0.6    agents/music_box.py
+                                                         (_tick_worms_passing)
+  =============================================  =====  ==========================
+
+A score above the threshold (default ``1.0``) is the promotion gate. Scores
+are cumulative — two 0.6 worm kills will eventually tip an NPC over.
+
+On promotion ``world.memory.promote_npc(world, npc, reason, score)`` is
+preferred (it owns surname generation + DB persistence); we fall back to a
+local surname pool when memory is detached so the simulation still works
+without a SQLite layer.
+
+Death of a sub-main is handled in ``agents/population.py``: a 30-tick
+tombstone period keeps them in ``world.agents`` with ``Status.DEAD`` so the
+frontend can render a fading marker, then the next reap pass drops them. Their
+id stays in ``world.sub_mains`` forever so any retroactive snapshot lookup
+(`is_sub_main: True`) still works.
+
+Engine wiring: call ``tick_promotion(world)`` once per tick from
+``simulation._do_tick`` right after ``tick_population``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from contracts import (
+    AgentKind,
+    Event,
+    Metric,
+    World,
+)
+import legacy
+
+
+# Local surname fallback — duplicated from ``storage.py``'s pool on purpose so
+# the simulation can still promote NPCs when ``world.memory`` is detached
+# (e.g. tests, or pre-Agent-A boots). Keep these two lists in lockstep.
+_SURNAMES = [
+    "Tate", "Reyes", "Hollander", "Burke", "Akeyo", "Vasquez", "Cromwell",
+    "Okafor", "Hendrix", "Walsh", "Marsh", "Quincey", "Dover", "Linde",
+    "Stoker", "Ashby", "Pendrake", "Yates", "Galt", "Roe",
+]
+
+
+# Cumulative count of sub-mains that have ever died — surfaced as a gauge so
+# Grafana can chart promotion churn against village wipes.
+_SUB_MAINS_DEAD_TOTAL: int = 0
+
+
+def bump_notability(npc: Any, score: float, reason: str) -> None:
+    """Add to ``npc.notability_score`` and remember the most recent reason.
+
+    Safe to call on any object; missing fields are defaulted. The promotion
+    sites (npc_problems, music_box, fear/creatures) call this immediately
+    after the event so the next ``tick_promotion`` pass can read it.
+    """
+    current = float(getattr(npc, "notability_score", 0.0))
+    try:
+        npc.notability_score = current + float(score)
+    except Exception:
+        # Read-only-attr fallback — best-effort, never blow up a tick.
+        return
+    try:
+        npc._last_promotion_reason = str(reason)
+    except Exception:
+        pass
+
+
+def _record_sub_main_death(count: int) -> None:
+    """Increment the module-level cumulative-death counter."""
+    global _SUB_MAINS_DEAD_TOTAL
+    _SUB_MAINS_DEAD_TOTAL += int(count)
+
+
+def sub_mains_dead_total() -> int:
+    """Cumulative count of sub-mains that have died this process lifetime."""
+    return _SUB_MAINS_DEAD_TOTAL
+
+
+def _local_surname(world: World, npc: Any) -> str:
+    """Generate a surname locally when ``world.memory`` is detached."""
+    existing_full = {getattr(a, "name", None) for a in world.agents.values()}
+    pool = list(_SURNAMES)
+    world.rng.shuffle(pool)
+    base = getattr(npc, "name", None) or "Stranger"
+    for surname in pool:
+        candidate = f"{base} {surname}"
+        if candidate not in existing_full:
+            return candidate
+    # All taken — append a roman-numeral-ish discriminator.
+    for n in range(2, 50):
+        for surname in pool:
+            candidate = f"{base} {surname} {n}"
+            if candidate not in existing_full:
+                return candidate
+    return f"{base} {world.rng.choice(pool)}"
+
+
+def _promote(world: World, npc: Any) -> None:
+    """Apply the promotion to ``npc`` (already verified eligible)."""
+    old_name = getattr(npc, "name", npc.id)
+    reason = getattr(npc, "_last_promotion_reason", None) or "noteworthy event"
+    score = float(getattr(npc, "notability_score", 0.0))
+
+    new_name: str
+    if world.memory is not None:
+        try:
+            generated = world.memory.promote_npc(world, npc, reason, score)
+        except Exception:
+            generated = None
+        new_name = generated or _local_surname(world, npc)
+    else:
+        new_name = _local_surname(world, npc)
+
+    try:
+        npc.name = new_name
+    except Exception:
+        # If we can't rename, abort the promotion — we don't want a half-
+        # promoted ghost.
+        return
+    try:
+        npc.is_sub_main = True
+    except Exception:
+        pass
+    world.sub_mains.add(npc.id)
+
+    world.emit(
+        Event(
+            tick=world.tick_count,
+            type="npc_promoted",
+            subject=npc.id,
+            detail=f"{old_name} -> {new_name} ({reason})",
+            severity="info",
+        )
+    )
+    try:
+        legacy.record(world, "npc_promoted", new_name=new_name, reason=reason)
+    except Exception:
+        pass
+
+
+def tick_promotion(world: World) -> None:
+    """Engine hook — promote eligible NPCs and update sub-main gauges.
+
+    Call once per tick from ``simulation._do_tick`` after ``tick_population``
+    so the dead have been reaped first and we don't promote corpses.
+    """
+    threshold = float(getattr(world.config, "npc_promotion_score_threshold", 1.0))
+
+    # Walk a snapshot — _promote mutates world.sub_mains, and a future hook
+    # might mutate world.agents (it doesn't today, but be safe).
+    for agent in list(world.agents.values()):
+        kind = getattr(agent, "kind", None)
+        # Only NPCs, never main characters or outsiders/creatures/supernaturals.
+        if kind is None or getattr(kind, "value", "") != "npc":
+            continue
+        if agent.id in world.sub_mains:
+            continue
+        score = float(getattr(agent, "notability_score", 0.0))
+        if score < threshold:
+            continue
+        _promote(world, agent)
+
+    # ----- Sub-main gauges (cheap; cleaner here than another hook).
+    tele = getattr(world, "telemetry", None)
+    if tele is not None:
+        alive = 0
+        for sid in world.sub_mains:
+            a = world.agents.get(sid)
+            if a is None:
+                continue
+            status = getattr(a, "status", None)
+            status_val = getattr(status, "value", status)
+            if status_val in (None, "ACTIVE", "RETURNING"):
+                alive += 1
+        tele.gauge_set(Metric.SUB_MAINS_ALIVE, float(alive))
+        tele.gauge_set(Metric.SUB_MAINS_DEAD_TOTAL, float(_SUB_MAINS_DEAD_TOTAL))

--- a/from-simulation/app/agents/resurrection.py
+++ b/from-simulation/app/agents/resurrection.py
@@ -21,7 +21,9 @@ from typing import Dict
 
 from contracts import Event, Status, World
 
+import legacy
 from agents.characters import Character, respawn_character
+from agents.social import adjust_trust
 
 
 RECOGNITION_RADIUS = 40.0
@@ -96,12 +98,31 @@ def tick_resurrection(world: World) -> None:
                     subject=r.id, detail=f"by {other.id} "
                     f"({world.recognition_counts[r.id]}/{world.config.recognition_threshold})",
                 ))
+                # Recognition rebuilds trust between the returner and the
+                # townsfolk who keep noticing them.
+                adjust_trust(world, r.id, other.id, 0.20, "recognition")
                 if world.recognition_counts[r.id] >= world.config.recognition_threshold:
                     r.status = Status.ACTIVE
                     world.recognition_counts.pop(r.id, None)
+                    # Re-apply accumulated drift to the live object so the
+                    # character that walks back in matches what the next cycle
+                    # would seed.
+                    drift = world.legacy.personality_drift.get(r.name, {})
+                    if drift:
+                        for trait, delta in drift.items():
+                            cur = r.personality.get(trait, 0.5)
+                            r.personality[trait] = max(0.0, min(1.0, cur + delta))
+                        world.emit(Event(
+                            tick=world.tick_count, type="personality_drift",
+                            subject=r.id,
+                            detail=f"on restore, applied {drift}",
+                            severity="info",
+                        ))
                     world.emit(Event(
                         tick=world.tick_count, type="char_restored",
                         subject=r.id, detail=f"{r.name} is recognised and restored",
                         severity="info",
                     ))
+                    # Journal: a homecoming completed.
+                    legacy.record(world, "homecoming", name=r.name)
                 break  # one bump per tick is plenty

--- a/from-simulation/app/agents/resurrection.py
+++ b/from-simulation/app/agents/resurrection.py
@@ -1,0 +1,107 @@
+"""
+Resurrection / homecoming loop.
+
+Agent B owns this module. Driven by ``characters.tick_societies(world)``.
+Lifecycle:
+
+* A character marked ``Status.DEAD`` by ``fear.py`` is converted to
+  ``Status.ABSENT`` and a resurrection-tick is scheduled.
+* On the scheduled tick the character is respawned at a forest intake point
+  with ``Status.RETURNING`` (no role bonus while in this status).
+* While ``RETURNING`` they wander town; every time another character passes
+  within ``RECOGNITION_RADIUS`` we bump ``world.recognition_counts[id]``.
+* When the recognition count crosses ``config.recognition_threshold`` they
+  are restored to ``Status.ACTIVE`` and ``char_restored`` is emitted.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Dict
+
+from contracts import Event, Status, World
+
+from agents.characters import Character, respawn_character
+
+
+RECOGNITION_RADIUS = 40.0
+
+
+def _get_schedule(world: World) -> Dict[str, int]:
+    """character id -> tick at which they respawn."""
+    s = getattr(world, "_resurrection_schedule", None)
+    if s is None:
+        s = {}
+        world._resurrection_schedule = s  # type: ignore[attr-defined]
+    return s
+
+
+def _get_recognised_recently(world: World) -> Dict[str, int]:
+    """char_id -> last tick we credited a recognition (anti-spam)."""
+    s = getattr(world, "_recognition_recent", None)
+    if s is None:
+        s = {}
+        world._recognition_recent = s  # type: ignore[attr-defined]
+    return s
+
+
+def tick_resurrection(world: World) -> None:
+    schedule = _get_schedule(world)
+
+    # 1) Sweep for newly DEAD characters and convert -> ABSENT.
+    for cid, agent in list(world.agents.items()):
+        if not isinstance(agent, Character):
+            continue
+        if agent.status == Status.DEAD:
+            agent.status = Status.ABSENT
+            cfg = world.config
+            jitter = world.rng.randint(-cfg.resurrection_jitter, cfg.resurrection_jitter)
+            schedule[cid] = world.tick_count + cfg.resurrection_base_ticks + jitter
+            world.emit(Event(
+                tick=world.tick_count, type="char_absent",
+                subject=cid, detail=f"{agent.name} has gone (return in ~{cfg.resurrection_base_ticks} ticks)",
+                severity="warn",
+            ))
+
+    # 2) Check schedule for respawns.
+    due = [cid for cid, when in schedule.items() if world.tick_count >= when]
+    for cid in due:
+        schedule.pop(cid, None)
+        # Drop the absent agent record before respawning.
+        prev = world.agents.get(cid)
+        if isinstance(prev, Character) and prev.status == Status.ABSENT:
+            del world.agents[cid]
+        respawn_character(world, cid)
+        # respawn_character emits "homecoming" itself.
+
+    # 3) Recognition: characters near a RETURNING peer accrue recognition.
+    recents = _get_recognised_recently(world)
+    returners = [a for a in world.agents.values()
+                 if isinstance(a, Character) and a.status == Status.RETURNING]
+    actives = [a for a in world.agents.values()
+               if isinstance(a, Character) and a.status == Status.ACTIVE]
+
+    for r in returners:
+        # Throttle: at most one recognition every ~20 ticks per returner.
+        last = recents.get(r.id, -10_000)
+        if world.tick_count - last < 20:
+            continue
+        for other in actives:
+            d = math.hypot(other.x - r.x, other.y - r.y)
+            if d <= RECOGNITION_RADIUS:
+                world.recognition_counts[r.id] = world.recognition_counts.get(r.id, 0) + 1
+                recents[r.id] = world.tick_count
+                world.emit(Event(
+                    tick=world.tick_count, type="char_recognised",
+                    subject=r.id, detail=f"by {other.id} "
+                    f"({world.recognition_counts[r.id]}/{world.config.recognition_threshold})",
+                ))
+                if world.recognition_counts[r.id] >= world.config.recognition_threshold:
+                    r.status = Status.ACTIVE
+                    world.recognition_counts.pop(r.id, None)
+                    world.emit(Event(
+                        tick=world.tick_count, type="char_restored",
+                        subject=r.id, detail=f"{r.name} is recognised and restored",
+                        severity="info",
+                    ))
+                break  # one bump per tick is plenty

--- a/from-simulation/app/agents/resurrection.py
+++ b/from-simulation/app/agents/resurrection.py
@@ -104,6 +104,16 @@ def tick_resurrection(world: World) -> None:
                 if world.recognition_counts[r.id] >= world.config.recognition_threshold:
                     r.status = Status.ACTIVE
                     world.recognition_counts.pop(r.id, None)
+                    # v5 — record a "recognized" memory row from the
+                    # recogniser's perspective. ``other`` is the recognising
+                    # active character; the returner is the subject.
+                    if world.memory is not None:
+                        try:
+                            world.memory.record_character_memory(
+                                world, other.id, "recognized", subject=r.id,
+                            )
+                        except Exception:
+                            pass
                     # Re-apply accumulated drift to the live object so the
                     # character that walks back in matches what the next cycle
                     # would seed.

--- a/from-simulation/app/agents/social.py
+++ b/from-simulation/app/agents/social.py
@@ -395,6 +395,37 @@ def _resolve_meeting(world: World, pm: _PendingMeeting) -> None:
         decision = world.rng.choices(
             ["agree", "disagree", "inconclusive"], weights=[0.5, 0.3, 0.2], k=1,
         )[0]
+    elif pm.topic == "destroy_music_box":
+        # SEER / PRIEST / INVESTIGATOR vote AGREE strongly.
+        # Worm-infected characters compulsively vote DISAGREE.
+        # Brave lean AGREE; paranoid lean DISAGREE.
+        worms = set(getattr(world, "worms_infected", set()) or set())
+        agree_w = 0.0
+        disagree_w = 0.0
+        for a in attendees:
+            if a.id in worms:
+                disagree_w += 3.0  # compulsion overrides everything
+                continue
+            if a.role in (Role.SEER, Role.PRIEST, Role.INVESTIGATOR):
+                agree_w += 2.5
+            brave = a.personality.get("brave", 0.4)
+            paranoid = a.personality.get("paranoid", 0.5)
+            agree_w += 1.0 + 1.2 * brave
+            disagree_w += 0.5 + 1.2 * paranoid
+        if agree_w > disagree_w:
+            decision = "agree"
+            world.expedition_authorised = True
+            world._expedition_is_music_box = True  # type: ignore[attr-defined]
+            # Journal it once.
+            already_logged = getattr(world, "_destroy_music_box_logged", False)
+            if not already_logged:
+                try:
+                    legacy.record(world, "destroy_music_box_called", caller="Khatri")
+                except Exception:
+                    pass
+                world._destroy_music_box_logged = True  # type: ignore[attr-defined]
+        else:
+            decision = "disagree"
     else:
         # Generic resolution — weighted by attendees' leader / social vibe.
         agree_w = sum(0.5 + 0.5 * a.personality.get("leader", 0.3) for a in attendees)

--- a/from-simulation/app/agents/social.py
+++ b/from-simulation/app/agents/social.py
@@ -24,6 +24,7 @@ from dataclasses import dataclass, field
 from typing import Dict, List, Optional, Tuple
 
 from contracts import (
+    AgentKind,
     Event,
     MeetingOutcome,
     Phase,
@@ -139,11 +140,16 @@ def adjust_trust(world: World, a_id: str, b_id: str, delta: float, reason: str) 
     new = max(0.0, min(1.0, cur + delta))
     world.trust[(a_id, b_id)] = new
     world.trust[(b_id, a_id)] = new
-    world.emit(Event(
-        tick=world.tick_count, type="trust_shift",
-        subject=a_id, detail=f"{a_id}<->{b_id} {delta:+.2f} ({reason}) -> {new:.2f}",
-        severity="info",
-    ))
+    # Routine ±0.03..±0.05 shifts (every conversation, every meeting attendee
+    # pair) would drown the event log — a single 10-person meeting otherwise
+    # emits 45 events. Only the dramatic shifts surface to the UI; SQLite
+    # still records the full pair history below for narrative reconstruction.
+    if abs(delta) >= 0.10:
+        world.emit(Event(
+            tick=world.tick_count, type="trust_shift",
+            subject=a_id, detail=f"{a_id}<->{b_id} {delta:+.2f} ({reason}) -> {new:.2f}",
+            severity="info",
+        ))
     # v5 — persist the trust shift to memory for both parties.
     if world.memory is not None:
         try:
@@ -224,6 +230,69 @@ def tick_social(world: World) -> None:
     _check_awareness_triggers(world)
     _drive_pending_meetings(world)
     _drive_conversations(world)
+    _drive_co_occupants(world)
+
+
+# v8 — limit greeting events so a house full of characters + NPCs doesn't
+# flood the log with "Boyd shared shelter with Maeve" every tick.
+_LAST_GREETING_TICK: Dict[Tuple[str, str], int] = {}
+_GREETING_COOLDOWN_TICKS = 480  # ~8 sim-hours
+
+
+def _drive_co_occupants(world: World) -> None:
+    """v8 — when a character and an NPC share a building's occupants set,
+    nudge their mutual trust upward and occasionally surface a greeting.
+
+    Triggers only at DUSK / NIGHT so the effect reads as "we sheltered
+    together while it was dark". DAY-time co-occupancy is handled by the
+    conversation spawner instead.
+    """
+    if world.time.phase not in (Phase.DUSK, Phase.NIGHT):
+        return
+    for b in world.buildings.values():
+        if not b.occupants:
+            continue
+        char_ids: List[str] = []
+        npc_ids: List[str] = []
+        for occ_id in b.occupants:
+            agent = world.agents.get(occ_id)
+            if agent is None:
+                continue
+            kind = getattr(agent, "kind", None)
+            if kind == AgentKind.CHARACTER:
+                char_ids.append(occ_id)
+            elif kind == AgentKind.NPC:
+                # Cultists in your house do NOT comfort you.
+                if getattr(agent, "cult_state", "NONE") == "CONVERTED":
+                    continue
+                npc_ids.append(occ_id)
+        if not char_ids or not npc_ids:
+            continue
+        for cid in char_ids:
+            for nid in npc_ids:
+                # Slow, steady trust drift — easier than the per-conversation
+                # bump but cumulative across a night of sheltering together.
+                adjust_trust(world, cid, nid, 0.006, "shared_shelter")
+                # Occasional event so the user sees that something happens.
+                key = tuple(sorted((cid, nid)))
+                last = _LAST_GREETING_TICK.get(key, -10_000)
+                if (
+                    world.tick_count - last >= _GREETING_COOLDOWN_TICKS
+                    and world.rng.random() < 0.002
+                ):
+                    _LAST_GREETING_TICK[key] = world.tick_count
+                    npc = world.agents.get(nid)
+                    npc_label = (
+                        f"{npc.name} {npc.surname}".strip()
+                        if npc and getattr(npc, "surname", None)
+                        else (getattr(npc, "name", nid) if npc else nid)
+                    )
+                    world.emit(Event(
+                        tick=world.tick_count,
+                        type="conversation",
+                        subject=cid,
+                        detail=f"shared shelter with {npc_label}",
+                    ))
 
 
 # ---------------------------------------------------------------------------
@@ -257,6 +326,40 @@ def _check_awareness_triggers(world: World) -> None:
             venue_id="church",
             payload={"accused_npc_id": suspect},
         )
+
+
+def _roll_npc_observers(world: World, pm: "_PendingMeeting") -> List[str]:
+    """v8 — pick NPCs to attend a meeting as silent observers.
+
+    Eligibility: NPC has a home_id (invested in the village), is ACTIVE, is
+    not IRRATIONAL or in the cult, and is currently within ~140 px of the
+    meeting venue (so they're "around"). Cap at 4 observers so the meeting
+    doesn't drown in NPCs.
+    """
+    venue = world.buildings.get(pm.venue_id) if pm.venue_id else None
+    if venue is None:
+        return []
+    out: List[str] = []
+    for a in world.agents.values():
+        if len(out) >= 4:
+            break
+        if getattr(a, "kind", None) != AgentKind.NPC:
+            continue
+        if getattr(a, "status", Status.ACTIVE) != Status.ACTIVE:
+            continue
+        if getattr(a, "home_id", None) is None:
+            continue
+        if getattr(a, "state", None) in (State.IRRATIONAL, State.SLEEPING):
+            continue
+        if getattr(a, "cult_state", "NONE") == "CONVERTED":
+            continue
+        d = math.hypot(a.x - venue.x, a.y - venue.y)
+        if d > 140.0:
+            continue
+        # 35% chance any qualifying NPC drops in.
+        if world.rng.random() < 0.35:
+            out.append(a.id)
+    return out
 
 
 def _attend_roll(world: World, ch: Character, topic: str, caller_id: Optional[str] = None) -> bool:
@@ -305,6 +408,12 @@ def _drive_pending_meetings(world: World) -> None:
             if isinstance(caller, Character) and caller.id not in pm.attendees:
                 pm.attendees.append(caller.id)
                 _pin_to_meeting(world, caller, pm.deadline_tick, pm.venue_id)
+            # v8 — NPCs with a home_id may also show up as observers. They
+            # don't vote on imposter trials (still char-only below) but they
+            # share the room and get trust uplift from the gathering.
+            npc_observers = _roll_npc_observers(world, pm)
+            for nid in npc_observers:
+                pm.attendees.append(nid)
             if pm.attendees:
                 world.emit(Event(
                     tick=world.tick_count, type="meeting_started",
@@ -322,8 +431,12 @@ def _drive_pending_meetings(world: World) -> None:
 
 
 def _resolve_meeting(world: World, pm: _PendingMeeting) -> None:
-    attendees = [world.agents[a] for a in pm.attendees if a in world.agents]
-    attendees = [a for a in attendees if isinstance(a, Character)]
+    all_attendees = [world.agents[a] for a in pm.attendees if a in world.agents]
+    # ``attendees`` is the character-only voting bloc kept for downstream
+    # vote-counting / argument logic; NPC observers are pulled out separately
+    # so they still get the social trust uplift the meeting produced.
+    attendees = [a for a in all_attendees if isinstance(a, Character)]
+    npc_observers = [a for a in all_attendees if not isinstance(a, Character)]
 
     if not attendees:
         outcome = MeetingOutcome(
@@ -351,8 +464,21 @@ def _resolve_meeting(world: World, pm: _PendingMeeting) -> None:
             score = float(a.awareness.get(accused, 0.0))
             paranoid = a.personality.get("paranoid", 0.5)
             trust_w = trust_for(world, a.id, pm.caller_id) if a.id != pm.caller_id else 1.0
+            # v9 — voter's own beliefs feed back into the vote: a hard
+            # ``yellow_suspect:<accused>`` belief tilts them toward guilty;
+            # a ``yellow_resolved:<accused>`` (the imposter has been banished
+            # before) tilts them toward disbelief.
+            belief_bias = 0.0
+            mind = getattr(a, "mind", None)
+            if mind is not None and accused:
+                b_yes = mind.beliefs.get(f"yellow_suspect:{accused}")
+                if b_yes is not None:
+                    belief_bias += 0.5 * b_yes.confidence * (b_yes.polarity or 1.0)
+                b_no = mind.beliefs.get(f"yellow_resolved:{accused}")
+                if b_no is not None:
+                    belief_bias -= 0.5 * b_no.confidence
             # Paranoid attendees tip toward guilty even with thin evidence.
-            vote_yes = (score + (paranoid - 0.5) * 2.0) * (0.5 + trust_w)
+            vote_yes = (score + (paranoid - 0.5) * 2.0 + belief_bias) * (0.5 + trust_w)
             if vote_yes > 0:
                 guilt_yes += vote_yes
                 guilty_voters.append(a.id)
@@ -476,14 +602,24 @@ def _resolve_meeting(world: World, pm: _PendingMeeting) -> None:
             except Exception:
                 pass
 
-    # Trust deltas across the attendee graph.
+    # Trust deltas across the attendee graph. v8 — NPC observers join the
+    # uplift so attending a meeting actually shifts how the village sees
+    # them. We use a softer delta for char↔NPC pairs (half the magnitude)
+    # since NPCs didn't speak, only stood in the room.
     if decision in ("agree", "disagree") and len(attendees) >= 2:
-        delta = 0.05 if decision == "agree" else -0.10
+        delta_char = 0.05 if decision == "agree" else -0.10
+        delta_npc = delta_char * 0.5
         reason = f"meeting_{decision}:{pm.topic}"
-        ids = [a.id for a in attendees]
-        for i in range(len(ids)):
-            for j in range(i + 1, len(ids)):
-                adjust_trust(world, ids[i], ids[j], delta, reason)
+        char_ids = [a.id for a in attendees]
+        npc_ids = [a.id for a in npc_observers]
+        # Character-to-character (full delta).
+        for i in range(len(char_ids)):
+            for j in range(i + 1, len(char_ids)):
+                adjust_trust(world, char_ids[i], char_ids[j], delta_char, reason)
+        # Each character ↔ each NPC observer (softer delta).
+        for cid in char_ids:
+            for nid in npc_ids:
+                adjust_trust(world, cid, nid, delta_npc, reason)
 
     # Release attendees from State.MEETING; on disagreement, flip a few to ARGUING.
     if decision == "disagree" and len(attendees) >= 2:
@@ -623,3 +759,74 @@ def _drive_conversations(world: World) -> None:
                         pass
                 adjust_trust(world, a.id, b.id, 0.03, "conversation")
                 break
+
+    # ---------------------------------------------------------------- v8
+    # Character ↔ NPC conversations. Previously the two castes ignored each
+    # other entirely; characters and NPCs in the same building or square
+    # would walk past one another like ghosts. We now pair them when nearby:
+    # the character must be in a "social" state, the NPC must be wandering
+    # / socialising / working (not sheltering, not irrational), and the
+    # pair must be within CONVERSATION_RADIUS. A successful chat raises
+    # mutual trust like a char-char chat would.
+    char_available = [
+        c for c in _characters(world)
+        if c.id not in pairs
+        and c.state not in (State.MEETING, State.ARGUING, State.CONVERSING,
+                            State.SLEEPING, State.EXPEDITION, State.HYPNOTIZED,
+                            State.IRRATIONAL, State.FLEEING, State.SHELTERING)
+    ]
+    if char_available:
+        npc_kindset = {State.WANDERING, State.WORKING, State.SOCIALIZING}
+        for c in char_available:
+            if c.id in pairs:
+                continue
+            # Find the nearest eligible NPC.
+            best = None
+            best_d = CONVERSATION_RADIUS
+            for n in world.agents.values():
+                if getattr(n, "kind", None) != AgentKind.NPC:
+                    continue
+                if getattr(n, "status", Status.ACTIVE) != Status.ACTIVE:
+                    continue
+                if getattr(n, "state", None) not in npc_kindset:
+                    continue
+                if n.id in pairs:
+                    continue
+                d = math.hypot(c.x - n.x, c.y - n.y)
+                if d < best_d:
+                    best_d = d
+                    best = n
+            if best is None:
+                continue
+            social = c.personality.get("social", 0.5)
+            paranoia = c.personality.get("paranoid", 0.5)
+            t = trust_for(world, c.id, best.id)
+            # Cult NPCs are unfriendly — they don't chat; they unsettle.
+            cult = getattr(best, "cult_state", "NONE")
+            if cult == "CONVERTED":
+                continue
+            score = (0.4 + 1.2 * social) * (1.1 - 0.5 * paranoia) * (0.5 + 2.0 * t)
+            if world.rng.random() < 0.035 * score:
+                until = world.tick_count + CONVERSATION_DURATION_TICKS
+                pairs[c.id] = (best.id, until)
+                pairs[best.id] = (c.id, until)
+                c.state = State.CONVERSING
+                c.conversation_partner = best.id
+                c.state_since_tick = world.tick_count
+                npc_label = (
+                    f"{best.name} {best.surname}".strip()
+                    if getattr(best, "surname", None)
+                    else getattr(best, "name", best.id)
+                )
+                world.emit(Event(
+                    tick=world.tick_count, type="conversation",
+                    subject=c.id, detail=f"with {npc_label}",
+                ))
+                if world.memory is not None:
+                    try:
+                        world.memory.record_character_memory(
+                            world, c.id, "conversation", subject=best.id,
+                        )
+                    except Exception:
+                        pass
+                adjust_trust(world, c.id, best.id, 0.03, "char_npc_conversation")

--- a/from-simulation/app/agents/social.py
+++ b/from-simulation/app/agents/social.py
@@ -33,6 +33,7 @@ from contracts import (
     World,
 )
 
+import legacy
 from agents.characters import Character
 
 
@@ -91,11 +92,61 @@ def _get_awareness_cooldowns(world: World) -> Dict[str, int]:
 
 
 # ---------------------------------------------------------------------------
-# Compatibility
+# Trust graph
 # ---------------------------------------------------------------------------
 
 
-# Role-pair compatibility hints — symmetric, default 1.0.
+def _trust_initialised(world: World) -> bool:
+    return bool(getattr(world, "_trust_initialised", False))
+
+
+def _initialise_trust(world: World) -> None:
+    """Seed every ordered pair of agents with the configured baseline once."""
+    baseline = world.config.trust_baseline
+    ids = list(world.agents.keys())
+    for i in range(len(ids)):
+        for j in range(len(ids)):
+            if i == j:
+                continue
+            key = (ids[i], ids[j])
+            if key not in world.trust:
+                world.trust[key] = baseline
+    world._trust_initialised = True  # type: ignore[attr-defined]
+
+
+def trust_for(world: World, a_id: str, b_id: str) -> float:
+    """Symmetric trust score in [0,1] between two agents.
+
+    Falls back to ``config.trust_baseline`` when the pair has no history.
+    The matrix is lazily initialised on first call.
+    """
+    if a_id == b_id:
+        return 0.0
+    if not _trust_initialised(world):
+        _initialise_trust(world)
+    baseline = world.config.trust_baseline
+    return world.trust.get((a_id, b_id), baseline)
+
+
+def adjust_trust(world: World, a_id: str, b_id: str, delta: float, reason: str) -> None:
+    """Apply a symmetric trust delta between two ids, clamped to [0,1]."""
+    if a_id == b_id or not a_id or not b_id:
+        return
+    if not _trust_initialised(world):
+        _initialise_trust(world)
+    baseline = world.config.trust_baseline
+    cur = world.trust.get((a_id, b_id), baseline)
+    new = max(0.0, min(1.0, cur + delta))
+    world.trust[(a_id, b_id)] = new
+    world.trust[(b_id, a_id)] = new
+    world.emit(Event(
+        tick=world.tick_count, type="trust_shift",
+        subject=a_id, detail=f"{a_id}<->{b_id} {delta:+.2f} ({reason}) -> {new:.2f}",
+        severity="info",
+    ))
+
+
+# Role-pair compatibility hints — feeds the conversation pairing on top of trust.
 _ROLE_COMPAT: Dict[frozenset, float] = {
     frozenset({Role.SHERIFF, Role.DEPUTY}): 1.8,
     frozenset({Role.SHERIFF, Role.LEADER_COLONY}): 1.4,
@@ -108,17 +159,6 @@ _ROLE_COMPAT: Dict[frozenset, float] = {
     frozenset({Role.INVESTIGATOR, Role.SEER}): 1.4,
     frozenset({Role.INVESTIGATOR, Role.LEADER_COLONY}): 0.7,
 }
-
-
-def compatibility(a: Character, b: Character) -> float:
-    """Score how likely two characters are to strike up a conversation."""
-    if a is b:
-        return 0.0
-    base = _ROLE_COMPAT.get(frozenset({a.role, b.role}), 1.0)
-    social = 0.5 * (a.personality.get("social", 0.5) + b.personality.get("social", 0.5))
-    # Paranoia depresses social inclination.
-    paranoia = 0.5 * (a.personality.get("paranoid", 0.5) + b.personality.get("paranoid", 0.5))
-    return base * (0.4 + 1.2 * social) * (1.1 - 0.5 * paranoia)
 
 
 # ---------------------------------------------------------------------------
@@ -203,7 +243,7 @@ def _check_awareness_triggers(world: World) -> None:
         )
 
 
-def _attend_roll(world: World, ch: Character, topic: str) -> bool:
+def _attend_roll(world: World, ch: Character, topic: str, caller_id: Optional[str] = None) -> bool:
     if ch.status != Status.ACTIVE:
         return False
     if ch.state in (State.SLEEPING, State.EXPEDITION, State.HYPNOTIZED, State.IRRATIONAL):
@@ -216,6 +256,11 @@ def _attend_roll(world: World, ch: Character, topic: str) -> bool:
         base += 0.4 * ch.personality.get("paranoid", 0.5)
     if topic == "food_supply":
         base += 0.3 * ch.personality.get("leader", 0.3)
+    # Trust in the caller skews willingness to show up.
+    if caller_id and caller_id != ch.id:
+        t = trust_for(world, ch.id, caller_id)
+        # Centred around baseline so neutral trust is a no-op.
+        base += (t - world.config.trust_baseline) * 0.5
     return world.rng.random() < min(0.95, base)
 
 
@@ -236,7 +281,7 @@ def _drive_pending_meetings(world: World) -> None:
         # Gather attendees the first tick after proposal.
         if not pm.attendees and world.tick_count == pm.started_tick + 1:
             for ch in _characters(world):
-                if _attend_roll(world, ch, pm.topic):
+                if _attend_roll(world, ch, pm.topic, caller_id=pm.caller_id):
                     pm.attendees.append(ch.id)
                     _pin_to_meeting(world, ch, pm.deadline_tick, pm.venue_id)
             # Ensure caller is present.
@@ -281,16 +326,20 @@ def _resolve_meeting(world: World, pm: _PendingMeeting) -> None:
 
     if pm.topic == "imposter_suspicion":
         accused = payload.get("accused_npc_id")
-        # Tally guilt scores: each attendee contributes their awareness of the accused.
+        # Tally guilt scores: each attendee contributes their awareness of the
+        # accused, weighted by how much they trust the caller (the accuser).
         guilt_yes = 0.0
         guilt_no = 0.0
+        guilty_voters: List[str] = []
         for a in attendees:
             score = float(a.awareness.get(accused, 0.0))
             paranoid = a.personality.get("paranoid", 0.5)
+            trust_w = trust_for(world, a.id, pm.caller_id) if a.id != pm.caller_id else 1.0
             # Paranoid attendees tip toward guilty even with thin evidence.
-            vote_yes = score + (paranoid - 0.5) * 2.0
+            vote_yes = (score + (paranoid - 0.5) * 2.0) * (0.5 + trust_w)
             if vote_yes > 0:
                 guilt_yes += vote_yes
+                guilty_voters.append(a.id)
             else:
                 guilt_no += -vote_yes + 0.5
         guilty = guilt_yes > guilt_no
@@ -304,6 +353,34 @@ def _resolve_meeting(world: World, pm: _PendingMeeting) -> None:
             detail=f"accused={accused} guilty={guilty}",
             severity="warn" if guilty else "info",
         ))
+        # Trust consequences for the verdict.
+        if guilty:
+            # Check whether the accusation was correct — accused must be a
+            # current Yellow tendril for the vote to be "right".
+            tendrils = set(world.yellow_active.tendrils or [])
+            disguised = world.yellow_active.disguised_as
+            if disguised:
+                tendrils.add(disguised)
+            correct = accused in tendrils
+            venue = world.buildings.get(pm.venue_id)
+            venue_name = venue.name if venue is not None else pm.venue_id
+            if correct:
+                # A genuine banishment — journal it.
+                world.emit(Event(
+                    tick=world.tick_count, type="imposter_banished",
+                    subject=pm.caller_id, detail=f"{accused} banished from {venue_name}",
+                    severity="warn",
+                ))
+                legacy.record(world, "imposter_banished", building=venue_name)
+            else:
+                # Witch-hunt: punish trust toward the accuser for everyone who
+                # voted guilty.
+                for voter_id in guilty_voters:
+                    if voter_id != pm.caller_id:
+                        adjust_trust(
+                            world, voter_id, pm.caller_id,
+                            -0.25, "innocent_npc_vote",
+                        )
     elif pm.topic == "food_supply":
         # Leaders + brave folk push for expedition.
         push = sum(0.5 * a.personality.get("leader", 0.3)
@@ -340,6 +417,15 @@ def _resolve_meeting(world: World, pm: _PendingMeeting) -> None:
         severity="warn" if pm.topic == "imposter_suspicion" else "info",
     ))
 
+    # Trust deltas across the attendee graph.
+    if decision in ("agree", "disagree") and len(attendees) >= 2:
+        delta = 0.05 if decision == "agree" else -0.10
+        reason = f"meeting_{decision}:{pm.topic}"
+        ids = [a.id for a in attendees]
+        for i in range(len(ids)):
+            for j in range(i + 1, len(ids)):
+                adjust_trust(world, ids[i], ids[j], delta, reason)
+
     # Release attendees from State.MEETING; on disagreement, flip a few to ARGUING.
     if decision == "disagree" and len(attendees) >= 2:
         n_arg = min(2, len(attendees))
@@ -347,6 +433,7 @@ def _resolve_meeting(world: World, pm: _PendingMeeting) -> None:
     else:
         arguers = []
     arg_set = {a.id for a in arguers}
+    arguer_ids = list(arg_set)
     for a in attendees:
         a.meeting_until_tick = 0
         if a.id in arg_set:
@@ -363,6 +450,10 @@ def _resolve_meeting(world: World, pm: _PendingMeeting) -> None:
             a.state = State.WANDERING
             a.state_since_tick = world.tick_count
             a.target = None
+    # Pairwise trust hit for the arguers.
+    for i in range(len(arguer_ids)):
+        for j in range(i + 1, len(arguer_ids)):
+            adjust_trust(world, arguer_ids[i], arguer_ids[j], -0.15, "argument")
 
     # Clear awareness for the accused once a verdict has landed.
     if pm.topic == "imposter_suspicion":
@@ -420,7 +511,13 @@ def _drive_conversations(world: World) -> None:
             d = math.hypot(a.x - b.x, a.y - b.y)
             if d > CONVERSATION_RADIUS:
                 continue
-            score = compatibility(a, b)
+            # Blend trust with the role-compat hint and social personality.
+            base = _ROLE_COMPAT.get(frozenset({a.role, b.role}), 1.0)
+            social = 0.5 * (a.personality.get("social", 0.5) + b.personality.get("social", 0.5))
+            paranoia = 0.5 * (a.personality.get("paranoid", 0.5) + b.personality.get("paranoid", 0.5))
+            t = trust_for(world, a.id, b.id)
+            # Centre trust around 0.5 so neutral is a no-op; max ~2x weighting.
+            score = base * (0.4 + 1.2 * social) * (1.1 - 0.5 * paranoia) * (0.5 + 2.0 * t)
             if world.rng.random() < 0.05 * score:
                 until = world.tick_count + CONVERSATION_DURATION_TICKS
                 pairs[a.id] = (b.id, until)
@@ -440,4 +537,5 @@ def _drive_conversations(world: World) -> None:
                     tick=world.tick_count, type="conversation",
                     subject=a.id, detail=f"with {b.id}",
                 ))
+                adjust_trust(world, a.id, b.id, 0.03, "conversation")
                 break

--- a/from-simulation/app/agents/social.py
+++ b/from-simulation/app/agents/social.py
@@ -144,6 +144,22 @@ def adjust_trust(world: World, a_id: str, b_id: str, delta: float, reason: str) 
         subject=a_id, detail=f"{a_id}<->{b_id} {delta:+.2f} ({reason}) -> {new:.2f}",
         severity="info",
     ))
+    # v5 — persist the trust shift to memory for both parties.
+    if world.memory is not None:
+        try:
+            world.memory.record_character_memory(
+                world, a_id, "trust_shift",
+                subject=b_id, detail=f"{delta:+.2f} {reason}",
+            )
+        except Exception:
+            pass
+        try:
+            world.memory.record_character_memory(
+                world, b_id, "trust_shift",
+                subject=a_id, detail=f"{delta:+.2f} {reason}",
+            )
+        except Exception:
+            pass
 
 
 # Role-pair compatibility hints — feeds the conversation pairing on top of trust.
@@ -448,6 +464,18 @@ def _resolve_meeting(world: World, pm: _PendingMeeting) -> None:
         severity="warn" if pm.topic == "imposter_suspicion" else "info",
     ))
 
+    # v5 — record a per-attendee memory row for the outcome.
+    if world.memory is not None and decision in ("agree", "disagree"):
+        kind = "meeting_agree" if decision == "agree" else "meeting_disagree"
+        for a in attendees:
+            try:
+                world.memory.record_character_memory(
+                    world, a.id, kind,
+                    subject=pm.topic, detail=pm.venue_id,
+                )
+            except Exception:
+                pass
+
     # Trust deltas across the attendee graph.
     if decision in ("agree", "disagree") and len(attendees) >= 2:
         delta = 0.05 if decision == "agree" else -0.10
@@ -477,6 +505,17 @@ def _resolve_meeting(world: World, pm: _PendingMeeting) -> None:
                 tick=world.tick_count, type="argument",
                 subject=a.id, detail=f"after {pm.topic}",
             ))
+            # v5 — argument memory for each fighter, naming an opponent.
+            if world.memory is not None:
+                opponents = [x for x in arguer_ids if x != a.id]
+                opp = opponents[0] if opponents else pm.topic
+                try:
+                    world.memory.record_character_memory(
+                        world, a.id, "argument",
+                        subject=opp, detail=pm.topic,
+                    )
+                except Exception:
+                    pass
         else:
             a.state = State.WANDERING
             a.state_since_tick = world.tick_count
@@ -568,5 +607,19 @@ def _drive_conversations(world: World) -> None:
                     tick=world.tick_count, type="conversation",
                     subject=a.id, detail=f"with {b.id}",
                 ))
+                # v5 — record a conversation memory row for both sides.
+                if world.memory is not None:
+                    try:
+                        world.memory.record_character_memory(
+                            world, a.id, "conversation", subject=b.id,
+                        )
+                    except Exception:
+                        pass
+                    try:
+                        world.memory.record_character_memory(
+                            world, b.id, "conversation", subject=a.id,
+                        )
+                    except Exception:
+                        pass
                 adjust_trust(world, a.id, b.id, 0.03, "conversation")
                 break

--- a/from-simulation/app/agents/social.py
+++ b/from-simulation/app/agents/social.py
@@ -1,0 +1,443 @@
+"""
+Social rituals: meetings, conversations, arguments.
+
+Agent B owns this module. It is invoked by ``characters.tick_societies(world)``
+once per simulation tick. Three things happen here:
+
+1. **Pending meetings** — gather attendees, run a 20-tick deliberation, sample
+   a ``MeetingOutcome`` weighted by attendees' personality, and emit it.
+2. **Opportunistic conversations** — during DAY, when two compatible characters
+   are within 30 px, pair them into ``State.CONVERSING`` for a few ticks.
+3. **Imposter suspicion** — when any character's awareness of a yellow-touched
+   NPC crosses ``AWARENESS_TRIGGER``, propose a meeting; voting tallies the
+   attendees' guilt scores and reflects the verdict in the outcome payload.
+
+Meeting outcomes are written into ``world.meeting_outcomes`` — Agent C reads
+the ``imposter_suspicion`` ones, Agent A reads the ``food_supply`` ones (to
+flip ``world.expedition_authorised``).
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional, Tuple
+
+from contracts import (
+    Event,
+    MeetingOutcome,
+    Phase,
+    Role,
+    State,
+    Status,
+    World,
+)
+
+from agents.characters import Character
+
+
+# ---------------------------------------------------------------------------
+# Tunables
+# ---------------------------------------------------------------------------
+
+MEETING_DURATION_TICKS = 20
+ARGUE_DURATION_TICKS = 6
+CONVERSATION_DURATION_TICKS = 10
+CONVERSATION_RADIUS = 30.0
+AWARENESS_TRIGGER = 5.0
+
+
+# ---------------------------------------------------------------------------
+# Pending meeting bookkeeping
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _PendingMeeting:
+    topic: str
+    venue_id: str
+    caller_id: str
+    started_tick: int
+    deadline_tick: int
+    attendees: List[str] = field(default_factory=list)
+    payload: Dict[str, object] = field(default_factory=dict)
+    resolved: bool = False
+
+
+def _get_pendings(world: World) -> List[_PendingMeeting]:
+    """Lazily attach the pending-meeting list to the world."""
+    p = getattr(world, "_pending_meetings", None)
+    if p is None:
+        p = []
+        world._pending_meetings = p  # type: ignore[attr-defined]
+    return p
+
+
+def _get_pairings(world: World) -> Dict[str, Tuple[str, int]]:
+    """Lazily attach active conversation pairings: id -> (partner, until_tick)."""
+    p = getattr(world, "_conversation_pairs", None)
+    if p is None:
+        p = {}
+        world._conversation_pairs = p  # type: ignore[attr-defined]
+    return p
+
+
+def _get_awareness_cooldowns(world: World) -> Dict[str, int]:
+    p = getattr(world, "_awareness_cooldowns", None)
+    if p is None:
+        p = {}
+        world._awareness_cooldowns = p  # type: ignore[attr-defined]
+    return p
+
+
+# ---------------------------------------------------------------------------
+# Compatibility
+# ---------------------------------------------------------------------------
+
+
+# Role-pair compatibility hints — symmetric, default 1.0.
+_ROLE_COMPAT: Dict[frozenset, float] = {
+    frozenset({Role.SHERIFF, Role.DEPUTY}): 1.8,
+    frozenset({Role.SHERIFF, Role.LEADER_COLONY}): 1.4,
+    frozenset({Role.PRIEST, Role.SEER}): 1.6,
+    frozenset({Role.PRIEST, Role.CARETAKER}): 1.5,
+    frozenset({Role.CARETAKER, Role.CHILD}): 1.7,
+    frozenset({Role.ENGINEER, Role.SHERIFF}): 1.3,
+    frozenset({Role.LEADER_COLONY, Role.BRIDGE}): 1.4,
+    frozenset({Role.BRIDGE, Role.SHERIFF}): 1.3,
+    frozenset({Role.INVESTIGATOR, Role.SEER}): 1.4,
+    frozenset({Role.INVESTIGATOR, Role.LEADER_COLONY}): 0.7,
+}
+
+
+def compatibility(a: Character, b: Character) -> float:
+    """Score how likely two characters are to strike up a conversation."""
+    if a is b:
+        return 0.0
+    base = _ROLE_COMPAT.get(frozenset({a.role, b.role}), 1.0)
+    social = 0.5 * (a.personality.get("social", 0.5) + b.personality.get("social", 0.5))
+    # Paranoia depresses social inclination.
+    paranoia = 0.5 * (a.personality.get("paranoid", 0.5) + b.personality.get("paranoid", 0.5))
+    return base * (0.4 + 1.2 * social) * (1.1 - 0.5 * paranoia)
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def propose_meeting(
+    world: World,
+    caller_id: str,
+    topic: str,
+    venue_id: str,
+    payload: Optional[Dict[str, object]] = None,
+) -> Optional[_PendingMeeting]:
+    """Schedule a meeting. Returns the pending record or None if invalid."""
+    if caller_id not in world.agents:
+        return None
+    if venue_id not in world.buildings:
+        venue_id = "church"
+    pendings = _get_pendings(world)
+    # Don't double-propose the same topic.
+    for p in pendings:
+        if p.topic == topic and not p.resolved:
+            return p
+    pm = _PendingMeeting(
+        topic=topic,
+        venue_id=venue_id,
+        caller_id=caller_id,
+        started_tick=world.tick_count,
+        deadline_tick=world.tick_count + MEETING_DURATION_TICKS,
+        payload=dict(payload or {}),
+    )
+    pendings.append(pm)
+    world.emit(Event(
+        tick=world.tick_count, type="meeting_proposed",
+        subject=caller_id, detail=f"{topic} @ {venue_id}",
+    ))
+    return pm
+
+
+# ---------------------------------------------------------------------------
+# Main tick
+# ---------------------------------------------------------------------------
+
+
+def tick_social(world: World) -> None:
+    _check_awareness_triggers(world)
+    _drive_pending_meetings(world)
+    _drive_conversations(world)
+
+
+# ---------------------------------------------------------------------------
+# Internals
+# ---------------------------------------------------------------------------
+
+
+def _characters(world: World) -> List[Character]:
+    return [a for a in world.agents.values()
+            if isinstance(a, Character) and a.status == Status.ACTIVE]
+
+
+def _check_awareness_triggers(world: World) -> None:
+    cooldowns = _get_awareness_cooldowns(world)
+    for ch in _characters(world):
+        if not ch.awareness:
+            continue
+        # Find the most suspicious NPC currently flagged for this character.
+        suspect, score = max(ch.awareness.items(), key=lambda kv: kv[1])
+        if score < AWARENESS_TRIGGER:
+            continue
+        # Cooldown so we don't spam meetings.
+        last = cooldowns.get(suspect, -10_000)
+        if world.tick_count - last < 300:
+            continue
+        cooldowns[suspect] = world.tick_count
+        propose_meeting(
+            world,
+            caller_id=ch.id,
+            topic="imposter_suspicion",
+            venue_id="church",
+            payload={"accused_npc_id": suspect},
+        )
+
+
+def _attend_roll(world: World, ch: Character, topic: str) -> bool:
+    if ch.status != Status.ACTIVE:
+        return False
+    if ch.state in (State.SLEEPING, State.EXPEDITION, State.HYPNOTIZED, State.IRRATIONAL):
+        return False
+    social = ch.personality.get("social", 0.5)
+    leader = ch.personality.get("leader", 0.3)
+    base = 0.35 + 0.5 * social + 0.25 * leader
+    # Imposter suspicion pulls in the paranoid hard.
+    if topic == "imposter_suspicion":
+        base += 0.4 * ch.personality.get("paranoid", 0.5)
+    if topic == "food_supply":
+        base += 0.3 * ch.personality.get("leader", 0.3)
+    return world.rng.random() < min(0.95, base)
+
+
+def _pin_to_meeting(world: World, ch: Character, until_tick: int, venue_id: str) -> None:
+    ch.state = State.MEETING
+    ch.state_since_tick = world.tick_count
+    ch.meeting_until_tick = until_tick
+    b = world.buildings.get(venue_id)
+    if b is not None:
+        ch.target = (b.x, b.y)
+
+
+def _drive_pending_meetings(world: World) -> None:
+    pendings = _get_pendings(world)
+    for pm in list(pendings):
+        if pm.resolved:
+            continue
+        # Gather attendees the first tick after proposal.
+        if not pm.attendees and world.tick_count == pm.started_tick + 1:
+            for ch in _characters(world):
+                if _attend_roll(world, ch, pm.topic):
+                    pm.attendees.append(ch.id)
+                    _pin_to_meeting(world, ch, pm.deadline_tick, pm.venue_id)
+            # Ensure caller is present.
+            caller = world.agents.get(pm.caller_id)
+            if isinstance(caller, Character) and caller.id not in pm.attendees:
+                pm.attendees.append(caller.id)
+                _pin_to_meeting(world, caller, pm.deadline_tick, pm.venue_id)
+            if pm.attendees:
+                world.emit(Event(
+                    tick=world.tick_count, type="meeting_started",
+                    subject=pm.caller_id,
+                    detail=f"{pm.topic} ({len(pm.attendees)} attending)",
+                ))
+
+        # Resolve on deadline.
+        if world.tick_count >= pm.deadline_tick:
+            _resolve_meeting(world, pm)
+            pm.resolved = True
+
+    # Drop resolved meetings to keep the list small.
+    world._pending_meetings = [p for p in pendings if not p.resolved]  # type: ignore[attr-defined]
+
+
+def _resolve_meeting(world: World, pm: _PendingMeeting) -> None:
+    attendees = [world.agents[a] for a in pm.attendees if a in world.agents]
+    attendees = [a for a in attendees if isinstance(a, Character)]
+
+    if not attendees:
+        outcome = MeetingOutcome(
+            tick=world.tick_count, topic=pm.topic, venue_id=pm.venue_id,
+            attendees=[], decision="inconclusive", payload=dict(pm.payload),
+        )
+        world.meeting_outcomes.append(outcome)
+        world.emit(Event(
+            tick=world.tick_count, type="meeting_outcome",
+            subject=pm.caller_id, detail=f"{pm.topic}: inconclusive (no quorum)",
+        ))
+        return
+
+    payload = dict(pm.payload)
+    decision = "inconclusive"
+
+    if pm.topic == "imposter_suspicion":
+        accused = payload.get("accused_npc_id")
+        # Tally guilt scores: each attendee contributes their awareness of the accused.
+        guilt_yes = 0.0
+        guilt_no = 0.0
+        for a in attendees:
+            score = float(a.awareness.get(accused, 0.0))
+            paranoid = a.personality.get("paranoid", 0.5)
+            # Paranoid attendees tip toward guilty even with thin evidence.
+            vote_yes = score + (paranoid - 0.5) * 2.0
+            if vote_yes > 0:
+                guilt_yes += vote_yes
+            else:
+                guilt_no += -vote_yes + 0.5
+        guilty = guilt_yes > guilt_no
+        decision = "agree" if guilty else "disagree"
+        payload["guilty"] = bool(guilty)
+        if accused is not None:
+            payload["accused_npc_id"] = accused
+        world.emit(Event(
+            tick=world.tick_count, type="imposter_vote",
+            subject=pm.caller_id,
+            detail=f"accused={accused} guilty={guilty}",
+            severity="warn" if guilty else "info",
+        ))
+    elif pm.topic == "food_supply":
+        # Leaders + brave folk push for expedition.
+        push = sum(0.5 * a.personality.get("leader", 0.3)
+                   + 0.5 * a.personality.get("brave", 0.4)
+                   for a in attendees)
+        threshold = max(1.0, 0.5 * len(attendees))
+        agree = push >= threshold
+        decision = "agree" if agree else "disagree"
+        if agree:
+            world.expedition_authorised = True
+    elif pm.topic == "creature_breach_review":
+        decision = world.rng.choices(
+            ["agree", "disagree", "inconclusive"], weights=[0.5, 0.3, 0.2], k=1,
+        )[0]
+    else:
+        # Generic resolution — weighted by attendees' leader / social vibe.
+        agree_w = sum(0.5 + 0.5 * a.personality.get("leader", 0.3) for a in attendees)
+        disagree_w = sum(0.3 + 0.6 * a.personality.get("paranoid", 0.5) for a in attendees)
+        if agree_w > disagree_w * 1.2:
+            decision = "agree"
+        elif disagree_w > agree_w * 1.2:
+            decision = "disagree"
+        else:
+            decision = "inconclusive"
+
+    outcome = MeetingOutcome(
+        tick=world.tick_count, topic=pm.topic, venue_id=pm.venue_id,
+        attendees=[a.id for a in attendees], decision=decision, payload=payload,
+    )
+    world.meeting_outcomes.append(outcome)
+    world.emit(Event(
+        tick=world.tick_count, type="meeting_outcome",
+        subject=pm.caller_id, detail=f"{pm.topic}: {decision}",
+        severity="warn" if pm.topic == "imposter_suspicion" else "info",
+    ))
+
+    # Release attendees from State.MEETING; on disagreement, flip a few to ARGUING.
+    if decision == "disagree" and len(attendees) >= 2:
+        n_arg = min(2, len(attendees))
+        arguers = world.rng.sample(attendees, n_arg)
+    else:
+        arguers = []
+    arg_set = {a.id for a in arguers}
+    for a in attendees:
+        a.meeting_until_tick = 0
+        if a.id in arg_set:
+            a.state = State.ARGUING
+            a.state_since_tick = world.tick_count
+            a.arguing_until_tick = world.tick_count + ARGUE_DURATION_TICKS
+            a.fear = min(100.0, a.fear + 8.0)
+            a.sanity = max(0.0, a.sanity - 3.0)
+            world.emit(Event(
+                tick=world.tick_count, type="argument",
+                subject=a.id, detail=f"after {pm.topic}",
+            ))
+        else:
+            a.state = State.WANDERING
+            a.state_since_tick = world.tick_count
+            a.target = None
+
+    # Clear awareness for the accused once a verdict has landed.
+    if pm.topic == "imposter_suspicion":
+        accused = payload.get("accused_npc_id")
+        if accused is not None:
+            for a in attendees:
+                a.awareness.pop(accused, None)
+
+
+# ---------------------------------------------------------------------------
+# Opportunistic conversations
+# ---------------------------------------------------------------------------
+
+
+def _drive_conversations(world: World) -> None:
+    pairs = _get_pairings(world)
+
+    # First, expire pairings whose deadline passed.
+    expired: List[str] = []
+    for cid, (partner, until) in pairs.items():
+        if world.tick_count >= until:
+            expired.append(cid)
+    for cid in expired:
+        partner, _ = pairs.pop(cid)
+        pairs.pop(partner, None)
+        a = world.agents.get(cid)
+        b = world.agents.get(partner)
+        if isinstance(a, Character) and a.state == State.CONVERSING:
+            a.state = State.WANDERING
+            a.conversation_partner = None
+        if isinstance(b, Character) and b.state == State.CONVERSING:
+            b.state = State.WANDERING
+            b.conversation_partner = None
+
+    # Only spawn new conversations during DAY phase.
+    if world.time.phase != Phase.DAY:
+        return
+
+    chars = [
+        c for c in _characters(world)
+        if c.id not in pairs
+        and c.state not in (State.MEETING, State.ARGUING, State.CONVERSING,
+                            State.SLEEPING, State.EXPEDITION, State.HYPNOTIZED,
+                            State.IRRATIONAL, State.FLEEING)
+    ]
+    # Limit work: O(n^2) over 10 characters is fine.
+    for i in range(len(chars)):
+        a = chars[i]
+        if a.id in pairs:
+            continue
+        for j in range(i + 1, len(chars)):
+            b = chars[j]
+            if b.id in pairs:
+                continue
+            d = math.hypot(a.x - b.x, a.y - b.y)
+            if d > CONVERSATION_RADIUS:
+                continue
+            score = compatibility(a, b)
+            if world.rng.random() < 0.05 * score:
+                until = world.tick_count + CONVERSATION_DURATION_TICKS
+                pairs[a.id] = (b.id, until)
+                pairs[b.id] = (a.id, until)
+                a.state = State.CONVERSING
+                b.state = State.CONVERSING
+                a.conversation_partner = b.id
+                b.conversation_partner = a.id
+                a.state_since_tick = world.tick_count
+                b.state_since_tick = world.tick_count
+                # Seers/caretakers chatting with supernaturals soften the sanity hit.
+                if a.role in (Role.SEER, Role.CARETAKER) or b.role in (Role.SEER, Role.CARETAKER):
+                    if world.supernaturals:
+                        a.sanity = min(100.0, a.sanity + 1.0)
+                        b.sanity = min(100.0, b.sanity + 1.0)
+                world.emit(Event(
+                    tick=world.tick_count, type="conversation",
+                    subject=a.id, detail=f"with {b.id}",
+                ))
+                break

--- a/from-simulation/app/agents/states.py
+++ b/from-simulation/app/agents/states.py
@@ -74,6 +74,10 @@ TRANSITION_TABLE: Dict[State, List[Transition]] = {
         (State.EATING, 1.5, _ANYTIME),
         (State.WANDERING, 1.0, _ANYTIME),
         (State.SHELTERING, 1.5, _DUSK_NIGHT),
+        # v7 — pivot to FORAGING when the barn is down. The weight here is
+        # baseline; characters.py applies an additional 3× boost via the
+        # food_shortage / barn_destroyed_until_tick checks.
+        (State.FORAGING, 1.2, _DAY_ONLY),
     ],
     State.GOSSIPING: [
         (State.GOSSIPING, 2.0, _DAY_ONLY),
@@ -130,6 +134,9 @@ TRANSITION_TABLE: Dict[State, List[Transition]] = {
         (State.REPAIRING, 0.4, _DAY_ONLY),
         (State.PLAYING, 0.4, _DAY_ONLY),
         (State.CONVERSING, 0.5, _BIASED_DAY),
+        # v6 — wanderers occasionally drift into the caves on their own.
+        # Lower base than the INVESTIGATING edge; same DAY-only gating.
+        (State.EXPLORING_CAVES, 0.4, _DAY_ONLY),
     ],
     State.FLEEING: [
         # Fleeing decays back into shelter / wander when fear subsides.
@@ -143,10 +150,16 @@ TRANSITION_TABLE: Dict[State, List[Transition]] = {
         (State.WANDERING, 0.2, _BIASED_DAY),
     ],
     State.INVESTIGATING: [
-        (State.INVESTIGATING, 1.5, _ANYTIME),
-        (State.WANDERING, 1.5, _ANYTIME),
+        (State.INVESTIGATING, 0.7, _ANYTIME),
+        (State.WANDERING, 1.0, _ANYTIME),
         (State.PATROLLING, 0.8, _BIASED_NIGHT),
         (State.MEETING, 0.4, _BIASED_DAY),
+        # v6 — cave exploration. DAY-only; INVESTIGATOR/SEER get a role bonus
+        # on top of this in characters.py via ROLE_PRIORITY. Bumped to 3.0 so
+        # the role bonus (2×) gives ~6.0 vs INVESTIGATING's ~1.4 — Jade and
+        # Sara actually leave the village for the caves rather than just
+        # picking nearby buildings.
+        (State.EXPLORING_CAVES, 3.0, _DAY_ONLY),
     ],
     State.PLAYING: [
         (State.PLAYING, 2.0, _DAY_ONLY),
@@ -214,5 +227,30 @@ TRANSITION_TABLE: Dict[State, List[Transition]] = {
     State.DREAMING: [
         (State.SLEEPING, 4.0, _ANYTIME),
         (State.DREAMING, 1.0, _ANYTIME),
+    ],
+    # v6 — cave exploration. caves.py drives the actual lifecycle (progress
+    # counter + outcome roll); these edges only matter if a character is
+    # sampled mid-exploration before caves.py has run its outcome.
+    State.EXPLORING_CAVES: [
+        # Heavily sticky — caves.py owns the exit. Otherwise the FSM can
+        # bounce the character out before they walk ~150 px to the entrance.
+        (State.EXPLORING_CAVES, 20.0, _DAY_ONLY),
+        (State.WANDERING, 0.2, _BIASED_DAY),
+        (State.FLEEING, 0.5, _ANYTIME),
+    ],
+    # v7 — FORAGING. characters.py owns the lifecycle (walking to a forage
+    # zone, gathering for FORAGE_TICKS_TO_GATHER, returning food). Sticky like
+    # EXPLORING_CAVES so the FSM doesn't pull the forager off mid-trip.
+    State.FORAGING: [
+        (State.FORAGING, 20.0, _DAY_ONLY),
+        (State.WANDERING, 0.3, _BIASED_DAY),
+        (State.FLEEING, 0.5, _ANYTIME),
+    ],
+    # v6 — CALLED is sticky. The hard-override in characters.py pins us to it
+    # while ``world.lighthouse_called`` names this character, but we still
+    # register edges so the FSM doesn't deadlock if the call is cleared.
+    State.CALLED: [
+        (State.CALLED, 10.0, _ANYTIME),
+        (State.WANDERING, 0.2, _BIASED_DAY),
     ],
 }

--- a/from-simulation/app/agents/states.py
+++ b/from-simulation/app/agents/states.py
@@ -202,4 +202,11 @@ TRANSITION_TABLE: Dict[State, List[Transition]] = {
         (State.GOSSIPING, 1.0, _DAY_ONLY),
         (State.SHELTERING, 1.0, _DUSK_NIGHT),
     ],
+    # v2 — dreaming decays back to sleeping; the engine's dreams.tick owns
+    # the actual lifecycle but we register a transition so the generic FSM
+    # never deadlocks if a character is sampled mid-dream.
+    State.DREAMING: [
+        (State.SLEEPING, 4.0, _ANYTIME),
+        (State.DREAMING, 1.0, _ANYTIME),
+    ],
 }

--- a/from-simulation/app/agents/states.py
+++ b/from-simulation/app/agents/states.py
@@ -168,6 +168,12 @@ TRANSITION_TABLE: Dict[State, List[Transition]] = {
         (State.IRRATIONAL, 4.0, _ANYTIME),
         (State.WANDERING, 0.3, _BIASED_DAY),
     ],
+    State.CARRYING_BOX: [
+        # v4 — Music Box carriers rarely transition; drop is driven by
+        # music_box.py's compulsion check. Self-stay dominates.
+        (State.CARRYING_BOX, 10.0, _ANYTIME),
+        (State.WANDERING, 0.2, _BIASED_DAY),
+    ],
     State.MEETING: [
         (State.MEETING, 3.0, _BIASED_DAY),
         (State.WANDERING, 1.0, _ANYTIME),

--- a/from-simulation/app/agents/states.py
+++ b/from-simulation/app/agents/states.py
@@ -1,0 +1,205 @@
+"""
+Time-of-day weighted state transition table.
+
+Every character + NPC FSM samples next-state candidates from this table,
+weighted by ``base_weight * tod_multipliers[current_phase]``. A multiplier of
+``0.0`` effectively bans the transition during that phase (e.g. SLEEPING is
+gated to NIGHT, FARMING to DAY).
+
+Wire-up:
+    candidates = TRANSITION_TABLE[current_state]
+    weights = [base * tod.get(phase, 1.0) for (_, base, tod) in candidates]
+    next_state = rng.choices([next for (next, _, _) in candidates], weights)[0]
+
+This is engine-shaped scaffolding; Agents B/C may *augment* by composing extra
+context (role gates, building proximity, fear thresholds) on top — they don't
+edit this table.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List, Tuple
+
+from contracts import Phase, State
+
+
+# A transition is (next_state, base_weight, per-phase multipliers).
+Transition = Tuple[State, float, Dict[Phase, float]]
+
+
+# --- Phase multiplier shortcuts -------------------------------------------------
+
+_DAY_ONLY: Dict[Phase, float] = {Phase.DAY: 1.0, Phase.DUSK: 0.2, Phase.NIGHT: 0.0, Phase.DAWN: 0.4}
+_NIGHT_ONLY: Dict[Phase, float] = {Phase.DAY: 0.0, Phase.DUSK: 0.4, Phase.NIGHT: 1.0, Phase.DAWN: 0.2}
+_DUSK_NIGHT: Dict[Phase, float] = {Phase.DAY: 0.1, Phase.DUSK: 1.0, Phase.NIGHT: 1.0, Phase.DAWN: 0.2}
+_ANYTIME: Dict[Phase, float] = {Phase.DAY: 1.0, Phase.DUSK: 1.0, Phase.NIGHT: 1.0, Phase.DAWN: 1.0}
+_BIASED_DAY: Dict[Phase, float] = {Phase.DAY: 1.0, Phase.DUSK: 0.6, Phase.NIGHT: 0.2, Phase.DAWN: 0.6}
+_BIASED_NIGHT: Dict[Phase, float] = {Phase.DAY: 0.3, Phase.DUSK: 0.7, Phase.NIGHT: 1.0, Phase.DAWN: 0.5}
+
+
+# --- The transition table -------------------------------------------------------
+#
+# Notes on coverage:
+#   * Every "solo" character state has a self-stay edge (return to WANDERING /
+#     current state) so the FSM never deadlocks if all weighted edges happen to
+#     score 0 for the current phase.
+#   * Multi-agent states (MEETING/ARGUING/CONVERSING/MEDIATING) decay back to
+#     WANDERING — the social driver in Agent B promotes them externally.
+#   * Creature/supernatural sub-FSMs are NOT in this table — they're managed
+#     inside agents/creatures.py and agents/supernatural.py respectively.
+#   * IRRATIONAL is a terminal "stuck" state from this table's POV — exit is
+#     driven by agents/fear.py outcome sampling, not by weighted transitions.
+
+TRANSITION_TABLE: Dict[State, List[Transition]] = {
+    State.SLEEPING: [
+        (State.SLEEPING, 6.0, _NIGHT_ONLY),
+        (State.WANDERING, 2.0, _BIASED_DAY),
+        (State.EATING, 1.5, _BIASED_DAY),
+        (State.FARMING, 1.0, _DAY_ONLY),
+    ],
+    State.EATING: [
+        (State.WANDERING, 2.0, _ANYTIME),
+        (State.GOSSIPING, 1.5, _BIASED_DAY),
+        (State.SHELTERING, 1.0, _DUSK_NIGHT),
+        (State.FARMING, 1.0, _DAY_ONLY),
+    ],
+    State.SCAVENGING: [
+        (State.SCAVENGING, 2.0, _BIASED_DAY),
+        (State.WANDERING, 1.5, _ANYTIME),
+        (State.EATING, 1.0, _ANYTIME),
+        (State.SHELTERING, 1.0, _DUSK_NIGHT),
+    ],
+    State.FARMING: [
+        (State.FARMING, 4.0, _DAY_ONLY),
+        (State.EATING, 1.5, _ANYTIME),
+        (State.WANDERING, 1.0, _ANYTIME),
+        (State.SHELTERING, 1.5, _DUSK_NIGHT),
+    ],
+    State.GOSSIPING: [
+        (State.GOSSIPING, 2.0, _DAY_ONLY),
+        (State.CONVERSING, 1.5, _DAY_ONLY),
+        (State.WANDERING, 2.0, _ANYTIME),
+        (State.MEETING, 0.5, _BIASED_DAY),
+    ],
+    State.PATROLLING: [
+        (State.PATROLLING, 3.0, _BIASED_NIGHT),
+        (State.WANDERING, 1.0, _ANYTIME),
+        (State.INVESTIGATING, 1.5, _DUSK_NIGHT),
+        (State.SHELTERING, 0.5, _NIGHT_ONLY),
+    ],
+    State.SHELTERING: [
+        (State.SHELTERING, 5.0, _NIGHT_ONLY),
+        (State.SLEEPING, 2.0, _NIGHT_ONLY),
+        (State.PRAYING, 1.0, _DUSK_NIGHT),
+        (State.WANDERING, 2.0, _BIASED_DAY),
+    ],
+    State.PRAYING: [
+        (State.PRAYING, 1.5, _DUSK_NIGHT),
+        (State.WANDERING, 2.0, _ANYTIME),
+        (State.SHELTERING, 1.0, _DUSK_NIGHT),
+        (State.MOURNING, 0.5, _ANYTIME),
+    ],
+    State.MEDICAL_CARE: [
+        (State.MEDICAL_CARE, 3.0, _ANYTIME),
+        (State.WANDERING, 1.0, _ANYTIME),
+        (State.CARETAKING, 1.0, _ANYTIME),
+    ],
+    State.MOURNING: [
+        (State.MOURNING, 2.0, _ANYTIME),
+        (State.PRAYING, 1.5, _ANYTIME),
+        (State.WANDERING, 1.5, _BIASED_DAY),
+        (State.GOSSIPING, 0.5, _DAY_ONLY),
+    ],
+    State.REPAIRING: [
+        (State.REPAIRING, 2.5, _DAY_ONLY),
+        (State.WANDERING, 1.0, _ANYTIME),
+        (State.EATING, 0.5, _ANYTIME),
+    ],
+    State.WANDERING: [
+        # The "hub" state — most transitions originate here.
+        (State.WANDERING, 1.0, _ANYTIME),
+        (State.EATING, 1.0, _BIASED_DAY),
+        (State.GOSSIPING, 1.0, _DAY_ONLY),
+        (State.FARMING, 1.0, _DAY_ONLY),
+        (State.SCAVENGING, 0.8, _BIASED_DAY),
+        (State.PATROLLING, 0.8, _BIASED_NIGHT),
+        (State.SHELTERING, 1.2, _DUSK_NIGHT),
+        (State.SLEEPING, 1.5, _NIGHT_ONLY),
+        (State.PRAYING, 0.4, _ANYTIME),
+        (State.INVESTIGATING, 0.3, _ANYTIME),
+        (State.REPAIRING, 0.4, _DAY_ONLY),
+        (State.PLAYING, 0.4, _DAY_ONLY),
+        (State.CONVERSING, 0.5, _BIASED_DAY),
+    ],
+    State.FLEEING: [
+        # Fleeing decays back into shelter / wander when fear subsides.
+        (State.SHELTERING, 3.0, _ANYTIME),
+        (State.WANDERING, 1.0, _BIASED_DAY),
+        (State.FLEEING, 1.5, _DUSK_NIGHT),
+    ],
+    State.HYPNOTIZED: [
+        # Hypnotised agents stay put until creatures.py releases them.
+        (State.HYPNOTIZED, 10.0, _ANYTIME),
+        (State.WANDERING, 0.2, _BIASED_DAY),
+    ],
+    State.INVESTIGATING: [
+        (State.INVESTIGATING, 1.5, _ANYTIME),
+        (State.WANDERING, 1.5, _ANYTIME),
+        (State.PATROLLING, 0.8, _BIASED_NIGHT),
+        (State.MEETING, 0.4, _BIASED_DAY),
+    ],
+    State.PLAYING: [
+        (State.PLAYING, 2.0, _DAY_ONLY),
+        (State.WANDERING, 1.5, _BIASED_DAY),
+        (State.SHELTERING, 1.0, _DUSK_NIGHT),
+    ],
+    State.EXPEDITION: [
+        # Owned externally by the expedition slice; included for completeness.
+        (State.EXPEDITION, 5.0, _ANYTIME),
+        (State.WANDERING, 0.2, _BIASED_DAY),
+    ],
+    State.CARETAKING: [
+        (State.CARETAKING, 2.0, _ANYTIME),
+        (State.MEDICAL_CARE, 1.0, _ANYTIME),
+        (State.WANDERING, 1.0, _ANYTIME),
+    ],
+    State.IRRATIONAL: [
+        # Driven externally by fear.py; offer a thin escape edge.
+        (State.IRRATIONAL, 4.0, _ANYTIME),
+        (State.WANDERING, 0.3, _BIASED_DAY),
+    ],
+    State.MEETING: [
+        (State.MEETING, 3.0, _BIASED_DAY),
+        (State.WANDERING, 1.0, _ANYTIME),
+        (State.ARGUING, 0.5, _BIASED_DAY),
+    ],
+    State.ARGUING: [
+        (State.WANDERING, 2.0, _ANYTIME),
+        (State.MEDIATING, 0.8, _BIASED_DAY),
+        (State.MEETING, 0.5, _BIASED_DAY),
+    ],
+    State.CONVERSING: [
+        (State.WANDERING, 1.5, _ANYTIME),
+        (State.GOSSIPING, 1.0, _DAY_ONLY),
+        (State.CONVERSING, 0.8, _ANYTIME),
+    ],
+    State.MEDIATING: [
+        (State.WANDERING, 2.0, _ANYTIME),
+        (State.MEETING, 0.8, _BIASED_DAY),
+        (State.CONVERSING, 0.6, _BIASED_DAY),
+    ],
+    # NPC mini-FSM (just two states — see agents/npcs.py for richer logic).
+    State.WORKING: [
+        (State.WORKING, 3.0, _DAY_ONLY),
+        (State.SOCIALIZING, 1.0, _DAY_ONLY),
+        (State.WANDERING, 0.5, _ANYTIME),
+        (State.SHELTERING, 1.0, _DUSK_NIGHT),
+        (State.SLEEPING, 1.5, _NIGHT_ONLY),
+    ],
+    State.SOCIALIZING: [
+        (State.SOCIALIZING, 2.0, _DAY_ONLY),
+        (State.WORKING, 1.5, _DAY_ONLY),
+        (State.GOSSIPING, 1.0, _DAY_ONLY),
+        (State.SHELTERING, 1.0, _DUSK_NIGHT),
+    ],
+}

--- a/from-simulation/app/agents/supernatural.py
+++ b/from-simulation/app/agents/supernatural.py
@@ -1,0 +1,258 @@
+"""
+"Dumb" supernatural entities — short-lived, mostly cosmetic effects.
+
+Three kinds live here:
+
+    BoyInWhite        — appears near a fearful agent; lowers their fear,
+                         raises their sanity. Disappears after a few ticks.
+    Anghkooey         — only spawns adjacent to an active Faraway Tree event.
+                         Wanders the perimeter chanting; emits ``anghkooey_chant``.
+    FarawayTreePortal — rare; flips a random wandering agent to ABSENT.
+
+The "Man in Yellow" is NOT here — Agent C owns him.
+
+These entities go into ``world.supernaturals`` (transient list). Each ticks
+itself and self-deletes by setting ``alive = False``; ``roll(world)`` prunes
+dead entries.
+"""
+
+from __future__ import annotations
+
+from typing import List, Optional
+
+from contracts import (
+    Agent,
+    AgentKind,
+    Event,
+    FARAWAY_TREES,
+    MarkerClass,
+    Phase,
+    State,
+    Status,
+    World,
+)
+from agents.base import distance, move_toward, nearest
+
+
+# ----------------------------------------------------------- BoyInWhite
+
+
+class BoyInWhite(Agent):
+    """A calming apparition. Walks toward a target, then dissipates."""
+
+    DURATION = 30  # ticks
+
+    def __init__(self, sid: str, x: float, y: float, target_id: Optional[str]) -> None:
+        self.id = sid
+        self.kind = AgentKind.SUPERNATURAL
+        self.marker_class = MarkerClass.BOY_IN_WHITE
+        self.x = float(x)
+        self.y = float(y)
+        self.target_id = target_id
+        self.ticks_left = self.DURATION
+        self.alive = True
+
+    def tick(self, world: World) -> None:
+        self.ticks_left -= 1
+        target = world.agents.get(self.target_id) if self.target_id else None
+        if target is not None:
+            move_toward(self, target.x, target.y, 1.0)
+            if distance(self, target) <= 30.0:
+                # Calming effect — reduce fear, restore a little sanity.
+                fear = float(getattr(target, "fear", 0.0))
+                sanity = float(getattr(target, "sanity", 100.0))
+                setattr(target, "fear", max(0.0, fear - 4.0))
+                setattr(target, "sanity", min(100.0, sanity + 2.0))
+        if self.ticks_left <= 0:
+            self.alive = False
+
+    def to_dict(self):
+        base = super().to_dict()
+        base["kind_detail"] = "boy_in_white"
+        base["target"] = self.target_id
+        return base
+
+
+# ----------------------------------------------------------- Anghkooey
+
+
+class Anghkooey(Agent):
+    """Wandering chanter — only spawns adjacent to an active Faraway Tree event."""
+
+    DURATION = 60
+
+    def __init__(self, sid: str, x: float, y: float) -> None:
+        self.id = sid
+        self.kind = AgentKind.SUPERNATURAL
+        self.marker_class = MarkerClass.ANGHKOOEY
+        self.x = float(x)
+        self.y = float(y)
+        self.ticks_left = self.DURATION
+        self.alive = True
+        self._next_chant_in = 8
+
+    def tick(self, world: World) -> None:
+        self.ticks_left -= 1
+        # Drift slightly each tick.
+        self.x += world.rng.uniform(-2.0, 2.0)
+        self.y += world.rng.uniform(-2.0, 2.0)
+        self._next_chant_in -= 1
+        if self._next_chant_in <= 0:
+            self._next_chant_in = world.rng.randint(6, 14)
+            world.emit(
+                Event(
+                    tick=world.tick_count,
+                    type="anghkooey_chant",
+                    subject=self.id,
+                    detail="chant from the treeline",
+                    severity="info",
+                )
+            )
+        if self.ticks_left <= 0:
+            self.alive = False
+
+    def to_dict(self):
+        base = super().to_dict()
+        base["kind_detail"] = "anghkooey"
+        return base
+
+
+# -------------------------------------------------------- FarawayTreePortal
+
+
+class FarawayTreePortal(Agent):
+    """A glowing portal at a Faraway Tree. Brief — may snatch a passerby."""
+
+    DURATION = 25
+
+    def __init__(self, sid: str, x: float, y: float) -> None:
+        self.id = sid
+        self.kind = AgentKind.SUPERNATURAL
+        self.marker_class = MarkerClass.FARAWAY_TREE
+        self.x = float(x)
+        self.y = float(y)
+        self.ticks_left = self.DURATION
+        self.alive = True
+        self.snatch_attempted = False
+
+    def tick(self, world: World) -> None:
+        self.ticks_left -= 1
+        # Halfway through, attempt to snatch a wandering character.
+        if not self.snatch_attempted and self.ticks_left <= (self.DURATION // 2):
+            self.snatch_attempted = True
+            candidates = [
+                a for a in world.agents.values()
+                if getattr(a, "state", None) == State.WANDERING
+                and getattr(a, "status", Status.ACTIVE) == Status.ACTIVE
+                and distance(a, self) <= 180.0
+            ]
+            if candidates and world.rng.random() < 0.4:
+                victim = world.rng.choice(candidates)
+                setattr(victim, "status", Status.ABSENT)
+                world.emit(
+                    Event(
+                        tick=world.tick_count,
+                        type="faraway_portal",
+                        subject=victim.id,
+                        detail="taken by the Faraway Tree",
+                        severity="warn",
+                    )
+                )
+        if self.ticks_left <= 0:
+            self.alive = False
+
+    def to_dict(self):
+        base = super().to_dict()
+        base["kind_detail"] = "faraway_tree"
+        return base
+
+
+# ----------------------------------------------------------- roll table
+
+
+# Per-tick spawn probabilities. Tuned so the village sees a couple of events
+# per sim-day at 2 Hz. Anghkooey is gated on FarawayTree active.
+_P_BOY = 0.0015        # mostly DUSK/NIGHT
+_P_FARAWAY = 0.0008
+_P_ANGHKOOEY = 0.004   # only when Faraway Tree active
+
+
+def _any_faraway_active(supernaturals: List[Agent]) -> bool:
+    return any(isinstance(s, FarawayTreePortal) and getattr(s, "alive", True) for s in supernaturals)
+
+
+def roll(world: World) -> None:
+    """Once-per-tick supernatural dispatcher.
+
+    Prunes dead entities, ticks the live ones, then rolls for new spawns.
+    """
+    # 1) Tick live entities.
+    for s in list(world.supernaturals):
+        if getattr(s, "alive", True):
+            s.tick(world)
+    # 2) Prune dead.
+    world.supernaturals[:] = [s for s in world.supernaturals if getattr(s, "alive", True)]
+
+    rng = world.rng
+    phase = world.time.phase
+
+    # --- Boy in White ---
+    boy_bias = 1.8 if phase in (Phase.DUSK, Phase.NIGHT) else 0.6
+    if rng.random() < _P_BOY * boy_bias:
+        # Pick the most-fearful active agent within view.
+        candidates = [
+            a for a in world.agents.values()
+            if getattr(a, "status", Status.ACTIVE) == Status.ACTIVE
+            and float(getattr(a, "fear", 0.0)) >= 30.0
+        ]
+        if candidates:
+            target = max(candidates, key=lambda a: float(getattr(a, "fear", 0.0)))
+            sx = target.x + rng.uniform(-30, 30)
+            sy = target.y + rng.uniform(-30, 30)
+            sid = f"boywhite_{world.tick_count}_{rng.randint(0, 9999)}"
+            world.supernaturals.append(BoyInWhite(sid, sx, sy, target.id))
+            world.emit(
+                Event(
+                    tick=world.tick_count,
+                    type="boy_in_white",
+                    subject=target.id,
+                    detail="visited by the boy in white",
+                    severity="info",
+                )
+            )
+
+    # --- Faraway Tree portal (rare, mostly at night/dusk/dawn) ---
+    tree_bias = 1.6 if phase in (Phase.NIGHT, Phase.DUSK, Phase.DAWN) else 0.3
+    if rng.random() < _P_FARAWAY * tree_bias:
+        tx, ty = rng.choice(FARAWAY_TREES)
+        sid = f"faraway_{world.tick_count}_{rng.randint(0, 9999)}"
+        world.supernaturals.append(FarawayTreePortal(sid, float(tx), float(ty)))
+
+    # --- Anghkooey (gated on active Faraway Tree) ---
+    if _any_faraway_active(world.supernaturals) and rng.random() < _P_ANGHKOOEY:
+        # Spawn near one of the active portals.
+        portals = [s for s in world.supernaturals if isinstance(s, FarawayTreePortal)]
+        portal = rng.choice(portals)
+        sx = portal.x + rng.uniform(-40, 40)
+        sy = portal.y + rng.uniform(-40, 40)
+        sid = f"anghk_{world.tick_count}_{rng.randint(0, 9999)}"
+        world.supernaturals.append(Anghkooey(sid, sx, sy))
+
+
+def spawn_glitch_marker(world: World, agent) -> Optional[Agent]:
+    """Helper used by fear.py to attach a transient glitch sprite to an agent.
+
+    Returns the marker (also appended to ``world.supernaturals``) so the caller
+    can hold a reference if it wants to track it.
+    """
+    marker = FarawayTreePortal(
+        sid=f"glitch_{agent.id}_{world.tick_count}",
+        x=float(agent.x),
+        y=float(agent.y),
+    )
+    # Repurpose marker_class for the glitch overlay so the UI knows.
+    marker.marker_class = MarkerClass.FARAWAY_TREE
+    marker.snatch_attempted = True  # don't try to abduct on a glitch marker
+    marker.ticks_left = 12
+    world.supernaturals.append(marker)
+    return marker

--- a/from-simulation/app/agents/yellow_man.py
+++ b/from-simulation/app/agents/yellow_man.py
@@ -153,7 +153,13 @@ def _distance(ax: float, ay: float, bx: float, by: float) -> float:
 
 
 def _start_appearance(world: World) -> None:
-    """Decide IMPOSTER vs VISIBLE_MARCH and arm the deadline."""
+    """Decide IMPOSTER vs VISIBLE_MARCH and arm the deadline.
+
+    v2: in IMPOSTER mode we now pick ``[yellow_hydra_min, yellow_hydra_max]``
+    distinct NPC tendrils. ``disguised_as`` points at the "leader" tendril
+    (the most visible one); ``tendrils`` lists all of them. OUTSIDERS are
+    excluded from the disguise pool — only plain NPCs can be hijacked.
+    """
     cfg = world.config
     rng = world.rng
     ya = world.yellow_active
@@ -169,11 +175,28 @@ def _start_appearance(world: World) -> None:
             # No NPC to wear -> fall back to a visible march.
             _begin_march(world)
             return
-        target = rng.choice(npcs)
+
+        # Decide how many tendrils, clamped to the available NPC count.
+        hydra_min = max(1, cfg.yellow_hydra_min)
+        hydra_max = max(hydra_min, cfg.yellow_hydra_max)
+        n_hydra = rng.randint(hydra_min, hydra_max)
+        n_hydra = max(1, min(n_hydra, len(npcs)))
+
+        chosen = rng.sample(npcs, n_hydra)
+        tendril_ids = [n.id for n in chosen]
+        leader_id = tendril_ids[0]
+
         ya.mode = YellowMode.IMPOSTER
-        ya.disguised_as = target.id
-        # Touched, definitionally.
-        world.yellow_touched_npcs.add(target.id)
+        ya.disguised_as = leader_id
+        ya.tendrils = list(tendril_ids)
+        # Track the initial hydra count so banishments can shorten the deadline
+        # proportionally. Stored via setattr because YellowState's dataclass
+        # is owned by contracts.py and we don't add fields unilaterally.
+        setattr(ya, "_initial_hydra", n_hydra)
+
+        # All tendrils are touched definitionally.
+        for tid in tendril_ids:
+            world.yellow_touched_npcs.add(tid)
     else:
         _begin_march(world)
         return
@@ -187,7 +210,10 @@ def _start_appearance(world: World) -> None:
             tick=world.tick_count,
             type="yellow_appearance",
             subject="yellow_man",
-            detail=f"mode={ya.mode.value} disguised_as={ya.disguised_as}",
+            detail=(
+                f"mode={ya.mode.value} disguised_as={ya.disguised_as} "
+                f"tendrils={len(ya.tendrils)}"
+            ),
             severity="warn",
         )
     )
@@ -201,6 +227,16 @@ def _start_appearance(world: World) -> None:
                 severity="warn",
             )
         )
+        for tid in ya.tendrils:
+            world.emit(
+                Event(
+                    tick=world.tick_count,
+                    type="yellow_tendril_added",
+                    subject=tid,
+                    detail=f"tendril count now {len(ya.tendrils)}",
+                    severity="warn",
+                )
+            )
 
 
 def _begin_march(world: World) -> None:
@@ -241,6 +277,13 @@ def _end_appearance(world: World, reason: str) -> None:
     ya.deadline_tick = 0
     ya.started_at_tick = 0
     ya.path_index = 0
+    ya.tendrils.clear()
+    # Drop the hydra-count sentinel.
+    if hasattr(ya, "_initial_hydra"):
+        try:
+            delattr(ya, "_initial_hydra")
+        except AttributeError:
+            pass
     # Touched set persists across appearances by design (per spec).
     _schedule_next_appearance(world)
 
@@ -311,6 +354,29 @@ def _find_disguise(world: World) -> Optional[NPC]:
     if isinstance(a, NPC) and a.status == Status.ACTIVE:
         return a
     return None
+
+
+def _live_tendrils(world: World) -> List[NPC]:
+    """Return the list of currently-living tendril NPCs.
+
+    Side-effect: prunes ``ya.tendrils`` of any ids that no longer point to an
+    active NPC (the underlying agent may have been reaped between ticks).
+    """
+    ya = world.yellow_active
+    out: List[NPC] = []
+    pruned: List[str] = []
+    for tid in list(ya.tendrils):
+        a = world.agents.get(tid)
+        if isinstance(a, NPC) and a.status == Status.ACTIVE:
+            out.append(a)
+        else:
+            pruned.append(tid)
+    if pruned:
+        ya.tendrils = [t for t in ya.tendrils if t not in pruned]
+        # Keep ``disguised_as`` consistent — promote a survivor if the leader fell.
+        if ya.disguised_as in pruned:
+            ya.disguised_as = ya.tendrils[0] if ya.tendrils else None
+    return out
 
 
 def _children(world: World) -> List[Any]:
@@ -394,17 +460,27 @@ def _consult_llm(world: World, npc: NPC) -> Optional[str]:
 
 
 def _tick_imposter(world: World) -> None:
-    npc = _find_disguise(world)
-    if npc is None:
-        # Our disguise died or vanished — abort silently and reschedule.
+    """Hydra-aware imposter tick.
+
+    Every live tendril gets the subtle fear bias each tick. To keep behaviour
+    legible (and not have every tendril simultaneously LURE_OUTSIDE on one tick),
+    we pick a single random tendril each tick to apply an imposter action to.
+    """
+    tendrils = _live_tendrils(world)
+    if not tendrils:
+        # Every tendril is dead/missing — abort silently and reschedule.
         _end_appearance(world, "disguise_lost")
         return
 
-    # Bias the imposter NPC: add subtle extra fear so it reads "off".
-    npc.fear = min(1.0, npc.fear + 0.0005)
+    # Subtle fear bias on every tendril — they all read slightly "off".
+    for t in tendrils:
+        t.fear = min(1.0, t.fear + 0.0005)
+
+    # Pick one tendril to act through this tick.
+    actor = world.rng.choice(tendrils)
 
     # Pick an action: LLM if available, else weighted random.
-    action = _consult_llm(world, npc)
+    action = _consult_llm(world, actor)
     if action is None:
         rng = world.rng
         # Phase-aware weighting.
@@ -423,7 +499,7 @@ def _tick_imposter(world: World) -> None:
             action = None
 
     if action is not None:
-        _apply_imposter_action(world, npc, action)
+        _apply_imposter_action(world, actor, action)
 
 
 # ---------------------------------------------------------------------------
@@ -445,6 +521,15 @@ def _consume_meeting_outcomes(world: World) -> None:
 
 
 def _handle_suspicion(world: World, mo: MeetingOutcome) -> None:
+    """Hydra-aware vote handling.
+
+    v2 rules:
+        * Not guilty           -> just log it (unchanged).
+        * Guilty + a tendril   -> banish that tendril; shorten deadline
+                                  proportionally; if no tendrils remain, the
+                                  whole imposter is banished (sanity bump).
+        * Guilty + not tendril -> innocent dies; fear spike; Yellow stays.
+    """
     ya = world.yellow_active
     accused = mo.payload.get("accused_npc_id")
     guilty = bool(mo.payload.get("guilty"))
@@ -462,38 +547,65 @@ def _handle_suspicion(world: World, mo: MeetingOutcome) -> None:
         )
         return
 
-    # Guilty + accusation matches our disguise -> banished.
-    if accused is not None and ya.mode == YellowMode.IMPOSTER and accused == ya.disguised_as:
-        # Bump sanity on every character (+5 scaled to a 0..1 sanity is huge,
-        # so we treat the "5" as a percent boost = +0.05).
-        for a in world.agents.values():
-            if getattr(a, "kind", None) == AgentKind.CHARACTER:
-                cur = getattr(a, "sanity", None)
-                if cur is not None:
-                    try:
-                        a.sanity = min(1.0, float(cur) + 0.05)
-                    except Exception:
-                        pass
-        # Kill the now-exposed impostor NPC.
+    # Guilty + the accused is one of our tendrils -> tendril banished.
+    if (
+        accused is not None
+        and ya.mode == YellowMode.IMPOSTER
+        and accused in ya.tendrils
+    ):
+        # Remove the tendril.
+        ya.tendrils = [t for t in ya.tendrils if t != accused]
+        # Kill the now-exposed tendril NPC.
         npc = world.agents.get(accused)
         if npc is not None:
             try:
                 npc.status = Status.DEAD
             except Exception:
                 pass
+
         world.emit(
             Event(
                 tick=world.tick_count,
-                type="imposter_banished",
+                type="yellow_tendril_banished",
                 subject=accused,
-                detail="The village named him true and he could not stay",
-                severity="info",
+                detail=f"tendrils remaining: {len(ya.tendrils)}",
+                severity="warn",
             )
         )
-        _end_appearance(world, "banished")
+
+        # Shorten the deadline proportionally to initial hydra size.
+        initial = int(getattr(ya, "_initial_hydra", max(1, len(ya.tendrils) + 1)))
+        if initial > 0:
+            shrink = world.config.yellow_deadline_ticks // initial
+            ya.deadline_tick = max(world.tick_count + 1, ya.deadline_tick - shrink)
+
+        # If the leader fell, promote a survivor.
+        if accused == ya.disguised_as:
+            ya.disguised_as = ya.tendrils[0] if ya.tendrils else None
+
+        # If no tendrils remain, the whole imposter is banished.
+        if not ya.tendrils:
+            for a in world.agents.values():
+                if getattr(a, "kind", None) == AgentKind.CHARACTER:
+                    cur = getattr(a, "sanity", None)
+                    if cur is not None:
+                        try:
+                            a.sanity = min(1.0, float(cur) + 0.05)
+                        except Exception:
+                            pass
+            world.emit(
+                Event(
+                    tick=world.tick_count,
+                    type="imposter_banished",
+                    subject=accused,
+                    detail="The last tendril fell — the village named him true",
+                    severity="info",
+                )
+            )
+            _end_appearance(world, "banished")
         return
 
-    # Guilty but they got the wrong person -> kill the innocent + fear spike.
+    # Guilty but they got someone outside the hydra -> kill the innocent + fear spike.
     if accused is not None and accused in world.agents:
         innocent = world.agents[accused]
         try:
@@ -586,6 +698,11 @@ def tick_yellow(world: World) -> None:
             Metric.YELLOW_ACTIVE,
             0.0 if ya.mode == YellowMode.DORMANT else 1.0,
             {"mode": ya.mode.value},
+        )
+        # v2 hydra count — 0 when not in IMPOSTER mode.
+        world.telemetry.gauge_set(
+            Metric.YELLOW_TENDRILS,
+            float(len(ya.tendrils)),
         )
 
 

--- a/from-simulation/app/agents/yellow_man.py
+++ b/from-simulation/app/agents/yellow_man.py
@@ -1,0 +1,597 @@
+"""
+The Man in Yellow — the show's central horror motif.
+
+Runs in three sub-modes stored on ``world.yellow_active.mode``:
+
+    DORMANT       Off-stage. Periodically taints NPCs (``yellow_touched_npcs``)
+                  during the day; rolls an appearance schedule.
+    VISIBLE_MARCH Walks the ``YELLOW_MARCH_PATH`` waypoints once as a
+                  ``MarkerClass.MAN_IN_YELLOW`` supernatural. NPCs within
+                  60 px are forced WANDERING for 10 ticks.
+    IMPOSTER      Hijacks a random existing NPC. No new marker is drawn —
+                  the disguised NPC's existing dot is what the player sees.
+                  Internally biases meeting votes and lures children outside
+                  talisman-protected doors at NIGHT (unlocks the door).
+
+When an appearance is live, ``world.yellow_active.deadline_tick`` is the
+hard timer. If the deadline elapses before the villagers either banish him
+(IMPOSTER mode is voted out in an ``imposter_suspicion`` meeting) or he
+finishes his visible march, a **village wipe** fires:
+
+    * ``village_wipe`` event (severity=crit)
+    * ``from_sim_village_wipes_total`` counter increments
+    * ``world.pending_reset = True``  -> Agent A reseeds next tick
+
+Meeting consumption (Agent B emits ``MeetingOutcome`` with
+``topic == "imposter_suspicion"``):
+
+    payload {accused_npc_id, guilty}:
+        guilty + accused matches disguise  -> imposter_banished, +5 sanity all,
+                                              mode -> DORMANT
+        guilty + accused != disguise       -> kill the innocent NPC, fear spike
+        not guilty                         -> just log it
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+from contracts import (
+    Agent,
+    AgentKind,
+    Event,
+    MarkerClass,
+    MeetingOutcome,
+    Metric,
+    Phase,
+    State,
+    Status,
+    World,
+    YellowMode,
+    YELLOW_MARCH_PATH,
+)
+from agents.npcs import NPC
+
+
+# ---------------------------------------------------------------------------
+# Visible-march supernatural marker
+# ---------------------------------------------------------------------------
+
+
+class _YellowMarchMarker:
+    """Lightweight ``Agent``-shaped object for ``world.supernaturals``.
+
+    We don't subclass ``Agent`` directly because the visible march has no
+    autonomous tick — the yellow_man module steps it from ``tick_yellow``.
+    But it honours the snapshot contract (``to_dict``) so the frontend
+    renders it the same way as any other supernatural.
+    """
+
+    kind = AgentKind.SUPERNATURAL
+    marker_class = MarkerClass.MAN_IN_YELLOW
+
+    def __init__(self, x: float, y: float) -> None:
+        self.id = "yellow_man_march"
+        self.x = float(x)
+        self.y = float(y)
+
+    def tick(self, world: World) -> None:  # pragma: no cover - stepped externally
+        pass
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "id": self.id,
+            "kind": self.kind.value,
+            "marker_class": self.marker_class.value,
+            "x": round(self.x, 2),
+            "y": round(self.y, 2),
+        }
+
+
+# ---------------------------------------------------------------------------
+# Scheduling state — kept module-local; world only stores the active payload.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _Schedule:
+    next_appearance_tick: int = 0
+    last_taint_day: int = -1
+    seen_outcome_count: int = 0  # how many meeting_outcomes we've already scanned
+
+
+_SCHED = _Schedule()
+
+
+def _ticks_per_day(world: World) -> int:
+    """Best-effort conversion. The engine ticks ``tick_hz`` times per second
+    and ``time_scale`` minutes pass per tick. 24h = 1440 sim-minutes, so
+    days-of-ticks = 1440 / time_scale.
+    """
+    scale = max(0.001, float(world.config.time_scale))
+    return max(60, int(1440.0 / scale))
+
+
+def _schedule_next_appearance(world: World) -> None:
+    """Roll a 5–10 sim-day timer (configurable)."""
+    cfg = world.config
+    days_min = max(1, cfg.yellow_appearance_days_min)
+    days_max = max(days_min, cfg.yellow_appearance_days_max)
+    days = world.rng.randint(days_min, days_max)
+    _SCHED.next_appearance_tick = world.tick_count + days * _ticks_per_day(world)
+
+
+def _maybe_taint_npcs(world: World) -> None:
+    """Once per sim-day, taint a few unsuspecting NPCs."""
+    today = world.time.day
+    if today == _SCHED.last_taint_day:
+        return
+    _SCHED.last_taint_day = today
+
+    rng = world.rng
+    npcs = [
+        a for a in world.agents.values()
+        if getattr(a, "kind", None) == AgentKind.NPC
+        and getattr(a, "status", Status.ACTIVE) == Status.ACTIVE
+    ]
+    if not npcs:
+        return
+    n_taint = min(len(npcs), rng.randint(1, 3))
+    for npc in rng.sample(npcs, n_taint):
+        world.yellow_touched_npcs.add(npc.id)
+
+
+def _distance(ax: float, ay: float, bx: float, by: float) -> float:
+    return math.hypot(ax - bx, ay - by)
+
+
+# ---------------------------------------------------------------------------
+# Appearance starters
+# ---------------------------------------------------------------------------
+
+
+def _start_appearance(world: World) -> None:
+    """Decide IMPOSTER vs VISIBLE_MARCH and arm the deadline."""
+    cfg = world.config
+    rng = world.rng
+    ya = world.yellow_active
+
+    # Pick mode.
+    if rng.random() < cfg.yellow_imposter_prob:
+        npcs = [
+            a for a in world.agents.values()
+            if getattr(a, "kind", None) == AgentKind.NPC
+            and getattr(a, "status", Status.ACTIVE) == Status.ACTIVE
+        ]
+        if not npcs:
+            # No NPC to wear -> fall back to a visible march.
+            _begin_march(world)
+            return
+        target = rng.choice(npcs)
+        ya.mode = YellowMode.IMPOSTER
+        ya.disguised_as = target.id
+        # Touched, definitionally.
+        world.yellow_touched_npcs.add(target.id)
+    else:
+        _begin_march(world)
+        return
+
+    ya.started_at_tick = world.tick_count
+    ya.deadline_tick = world.tick_count + cfg.yellow_deadline_ticks
+    ya.path_index = 0
+
+    world.emit(
+        Event(
+            tick=world.tick_count,
+            type="yellow_appearance",
+            subject="yellow_man",
+            detail=f"mode={ya.mode.value} disguised_as={ya.disguised_as}",
+            severity="warn",
+        )
+    )
+    if ya.mode == YellowMode.IMPOSTER:
+        world.emit(
+            Event(
+                tick=world.tick_count,
+                type="yellow_imposter_join",
+                subject=ya.disguised_as or "yellow_man",
+                detail="A stranger has slipped into the village",
+                severity="warn",
+            )
+        )
+
+
+def _begin_march(world: World) -> None:
+    cfg = world.config
+    ya = world.yellow_active
+    ya.mode = YellowMode.VISIBLE_MARCH
+    ya.disguised_as = None
+    ya.path_index = 0
+    ya.started_at_tick = world.tick_count
+    ya.deadline_tick = world.tick_count + cfg.yellow_deadline_ticks
+
+    # Spawn the visible marker at the first waypoint.
+    if YELLOW_MARCH_PATH:
+        x, y = YELLOW_MARCH_PATH[0]
+        world.supernaturals.append(_YellowMarchMarker(x, y))
+
+    world.emit(
+        Event(
+            tick=world.tick_count,
+            type="yellow_appearance",
+            subject="yellow_man",
+            detail=f"mode={ya.mode.value}",
+            severity="warn",
+        )
+    )
+
+
+def _end_appearance(world: World, reason: str) -> None:
+    """Return to DORMANT cleanly. Caller decides whether to emit anything."""
+    ya = world.yellow_active
+    # Strip any march marker from supernaturals.
+    world.supernaturals[:] = [
+        s for s in world.supernaturals
+        if getattr(s, "id", None) != "yellow_man_march"
+    ]
+    ya.mode = YellowMode.DORMANT
+    ya.disguised_as = None
+    ya.deadline_tick = 0
+    ya.started_at_tick = 0
+    ya.path_index = 0
+    # Touched set persists across appearances by design (per spec).
+    _schedule_next_appearance(world)
+
+
+# ---------------------------------------------------------------------------
+# Per-mode tick helpers
+# ---------------------------------------------------------------------------
+
+
+_MARCH_STEP_PX = 8.0
+_MARCH_INFLUENCE_RADIUS = 60.0
+_WANDER_FORCE_TICKS = 10
+
+
+def _tick_visible_march(world: World) -> None:
+    ya = world.yellow_active
+    if not YELLOW_MARCH_PATH:
+        _end_appearance(world, "no_path")
+        return
+
+    # Find our marker.
+    marker: Optional[_YellowMarchMarker] = None
+    for s in world.supernaturals:
+        if getattr(s, "id", None) == "yellow_man_march":
+            marker = s  # type: ignore[assignment]
+            break
+    if marker is None:
+        # Lost it somehow; respawn at current waypoint.
+        wx, wy = YELLOW_MARCH_PATH[min(ya.path_index, len(YELLOW_MARCH_PATH) - 1)]
+        marker = _YellowMarchMarker(wx, wy)
+        world.supernaturals.append(marker)
+
+    # Step toward current waypoint.
+    if ya.path_index >= len(YELLOW_MARCH_PATH):
+        # Path done.
+        _end_appearance(world, "march_complete")
+        return
+
+    tx, ty = YELLOW_MARCH_PATH[ya.path_index]
+    dx, dy = tx - marker.x, ty - marker.y
+    d = math.hypot(dx, dy)
+    if d <= _MARCH_STEP_PX:
+        marker.x, marker.y = tx, ty
+        ya.path_index += 1
+    else:
+        marker.x += dx * (_MARCH_STEP_PX / d)
+        marker.y += dy * (_MARCH_STEP_PX / d)
+
+    # Influence nearby NPCs.
+    wander_until = world.tick_count + _WANDER_FORCE_TICKS
+    for a in world.agents.values():
+        if getattr(a, "kind", None) != AgentKind.NPC:
+            continue
+        if _distance(marker.x, marker.y, a.x, a.y) <= _MARCH_INFLUENCE_RADIUS:
+            if isinstance(a, NPC):
+                a.force_wander(wander_until)
+
+
+# Imposter action menu — also used as the LLM decision menu.
+_IMPOSTER_ACTIONS = ("LURK_NEAR_CHILD", "STIR_MEETING", "LIE_LOW", "LURE_OUTSIDE")
+
+
+def _find_disguise(world: World) -> Optional[NPC]:
+    ya = world.yellow_active
+    if not ya.disguised_as:
+        return None
+    a = world.agents.get(ya.disguised_as)
+    if isinstance(a, NPC) and a.status == Status.ACTIVE:
+        return a
+    return None
+
+
+def _children(world: World) -> List[Any]:
+    """Return any agents tagged Role.CHILD. Agent B owns the role attr."""
+    out = []
+    for a in world.agents.values():
+        if getattr(a, "kind", None) == AgentKind.CHARACTER:
+            role = getattr(a, "role", None)
+            # Compare by value to dodge import order with characters module.
+            if role is not None and getattr(role, "value", role) == "CHILD":
+                out.append(a)
+    return out
+
+
+def _apply_imposter_action(world: World, npc: NPC, action: str) -> None:
+    rng = world.rng
+    if action == "LURK_NEAR_CHILD":
+        kids = _children(world)
+        if kids:
+            kid = rng.choice(kids)
+            npc.target_x = kid.x + rng.uniform(-20, 20)
+            npc.target_y = kid.y + rng.uniform(-20, 20)
+    elif action == "STIR_MEETING":
+        # Drift toward the church (meeting venue) and flip state to ARGUING.
+        for b in world.buildings.values():
+            if b.role_tag == "church":
+                npc.target_x = b.x + rng.uniform(-20, 20)
+                npc.target_y = b.y + rng.uniform(-20, 20)
+                break
+        npc.state = State.ARGUING
+    elif action == "LIE_LOW":
+        # Park near the diner; act normal.
+        for b in world.buildings.values():
+            if b.role_tag == "diner":
+                npc.target_x = b.x + rng.uniform(-25, 25)
+                npc.target_y = b.y + rng.uniform(-25, 25)
+                break
+        npc.state = State.SOCIALIZING
+    elif action == "LURE_OUTSIDE":
+        # NIGHT-only: try to unlock a talisman door so a hypnotized kid can leave.
+        if world.time.phase == Phase.NIGHT:
+            talismans = [b for b in world.buildings.values() if b.has_talisman and b.locked]
+            if talismans:
+                b = rng.choice(talismans)
+                b.locked = False
+                npc.target_x = b.x + rng.uniform(-15, 15)
+                npc.target_y = b.y + rng.uniform(25, 45)
+                world.emit(
+                    Event(
+                        tick=world.tick_count,
+                        type="yellow_imposter_acted",
+                        subject=npc.id,
+                        detail=f"unlocked {b.id}",
+                        severity="warn",
+                    )
+                )
+
+
+def _consult_llm(world: World, npc: NPC) -> Optional[str]:
+    """If an LLM decider is wired, ask it which action to take."""
+    decider = getattr(world, "llm_decider", None)
+    if decider is None:
+        return None
+    rate = world.config.llm_yellow_rate
+    try:
+        # The decider interface (defined by Agent A's llm package) returns
+        # either a chosen option string or None when rate-limited / disabled.
+        return decider.maybe_decide(
+            actor=f"yellow_man:{npc.id}",
+            rate=rate,
+            options=list(_IMPOSTER_ACTIONS),
+            context={
+                "tick": world.tick_count,
+                "phase": world.time.phase.value,
+                "disguised_as": npc.id,
+                "n_children_visible": len(_children(world)),
+            },
+        )
+    except Exception:
+        return None
+
+
+def _tick_imposter(world: World) -> None:
+    npc = _find_disguise(world)
+    if npc is None:
+        # Our disguise died or vanished — abort silently and reschedule.
+        _end_appearance(world, "disguise_lost")
+        return
+
+    # Bias the imposter NPC: add subtle extra fear so it reads "off".
+    npc.fear = min(1.0, npc.fear + 0.0005)
+
+    # Pick an action: LLM if available, else weighted random.
+    action = _consult_llm(world, npc)
+    if action is None:
+        rng = world.rng
+        # Phase-aware weighting.
+        if world.time.phase == Phase.NIGHT:
+            weights = {"LURE_OUTSIDE": 0.45, "LURK_NEAR_CHILD": 0.3, "LIE_LOW": 0.2, "STIR_MEETING": 0.05}
+        elif world.time.phase == Phase.DUSK:
+            weights = {"STIR_MEETING": 0.4, "LURK_NEAR_CHILD": 0.3, "LIE_LOW": 0.2, "LURE_OUTSIDE": 0.1}
+        else:
+            weights = {"LIE_LOW": 0.5, "LURK_NEAR_CHILD": 0.25, "STIR_MEETING": 0.2, "LURE_OUTSIDE": 0.05}
+        # 1/8 ticks we actually pick — otherwise let normal NPC tick run.
+        if rng.random() < 0.12:
+            action = rng.choices(
+                list(weights.keys()), weights=list(weights.values()), k=1
+            )[0]
+        else:
+            action = None
+
+    if action is not None:
+        _apply_imposter_action(world, npc, action)
+
+
+# ---------------------------------------------------------------------------
+# Meeting outcomes consumption
+# ---------------------------------------------------------------------------
+
+
+def _consume_meeting_outcomes(world: World) -> None:
+    """Process any new ``imposter_suspicion`` outcomes since the last tick."""
+    outcomes: List[MeetingOutcome] = world.meeting_outcomes
+    start = _SCHED.seen_outcome_count
+    # New ones are appended at the end.
+    for i in range(start, len(outcomes)):
+        mo = outcomes[i]
+        if mo.topic != "imposter_suspicion":
+            continue
+        _handle_suspicion(world, mo)
+    _SCHED.seen_outcome_count = len(outcomes)
+
+
+def _handle_suspicion(world: World, mo: MeetingOutcome) -> None:
+    ya = world.yellow_active
+    accused = mo.payload.get("accused_npc_id")
+    guilty = bool(mo.payload.get("guilty"))
+
+    if not guilty:
+        # Just a log line — they couldn't agree, life goes on.
+        world.emit(
+            Event(
+                tick=world.tick_count,
+                type="imposter_vote",
+                subject=accused or "unknown",
+                detail="not guilty",
+                severity="info",
+            )
+        )
+        return
+
+    # Guilty + accusation matches our disguise -> banished.
+    if accused is not None and ya.mode == YellowMode.IMPOSTER and accused == ya.disguised_as:
+        # Bump sanity on every character (+5 scaled to a 0..1 sanity is huge,
+        # so we treat the "5" as a percent boost = +0.05).
+        for a in world.agents.values():
+            if getattr(a, "kind", None) == AgentKind.CHARACTER:
+                cur = getattr(a, "sanity", None)
+                if cur is not None:
+                    try:
+                        a.sanity = min(1.0, float(cur) + 0.05)
+                    except Exception:
+                        pass
+        # Kill the now-exposed impostor NPC.
+        npc = world.agents.get(accused)
+        if npc is not None:
+            try:
+                npc.status = Status.DEAD
+            except Exception:
+                pass
+        world.emit(
+            Event(
+                tick=world.tick_count,
+                type="imposter_banished",
+                subject=accused,
+                detail="The village named him true and he could not stay",
+                severity="info",
+            )
+        )
+        _end_appearance(world, "banished")
+        return
+
+    # Guilty but they got the wrong person -> kill the innocent + fear spike.
+    if accused is not None and accused in world.agents:
+        innocent = world.agents[accused]
+        try:
+            innocent.status = Status.DEAD
+        except Exception:
+            pass
+        for a in world.agents.values():
+            if getattr(a, "kind", None) == AgentKind.CHARACTER:
+                cur = getattr(a, "fear", None)
+                if cur is not None:
+                    try:
+                        a.fear = min(1.0, float(cur) + 0.15)
+                    except Exception:
+                        pass
+    world.emit(
+        Event(
+            tick=world.tick_count,
+            type="imposter_vote",
+            subject=accused or "unknown",
+            detail="wrong accusation — the real one walks on",
+            severity="warn",
+        )
+    )
+    # Yellow Man stays; deadline keeps ticking.
+
+
+# ---------------------------------------------------------------------------
+# Wipe handling
+# ---------------------------------------------------------------------------
+
+
+def _trigger_wipe(world: World) -> None:
+    world.emit(
+        Event(
+            tick=world.tick_count,
+            type="village_wipe",
+            subject="world",
+            detail=f"Deadline reached — cycle {world.cycle_number} ends",
+            severity="crit",
+        )
+    )
+    world.pending_reset = True
+    # Agent A's reset_world() will increment village_wipes for the next cycle,
+    # but the counter metric should reflect the wipe NOW so dashboards line up.
+    if world.telemetry is not None:
+        world.telemetry.counter_inc(Metric.VILLAGE_WIPES_TOTAL, 1.0)
+    # Strip the march marker if any, so the reset doesn't carry it forward.
+    world.supernaturals[:] = [
+        s for s in world.supernaturals
+        if getattr(s, "id", None) != "yellow_man_march"
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+def tick_yellow(world: World) -> None:
+    """Engine hook — call once per tick, AFTER agents have ticked."""
+    ya = world.yellow_active
+
+    # Always: dormant-time taint + scheduling.
+    if ya.mode == YellowMode.DORMANT:
+        _maybe_taint_npcs(world)
+        # Lazily initialise the schedule the very first time we run.
+        if _SCHED.next_appearance_tick == 0:
+            _schedule_next_appearance(world)
+        elif world.tick_count >= _SCHED.next_appearance_tick:
+            _start_appearance(world)
+    else:
+        # Active modes consume any votes BEFORE checking the deadline so
+        # a banishment on the deadline tick still saves the village.
+        _consume_meeting_outcomes(world)
+
+        # If a vote ended the appearance, ya.mode is now DORMANT and we drop out.
+        if ya.mode == YellowMode.VISIBLE_MARCH:
+            _tick_visible_march(world)
+        elif ya.mode == YellowMode.IMPOSTER:
+            _tick_imposter(world)
+
+        # Deadline check.
+        if ya.mode != YellowMode.DORMANT and world.tick_count >= ya.deadline_tick:
+            _trigger_wipe(world)
+            # Don't call _end_appearance — let A's reset_world wipe state.
+
+    # Gauge update every tick.
+    if world.telemetry is not None:
+        world.telemetry.gauge_set(
+            Metric.YELLOW_ACTIVE,
+            0.0 if ya.mode == YellowMode.DORMANT else 1.0,
+            {"mode": ya.mode.value},
+        )
+
+
+def reset_yellow_scheduling(world: World) -> None:
+    """Called by ``population.clear_npcs`` / reset hook to wipe local schedule
+    state so a fresh cycle starts cleanly. Safe to call standalone."""
+    _SCHED.next_appearance_tick = 0
+    _SCHED.last_taint_day = -1
+    _SCHED.seen_outcome_count = 0

--- a/from-simulation/app/agents/yellow_man.py
+++ b/from-simulation/app/agents/yellow_man.py
@@ -42,6 +42,7 @@ from contracts import (
     Agent,
     AgentKind,
     Event,
+    FOREST_SPAWN_POINTS,
     MarkerClass,
     MeetingOutcome,
     Metric,
@@ -77,6 +78,38 @@ class _YellowMarchMarker:
         self.id = "yellow_man_march"
         self.x = float(x)
         self.y = float(y)
+
+    def tick(self, world: World) -> None:  # pragma: no cover - stepped externally
+        pass
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "id": self.id,
+            "kind": self.kind.value,
+            "marker_class": self.marker_class.value,
+            "x": round(self.x, 2),
+            "y": round(self.y, 2),
+        }
+
+
+class _YellowLurkMarker:
+    """v8 — Yellow Man visible in the forest at night when DORMANT.
+
+    He drifts between forest spawn points so the viewer sees him watching
+    even when he isn't actively marching or playing a tendril. The marker
+    is the same ``man-in-yellow`` class as the march so the frontend
+    sprite work is unchanged.
+    """
+
+    kind = AgentKind.SUPERNATURAL
+    marker_class = MarkerClass.MAN_IN_YELLOW
+
+    def __init__(self, x: float, y: float) -> None:
+        self.id = "yellow_man_lurk"
+        self.x = float(x)
+        self.y = float(y)
+        self.target_x = float(x)
+        self.target_y = float(y)
 
     def tick(self, world: World) -> None:  # pragma: no cover - stepped externally
         pass
@@ -149,6 +182,79 @@ def _distance(ax: float, ay: float, bx: float, by: float) -> float:
 
 
 # ---------------------------------------------------------------------------
+# v9 — weighted tendril selection
+# ---------------------------------------------------------------------------
+
+
+_LOAD_BEARING_ROLES = ("SHERIFF", "CARETAKER", "PRIEST", "LEADER_COLONY")
+
+
+def _tendril_weight(world: World, npc: Any) -> float:
+    """How "good" a tendril this NPC would be. Returns a positive float.
+
+    Two signals — both deterministic, read off existing world state:
+      * ``closing_in``: sum of any character's existing awareness suspicion
+        of THIS npc. The closer the village is to discovering them, the
+        juicier the wear (sense of dread: "they almost knew").
+      * ``social_load``: high-trust relationships between this NPC and a
+        load-bearing role (sheriff / caretaker / priest / leader).
+    """
+    w = 1.0
+    closing_in = 0.0
+    social_load = 0.0
+    trust = getattr(world, "trust", {}) or {}
+    for c in world.agents.values():
+        if getattr(c, "kind", None) != AgentKind.CHARACTER:
+            continue
+        aware = getattr(c, "awareness", None) or {}
+        if isinstance(aware, dict):
+            try:
+                closing_in += float(aware.get(npc.id, 0.0))
+            except (TypeError, ValueError):
+                pass
+        role = getattr(c, "role", None)
+        rname = getattr(role, "value", str(role) if role else "")
+        if rname in _LOAD_BEARING_ROLES:
+            t = trust.get((c.id, npc.id), trust.get((npc.id, c.id), None))
+            if t is not None:
+                try:
+                    social_load += max(0.0, float(t) - 0.5)
+                except (TypeError, ValueError):
+                    pass
+    w *= 1.0 + min(2.0, closing_in / 3.0)
+    w *= 1.0 + min(1.0, social_load)
+    return w
+
+
+def _weighted_sample(rng: Any, items: List[Any], weights: List[float], k: int) -> List[Any]:
+    """Sample ``k`` distinct items without replacement, weighted by ``weights``.
+
+    Falls back to uniform if all weights are zero.
+    """
+    if not items:
+        return []
+    k = max(1, min(int(k), len(items)))
+    pool = list(zip(items, weights))
+    chosen: List[Any] = []
+    for _ in range(k):
+        total = sum(w for _, w in pool)
+        if total <= 0.0:
+            # Degenerate weights — uniform fallback for the rest.
+            picks = rng.sample([it for it, _ in pool], k - len(chosen))
+            chosen.extend(picks)
+            return chosen
+        r = rng.random() * total
+        acc = 0.0
+        for i, (it, w) in enumerate(pool):
+            acc += w
+            if r <= acc:
+                chosen.append(it)
+                pool.pop(i)
+                break
+    return chosen
+
+
+# ---------------------------------------------------------------------------
 # Appearance starters
 # ---------------------------------------------------------------------------
 
@@ -165,8 +271,14 @@ def _start_appearance(world: World) -> None:
     rng = world.rng
     ya = world.yellow_active
 
+    # v9 — Director can nudge imposter probability when pressure is low
+    # (escalate) or high (de-escalate).
+    director = getattr(world, "director", None)
+    bias = float(getattr(director, "yellow_appearance_bias", 0.0))
+    imposter_prob = max(0.0, min(1.0, cfg.yellow_imposter_prob + bias))
+
     # Pick mode.
-    if rng.random() < cfg.yellow_imposter_prob:
+    if rng.random() < imposter_prob:
         npcs = [
             a for a in world.agents.values()
             if getattr(a, "kind", None) == AgentKind.NPC
@@ -183,9 +295,26 @@ def _start_appearance(world: World) -> None:
         n_hydra = rng.randint(hydra_min, hydra_max)
         n_hydra = max(1, min(n_hydra, len(npcs)))
 
-        chosen = rng.sample(npcs, n_hydra)
+        # v9 — weighted tendril selection. Characters whose awareness of a
+        # given NPC is already high (they're "closing in" on a suspicion)
+        # make that NPC a juicier wear; tendrils trust-adjacent to high-role
+        # characters (sheriff / caretaker / priest) get a smaller boost so
+        # the imposter ends up next to load-bearing relationships.
+        weights = [_tendril_weight(world, n) for n in npcs]
+        chosen = _weighted_sample(rng, npcs, weights, n_hydra)
         tendril_ids = [n.id for n in chosen]
         leader_id = tendril_ids[0]
+        # Emit one telemetry counter labelled by chosen leader's "role" so a
+        # dashboard can show which kind of NPC the Yellow Man tends to wear.
+        if world.telemetry is not None:
+            try:
+                world.telemetry.counter_inc(
+                    Metric.YELLOW_TARGET_ROLE,
+                    1.0,
+                    {"role": "imposter"},
+                )
+            except Exception:
+                pass
 
         ya.mode = YellowMode.IMPOSTER
         ya.disguised_as = leader_id
@@ -421,10 +550,43 @@ def _apply_imposter_action(world: World, npc: NPC, action: str) -> None:
         if world.time.phase == Phase.NIGHT:
             talismans = [b for b in world.buildings.values() if b.has_talisman and b.locked]
             if talismans:
-                b = rng.choice(talismans)
+                # v9 — weighted by (a) presence of a load-bearing-role occupant
+                # and (b) the Director's target_bias for cross-cycle weakness.
+                director = getattr(world, "director", None)
+                tb = getattr(director, "target_bias", {}) or {}
+                def _bldg_weight(b) -> float:
+                    w = 1.0
+                    occupants = getattr(b, "occupants", set()) or set()
+                    for occ_id in occupants:
+                        a = world.agents.get(occ_id)
+                        if a is None:
+                            continue
+                        rname = getattr(getattr(a, "role", None), "value", "")
+                        if rname in _LOAD_BEARING_ROLES:
+                            w += 1.5
+                    w += 2.0 * float(tb.get(b.id, 0.0))
+                    return w
+                weights = [_bldg_weight(b) for b in talismans]
+                b = _weighted_sample(rng, talismans, weights, 1)[0]
                 b.locked = False
                 npc.target_x = b.x + rng.uniform(-15, 15)
                 npc.target_y = b.y + rng.uniform(25, 45)
+                # Telemetry: record the role label of the most "load-bearing"
+                # occupant so a dashboard can show who tends to get isolated.
+                role_label = "unknown"
+                for occ_id in getattr(b, "occupants", set()) or set():
+                    a = world.agents.get(occ_id)
+                    rname = getattr(getattr(a, "role", None), "value", "")
+                    if rname in _LOAD_BEARING_ROLES:
+                        role_label = rname
+                        break
+                if world.telemetry is not None:
+                    try:
+                        world.telemetry.counter_inc(
+                            Metric.YELLOW_TARGET_ROLE, 1.0, {"role": role_label}
+                        )
+                    except Exception:
+                        pass
                 world.emit(
                     Event(
                         tick=world.tick_count,
@@ -456,24 +618,40 @@ def _apply_imposter_action(world: World, npc: NPC, action: str) -> None:
 
 
 def _consult_llm(world: World, npc: NPC) -> Optional[str]:
-    """If an LLM decider is wired, ask it which action to take."""
+    """If an LLM decider is wired, ask it which imposter action to take.
+
+    v9 — previously called ``maybe_decide`` with a kwargs shape that didn't
+    match the decider's signature, so the call always raised and got
+    swallowed by the surrounding try/except. We now use the dedicated
+    string-picker which lives on its own thinking-budget bucket.
+    """
     decider = getattr(world, "llm_decider", None)
     if decider is None:
         return None
-    rate = world.config.llm_yellow_rate
+    # Coarse rate gate kept for behavioural parity with the v8 path.
+    if world.rng.random() >= world.config.llm_yellow_rate:
+        return None
+    system = (
+        "You play the Man in Yellow — a smiling, polite imposter wearing an "
+        "NPC's face in the small town of From. Pick ONE action that escalates "
+        "dread without revealing the disguise. Reason briefly (<=120 chars)."
+    )
+    prompt = (
+        f"Disguised as: {npc.id}\n"
+        f"Phase: {world.time.phase.value}\n"
+        f"Tick: {world.tick_count}\n"
+        f"Children visible: {len(_children(world))}\n"
+        f"Tendrils alive: {len(_live_tendrils(world))}\n"
+        f"Pressure: {round(float(getattr(getattr(world, 'director', None), 'pressure', 0.0)), 2)}\n"
+        f"Menu: {', '.join(_IMPOSTER_ACTIONS)}"
+    )
     try:
-        # The decider interface (defined by Agent A's llm package) returns
-        # either a chosen option string or None when rate-limited / disabled.
-        return decider.maybe_decide(
-            actor=f"yellow_man:{npc.id}",
-            rate=rate,
+        return decider.maybe_pick_string(
+            actor_id=f"yellow_man:{npc.id}",
             options=list(_IMPOSTER_ACTIONS),
-            context={
-                "tick": world.tick_count,
-                "phase": world.time.phase.value,
-                "disguised_as": npc.id,
-                "n_children_visible": len(_children(world)),
-            },
+            current_tick=int(world.tick_count),
+            system=system,
+            prompt=prompt,
         )
     except Exception:
         return None
@@ -685,16 +863,100 @@ def _trigger_wipe(world: World) -> None:
 
 
 def _maybe_force_box_drop(world: World) -> None:
-    """v4: tiny NIGHT-only chance to gift the village a Music Box.
+    """v4/v7: tiny NIGHT-only chance to gift the village a Music Box.
 
-    Active in DORMANT and IMPOSTER modes. The 0.5% per-tick roll gives roughly
-    one drop per sim-day at NIGHT. No-op if a box already exists.
+    Active in DORMANT and IMPOSTER modes. v7: lowered from 0.5% to 0.0006%
+    per-tick — at 360 NIGHT ticks/sim-day that's ~20% per night, so a force
+    drop lands roughly every 5 sim-nights when not gated by cooldown. Also
+    respects the global music_box_interval_days cooldown so we never spam
+    boxes on top of each other.
     """
     if world.time.phase != Phase.NIGHT:
         return
-    if world.rng.random() >= 0.005:
+    if world.rng.random() >= 0.0006:
+        return
+    # Honour the module-level cooldown so Yellow Man can't shortcut the
+    # full music_box_interval_days gate every single night.
+    last = _music_box._LAST_SPAWN_TICK  # type: ignore[attr-defined]
+    interval = max(1, world.config.music_box_interval_days) * 720
+    if world.tick_count < last + (interval // 2):
         return
     _music_box.force_drop(world, None)
+
+
+def _tick_dormant_lurk(world: World) -> None:
+    """v8 — Yellow Man lurks visibly in the forest at night while DORMANT.
+
+    DUSK / NIGHT: ensure a single _YellowLurkMarker exists at a forest spawn
+    point and let it drift slowly between points so the viewer sees him
+    watching the village from the treeline.
+
+    DAY / DAWN, or any non-DORMANT mode: remove the lurk marker so the
+    forest empties at first light (and so the active-mode marchers don't
+    collide with a dormant ghost).
+    """
+    ya = world.yellow_active
+    phase = world.time.phase
+    should_lurk = (
+        ya.mode == YellowMode.DORMANT
+        and phase in (Phase.NIGHT, Phase.DUSK)
+    )
+
+    # Find any existing lurk marker.
+    existing = next(
+        (s for s in world.supernaturals
+         if getattr(s, "id", "") == "yellow_man_lurk"),
+        None,
+    )
+
+    if not should_lurk:
+        if existing is not None:
+            world.supernaturals[:] = [
+                s for s in world.supernaturals
+                if getattr(s, "id", "") != "yellow_man_lurk"
+            ]
+        return
+
+    if existing is None:
+        # Choose a forest point that isn't too close to the lighthouse —
+        # the user's complaint was creatures at the lighthouse; the Yellow
+        # Man has the same "wrong location" risk if he spawns right on top
+        # of it. Filter to forest points whose x is right of the village
+        # so he reads as "in the woods" not "at the lighthouse clearing".
+        candidates = [pt for pt in FOREST_SPAWN_POINTS if pt[0] > 280.0]
+        if not candidates:
+            candidates = list(FOREST_SPAWN_POINTS)
+        sx, sy = world.rng.choice(candidates)
+        world.supernaturals.append(_YellowLurkMarker(sx, sy))
+        world.emit(Event(
+            tick=world.tick_count,
+            type="yellow_appearance",
+            subject="yellow_man_lurk",
+            detail=f"the Yellow Man watches from the trees at ({sx:.0f},{sy:.0f})",
+            severity="warn",
+        ))
+        return
+
+    # Drift the existing lurker toward its target; occasionally re-pick a
+    # new target so he moves around the treeline. Speed kept low so he
+    # reads as "watching" rather than "approaching".
+    LURK_SPEED = 0.6
+    LURK_RETARGET_TICKS = 120
+    last_pick = int(getattr(existing, "_last_retarget_tick", -10_000))
+    if world.tick_count - last_pick > LURK_RETARGET_TICKS:
+        candidates = [pt for pt in FOREST_SPAWN_POINTS if pt[0] > 280.0]
+        if not candidates:
+            candidates = list(FOREST_SPAWN_POINTS)
+        tx, ty = world.rng.choice(candidates)
+        existing.target_x = float(tx)
+        existing.target_y = float(ty)
+        existing._last_retarget_tick = world.tick_count
+    dx = existing.target_x - existing.x
+    dy = existing.target_y - existing.y
+    dist = math.hypot(dx, dy)
+    if dist > LURK_SPEED:
+        existing.x += LURK_SPEED * (dx / dist)
+        existing.y += LURK_SPEED * (dy / dist)
 
 
 def tick_yellow(world: World) -> None:
@@ -705,12 +967,19 @@ def tick_yellow(world: World) -> None:
     if ya.mode == YellowMode.DORMANT:
         _maybe_taint_npcs(world)
         _maybe_force_box_drop(world)
+        _tick_dormant_lurk(world)
         # Lazily initialise the schedule the very first time we run.
         if _SCHED.next_appearance_tick == 0:
             _schedule_next_appearance(world)
         elif world.tick_count >= _SCHED.next_appearance_tick:
             _start_appearance(world)
     else:
+        # Active mode — the lurk marker must not coexist with the march /
+        # imposter rendering. _tick_dormant_lurk handles its own removal
+        # when called outside the lurk window, but mode-change is an edge
+        # case (it can flip on a DAY tick when the schedule fires) so do
+        # an explicit cleanup here too.
+        _tick_dormant_lurk(world)
         # Active modes consume any votes BEFORE checking the deadline so
         # a banishment on the deadline tick still saves the village.
         _consume_meeting_outcomes(world)

--- a/from-simulation/app/agents/yellow_man.py
+++ b/from-simulation/app/agents/yellow_man.py
@@ -53,6 +53,7 @@ from contracts import (
     YELLOW_MARCH_PATH,
 )
 from agents.npcs import NPC
+from agents import music_box as _music_box
 
 
 # ---------------------------------------------------------------------------
@@ -343,7 +344,7 @@ def _tick_visible_march(world: World) -> None:
 
 
 # Imposter action menu — also used as the LLM decision menu.
-_IMPOSTER_ACTIONS = ("LURK_NEAR_CHILD", "STIR_MEETING", "LIE_LOW", "LURE_OUTSIDE")
+_IMPOSTER_ACTIONS = ("LURK_NEAR_CHILD", "STIR_MEETING", "LIE_LOW", "LURE_OUTSIDE", "DROP_BOX")
 
 
 def _find_disguise(world: World) -> Optional[NPC]:
@@ -433,6 +434,25 @@ def _apply_imposter_action(world: World, npc: NPC, action: str) -> None:
                         severity="warn",
                     )
                 )
+    elif action == "DROP_BOX":
+        # v4: force-spawn the Music Box just outside the npc's current pos.
+        # No-op if a box already exists. Drop it slightly away so the imposter
+        # isn't the obvious candidate to grab it.
+        drop_xy = (
+            npc.x + rng.uniform(-30.0, 30.0),
+            npc.y + rng.uniform(-30.0, 30.0),
+        )
+        box = _music_box.force_drop(world, drop_xy)
+        if box is not None:
+            world.emit(
+                Event(
+                    tick=world.tick_count,
+                    type="yellow_imposter_acted",
+                    subject=npc.id,
+                    detail=f"left a music box at ({round(drop_xy[0],1)}, {round(drop_xy[1],1)})",
+                    severity="warn",
+                )
+            )
 
 
 def _consult_llm(world: World, npc: NPC) -> Optional[str]:
@@ -664,6 +684,19 @@ def _trigger_wipe(world: World) -> None:
 # ---------------------------------------------------------------------------
 
 
+def _maybe_force_box_drop(world: World) -> None:
+    """v4: tiny NIGHT-only chance to gift the village a Music Box.
+
+    Active in DORMANT and IMPOSTER modes. The 0.5% per-tick roll gives roughly
+    one drop per sim-day at NIGHT. No-op if a box already exists.
+    """
+    if world.time.phase != Phase.NIGHT:
+        return
+    if world.rng.random() >= 0.005:
+        return
+    _music_box.force_drop(world, None)
+
+
 def tick_yellow(world: World) -> None:
     """Engine hook — call once per tick, AFTER agents have ticked."""
     ya = world.yellow_active
@@ -671,6 +704,7 @@ def tick_yellow(world: World) -> None:
     # Always: dormant-time taint + scheduling.
     if ya.mode == YellowMode.DORMANT:
         _maybe_taint_npcs(world)
+        _maybe_force_box_drop(world)
         # Lazily initialise the schedule the very first time we run.
         if _SCHED.next_appearance_tick == 0:
             _schedule_next_appearance(world)
@@ -686,6 +720,8 @@ def tick_yellow(world: World) -> None:
             _tick_visible_march(world)
         elif ya.mode == YellowMode.IMPOSTER:
             _tick_imposter(world)
+            # v4: in IMPOSTER mode the Yellow Man can also nudge a box drop.
+            _maybe_force_box_drop(world)
 
         # Deadline check.
         if ya.mode != YellowMode.DORMANT and world.tick_count >= ya.deadline_tick:

--- a/from-simulation/app/app.py
+++ b/from-simulation/app/app.py
@@ -74,6 +74,22 @@ def _build_app() -> tuple[Flask, SocketIO, Any, Any, SimTelemetry]:
     # it via ``world.llm_decider``.
     world.llm_decider = LLMDecider(config, telemetry)
     world.llm_decider.attach_world(world)
+
+    # v5 — SQLite-backed Memory. Optional: if the DB can't be opened (e.g. the
+    # /data volume is read-only) we log and run the simulation without
+    # persistence, identical to the v4 behaviour. Hydration MUST happen before
+    # ``build_characters`` so any restored personality drift applies on rebuild.
+    from storage import Memory  # local import — avoids hard fail if the file
+                                # is missing from a stripped-down image
+    try:
+        world.memory = Memory.open(config.db_path)
+        world.memory.hydrate(world)
+    except Exception:
+        telemetry.get_logger().exception(
+            "memory init failed; continuing without persistence"
+        )
+        world.memory = None
+
     # Populate the named cast before the simulation starts ticking so the
     # first snapshot the browser receives already shows the village.
     build_characters(world)
@@ -151,6 +167,13 @@ def _build_app() -> tuple[Flask, SocketIO, Any, Any, SimTelemetry]:
                 simulation.stop()
         except Exception:
             log.exception("simulation stop failed")
+        # v5 — drain memory buffers and close the SQLite handle before the
+        # process exits so the last few ticks aren't lost.
+        try:
+            if getattr(world, "memory", None) is not None:
+                world.memory.close()
+        except Exception:
+            log.exception("memory close failed")
         try:
             telemetry.shutdown()
         except Exception:

--- a/from-simulation/app/app.py
+++ b/from-simulation/app/app.py
@@ -1,0 +1,240 @@
+"""
+Flask + Flask-SocketIO entrypoint for the From simulation UI.
+
+Responsibilities (Agent D scope):
+  * Boot the Config / SimTelemetry / world / simulation in the correct order.
+  * Expose HTTP routes for the SPA shell (``/``), health probes (``/health``),
+    and a JSON snapshot dump (``/api/snapshot``) for curl-style debugging.
+  * Bridge the simulation's broadcast callback to Socket.IO so every connected
+    client receives a ``tick`` payload each engine step.
+  * Handle ``inspect`` requests from the browser and reply with the full agent
+    record so the right-hand inspector panel can render rich detail.
+  * Forward ``cycle_reset`` to the client so the wipe overlay can play.
+
+The simulation owns the timing thread; this module is intentionally thin.
+"""
+
+from __future__ import annotations
+
+import atexit
+import logging
+import os
+from typing import Any, Dict, Optional
+
+from flask import Flask, jsonify, render_template
+from flask_socketio import SocketIO
+
+from contracts import Config, SocketEvent, snapshot_dict
+from telemetry import SimTelemetry
+from world import build_world
+from agents.characters import build_characters
+from llm.decider import LLMDecider
+
+
+# ---------------------------------------------------------------------------
+# Bootstrap
+# ---------------------------------------------------------------------------
+
+
+def _build_app() -> tuple[Flask, SocketIO, Any, Any, SimTelemetry]:
+    """Wire Flask, SocketIO, telemetry, world, and simulation together.
+
+    Returned tuple lets the module-level globals stay readable while keeping
+    construction itself testable.
+    """
+    config = Config.from_env(os.environ.get)
+
+    flask_app = Flask(
+        __name__,
+        static_folder="static",
+        template_folder="templates",
+    )
+    flask_app.config["SECRET_KEY"] = os.environ.get(
+        "SECRET_KEY", "from_simulation_secret_key"
+    )
+
+    # eventlet is in requirements.txt; using it as the async_mode lets the
+    # background simulation thread share the GIL fairly with the web server.
+    socketio = SocketIO(
+        flask_app,
+        cors_allowed_origins="*",
+        async_mode="eventlet",
+        logger=False,
+        engineio_logger=False,
+    )
+
+    telemetry = SimTelemetry(config)
+    log = telemetry.get_logger()
+    log.info("from-sim boot: telemetry ready")
+
+    world = build_world(config)
+    world.telemetry = telemetry
+    # Optional LLM driver: no-op when ANTHROPIC_API_KEY is unset, so this is
+    # always safe to construct. Both characters (B) and Yellow Man (C) read
+    # it via ``world.llm_decider``.
+    world.llm_decider = LLMDecider(config, telemetry)
+    world.llm_decider.attach_world(world)
+    # Populate the named cast before the simulation starts ticking so the
+    # first snapshot the browser receives already shows the village.
+    build_characters(world)
+
+    from simulation import Simulation  # type: ignore
+
+    simulation = Simulation(world)
+
+    def _emit_tick(payload: Dict[str, Any]) -> None:
+        try:
+            socketio.emit(SocketEvent.TICK, payload)
+        except Exception:  # never let a broken socket kill the sim
+            log.exception("tick emit failed")
+
+    def _emit_cycle_reset(payload: Dict[str, Any]) -> None:
+        try:
+            socketio.emit(SocketEvent.CYCLE_RESET, payload)
+        except Exception:
+            log.exception("cycle_reset emit failed")
+
+    # The simulation exposes a setter for the broadcast hook. We hand it two
+    # closures so it can fire tick + wipe events without importing Flask itself.
+    if hasattr(simulation, "set_emitter"):
+        simulation.set_emitter(_emit_tick)
+    if hasattr(simulation, "set_cycle_reset_emitter"):
+        simulation.set_cycle_reset_emitter(_emit_cycle_reset)
+    else:
+        # Fall back: stash the callable on the simulation under a known name so
+        # the engine can call it without a formal API if it didn't ship one.
+        setattr(simulation, "_cycle_reset_emitter", _emit_cycle_reset)
+
+    # ---------------------------------------------------------------- routes
+    @flask_app.route("/")
+    def index():
+        # Whether the optional Anthropic narration is wired is decided at boot;
+        # the template uses it to keep the narration panel hidden when off.
+        llm_enabled = bool(config.anthropic_api_key)
+        return render_template("index.html", llm_enabled=llm_enabled)
+
+    @flask_app.route("/health")
+    def health():
+        return jsonify({"ok": True, "tick": world.tick_count})
+
+    @flask_app.route("/api/snapshot")
+    def api_snapshot():
+        return jsonify(snapshot_dict(world))
+
+    # --------------------------------------------------------- socket events
+    @socketio.on("connect")
+    def on_connect():
+        # Push the current snapshot immediately so the client doesn't show an
+        # empty map for up to one tick after connecting.
+        try:
+            socketio.emit(SocketEvent.TICK, snapshot_dict(world))
+        except Exception:
+            log.exception("initial snapshot emit failed")
+
+    @socketio.on(SocketEvent.INSPECT)
+    def on_inspect(data: Optional[Dict[str, Any]]):
+        target_id = (data or {}).get("id")
+        if not target_id:
+            socketio.emit(
+                SocketEvent.INSPECT_REPLY,
+                {"id": None, "error": "missing id"},
+            )
+            return
+
+        record = _resolve_agent(world, target_id)
+        socketio.emit(SocketEvent.INSPECT_REPLY, record)
+
+    # ---------------------------------------------------------- shutdown
+    def _shutdown() -> None:
+        try:
+            if hasattr(simulation, "stop"):
+                simulation.stop()
+        except Exception:
+            log.exception("simulation stop failed")
+        try:
+            telemetry.shutdown()
+        except Exception:
+            log.exception("telemetry shutdown failed")
+
+    atexit.register(_shutdown)
+
+    # Kick off the simulation thread; the engine is responsible for cadence.
+    if hasattr(simulation, "start"):
+        simulation.start()
+
+    return flask_app, socketio, world, simulation, telemetry
+
+
+def _resolve_agent(world: Any, target_id: str) -> Dict[str, Any]:
+    """Look up an agent across all four pools and return a rich detail dict.
+
+    Order matters: characters/NPCs live in ``world.agents``; transient
+    supernaturals and creatures live in their own lists. We fall through them
+    so the inspector works for every dot on the map.
+    """
+    candidate = world.agents.get(target_id) if hasattr(world, "agents") else None
+
+    if candidate is None:
+        for pool_name in ("creatures", "supernaturals"):
+            pool = getattr(world, pool_name, []) or []
+            for item in pool:
+                if getattr(item, "id", None) == target_id:
+                    candidate = item
+                    break
+            if candidate is not None:
+                break
+
+    if candidate is None:
+        return {"id": target_id, "error": "not found"}
+
+    # Start from the agent's own to_dict() so subclass overrides flow through.
+    try:
+        base = candidate.to_dict()
+    except Exception:
+        base = {"id": target_id}
+
+    # Augment with optional rich fields. These attributes are conventional —
+    # not every agent has them, hence the getattr guards.
+    for attr in (
+        "name",
+        "personality",
+        "role",
+        "status",
+        "state",
+        "fear",
+        "sanity",
+        "trust",
+        "hunger",
+        "faction",
+        "home_id",
+        "target_id",
+        "last_event",
+        "is_returner",
+        "memory",
+    ):
+        value = getattr(candidate, attr, None)
+        if value is None:
+            continue
+        # Stringify enums for the wire.
+        if hasattr(value, "value"):
+            value = value.value
+        base[attr] = value
+
+    return base
+
+
+# ---------------------------------------------------------------------------
+# Module-level singletons (importable by tests / `flask run`)
+# ---------------------------------------------------------------------------
+
+
+app, socketio, _world, _simulation, _telemetry = _build_app()
+
+
+if __name__ == "__main__":
+    # ``host=0.0.0.0`` is needed for the container port mapping; eventlet
+    # handles the websocket upgrade.
+    host = os.environ.get("HOST", "0.0.0.0")
+    port = int(os.environ.get("PORT", "8080"))
+    logging.getLogger(__name__).info("from-sim listening on %s:%d", host, port)
+    socketio.run(app, host=host, port=port, allow_unsafe_werkzeug=True)

--- a/from-simulation/app/app.py
+++ b/from-simulation/app/app.py
@@ -53,12 +53,13 @@ def _build_app() -> tuple[Flask, SocketIO, Any, Any, SimTelemetry]:
         "SECRET_KEY", "from_simulation_secret_key"
     )
 
-    # eventlet is in requirements.txt; using it as the async_mode lets the
-    # background simulation thread share the GIL fairly with the web server.
+    # Threading async_mode keeps cross-thread emits simple: the simulation
+    # tick thread is a plain ``threading.Thread`` and calls ``socketio.emit``
+    # directly. Eventlet without monkey_patch silently drops those emits.
     socketio = SocketIO(
         flask_app,
         cors_allowed_origins="*",
-        async_mode="eventlet",
+        async_mode="threading",
         logger=False,
         engineio_logger=False,
     )
@@ -93,6 +94,14 @@ def _build_app() -> tuple[Flask, SocketIO, Any, Any, SimTelemetry]:
     # Populate the named cast before the simulation starts ticking so the
     # first snapshot the browser receives already shows the village.
     build_characters(world)
+
+    # v9 — lift any persisted minds (open goals + recent beliefs) back onto
+    # the freshly-built Character instances. Safe no-op when memory is off.
+    if world.memory is not None:
+        try:
+            world.memory.hydrate_minds(world)
+        except Exception:
+            telemetry.get_logger().exception("hydrate_minds failed; continuing")
 
     from simulation import Simulation  # type: ignore
 
@@ -136,6 +145,55 @@ def _build_app() -> tuple[Flask, SocketIO, Any, Any, SimTelemetry]:
     @flask_app.route("/api/snapshot")
     def api_snapshot():
         return jsonify(snapshot_dict(world))
+
+    @flask_app.route("/api/debug/force_music_box", methods=["POST", "GET"])
+    def api_debug_force_music_box():
+        """Drop a music box at a random spawn point right now (for verification)."""
+        try:
+            from agents import music_box as _mb
+            _mb.force_drop(world, None)
+            return jsonify({"ok": True, "music_box_id": world.music_box_id})
+        except Exception as exc:  # pragma: no cover — debug only
+            return jsonify({"ok": False, "error": str(exc)}), 500
+
+    @flask_app.route("/api/debug/force_yellow", methods=["POST", "GET"])
+    def api_debug_force_yellow():
+        """Skip Yellow Man's scheduling to fire immediately on the next tick."""
+        try:
+            from agents.yellow_man import _SCHED
+            _SCHED.next_appearance_tick = world.tick_count
+            return jsonify({"ok": True})
+        except Exception as exc:  # pragma: no cover
+            return jsonify({"ok": False, "error": str(exc)}), 500
+
+    @flask_app.route("/api/debug/break_barn", methods=["POST", "GET"])
+    def api_debug_break_barn():
+        """Manually trigger the barn-destroyed cascade (for verification)."""
+        try:
+            from agents.creatures import _destroy_barn
+            class _Fake:
+                id = "debug"
+            _destroy_barn(world, _Fake())
+            return jsonify({"ok": True, "until_tick": world.barn_destroyed_until_tick})
+        except Exception as exc:
+            return jsonify({"ok": False, "error": str(exc)}), 500
+
+    @flask_app.route("/api/debug/skip_to", methods=["POST", "GET"])
+    def api_debug_skip_to():
+        """Advance ``world.time`` to a given hour for spot-checks.
+
+        Useful for verifying DUSK / NIGHT visuals and creature spawn flow
+        without sitting through a full 2-minute real-time cycle. Query/body
+        params: ``hour`` (0..23), ``minute`` (0..59, optional).
+        """
+        from flask import request
+        hour = int(request.values.get("hour", 20))
+        minute = int(request.values.get("minute", 0))
+        hour = max(0, min(23, hour))
+        minute = max(0, min(59, minute))
+        world.time.hour = hour
+        world.time.minute = minute
+        return jsonify({"ok": True, "time": {"hour": hour, "minute": minute}})
 
     # --------------------------------------------------------- socket events
     @socketio.on("connect")
@@ -188,12 +246,107 @@ def _build_app() -> tuple[Flask, SocketIO, Any, Any, SimTelemetry]:
     return flask_app, socketio, world, simulation, telemetry
 
 
+def _display_name(agent) -> str:
+    """Build a display name including surname for NPCs."""
+    base = getattr(agent, "name", None) or ""
+    surname = getattr(agent, "surname", None) or ""
+    if base and surname and surname not in base:
+        return f"{base} {surname}".strip()
+    return base or ""
+
+
+def _resolve_building(world: Any, building_id: str) -> Dict[str, Any]:
+    """v8 — return a dossier dict for a building so it can be inspected."""
+    b = world.buildings.get(building_id) if hasattr(world, "buildings") else None
+    if b is None:
+        return {"id": building_id, "error": "not found"}
+    occupants = []
+    for occ_id in sorted(b.occupants):
+        agent = world.agents.get(occ_id) if hasattr(world, "agents") else None
+        if agent is not None:
+            occupants.append({
+                "id": occ_id,
+                "name": _display_name(agent) or occ_id,
+                "role": getattr(getattr(agent, "role", None), "value", None)
+                    or getattr(agent, "role", None) or "",
+            })
+        else:
+            occupants.append({"id": occ_id, "name": occ_id, "role": ""})
+    # Also list NPCs whose home_id is this building but who aren't currently
+    # inside (away during the day) so the viewer can see who lives there.
+    residents = []
+    if hasattr(world, "agents"):
+        for a_id, a in world.agents.items():
+            if a_id in b.occupants:
+                continue
+            if getattr(a, "home_id", None) == building_id:
+                residents.append({
+                    "id": a_id,
+                    "name": _display_name(a) or a_id,
+                    "role": getattr(getattr(a, "role", None), "value", None)
+                        or getattr(a, "role", None) or "",
+                })
+    tick = getattr(world, "tick_count", 0)
+    capacity = b.capacity if hasattr(b, "capacity") else int(b.footprint)
+    # v8 — residents-based occupancy: how many NPCs call this building home,
+    # whether they're inside or out. So a 5-cap house with 4 residents
+    # reads "4 of 5" even when everyone is at work.
+    residents_total = len(occupants) + len(residents)
+    return {
+        "id": b.id,
+        "kind": "building",
+        "name": b.name,
+        "x": b.x,
+        "y": b.y,
+        "role": b.role_tag or "building",
+        "has_talisman": bool(b.has_talisman),
+        "destroyed": bool(getattr(b, "destroyed", False)),
+        "damage": int(getattr(b, "damage", 0)),
+        "rebuild_progress": float(getattr(b, "rebuild_progress", 0.0)),
+        "cooling_off_in_ticks": max(0, int(b.cooling_off_until_tick) - tick),
+        "occupants_inside": occupants,
+        "residents_away": residents,
+        "locked": bool(b.locked),
+        # v8 — capacity / vacancy so the dossier can show "4 of 5" and
+        # flag a full house. capacity == 0 means the structure isn't a
+        # residence (choosing stone, pool, lighthouse). "occupied" tracks
+        # the resident count (home_id assignments), not transient occupants.
+        "capacity": int(capacity),
+        "occupied": residents_total,
+        "full": capacity > 0 and residents_total >= capacity,
+    }
+
+
+def _resolve_car(world: Any, candidate) -> Dict[str, Any]:
+    """v8 — car dossier. Shows the driver/passenger and trip state."""
+    pid = getattr(candidate, "passenger_npc_id", None)
+    passenger = world.agents.get(pid) if pid and hasattr(world, "agents") else None
+    pass_name = _display_name(passenger) if passenger is not None else (pid or "—")
+    return {
+        "id": candidate.id,
+        "kind": "car",
+        "name": "Arrival Car",
+        "x": getattr(candidate, "x", 0.0),
+        "y": getattr(candidate, "y", 0.0),
+        "role": "car",
+        "substate": getattr(candidate, "substate", "—"),
+        "passenger": {
+            "id": pid or "",
+            "name": pass_name,
+        } if pid else None,
+        "outbound_done": int(getattr(candidate, "outbound_waypoints_done", 0)),
+    }
+
+
 def _resolve_agent(world: Any, target_id: str) -> Dict[str, Any]:
     """Look up an agent across all four pools and return a rich detail dict.
 
     Order matters: characters/NPCs live in ``world.agents``; transient
     supernaturals and creatures live in their own lists. We fall through them
     so the inspector works for every dot on the map.
+
+    v8 — also resolves ``world.buildings`` so the user can click houses on
+    the map and see who's assigned to them.
     """
     candidate = world.agents.get(target_id) if hasattr(world, "agents") else None
 
@@ -208,7 +361,15 @@ def _resolve_agent(world: Any, target_id: str) -> Dict[str, Any]:
                 break
 
     if candidate is None:
+        # Try buildings — return early with a building-shaped dossier dict.
+        if hasattr(world, "buildings") and target_id in world.buildings:
+            return _resolve_building(world, target_id)
         return {"id": target_id, "error": "not found"}
+
+    # v8 — Car gets a tailored dossier (no vitals etc.).
+    if str(getattr(candidate, "marker_class", "")).lower() in ("car", "markerclass.car") \
+            or getattr(getattr(candidate, "marker_class", None), "value", None) == "car":
+        return _resolve_car(world, candidate)
 
     # Start from the agent's own to_dict() so subclass overrides flow through.
     try:
@@ -217,9 +378,10 @@ def _resolve_agent(world: Any, target_id: str) -> Dict[str, Any]:
         base = {"id": target_id}
 
     # Augment with optional rich fields. These attributes are conventional —
-    # not every agent has them, hence the getattr guards.
+    # not every agent has them, hence the getattr guards. ``name`` is
+    # deliberately excluded — to_dict() already builds the display name
+    # (NPCs combine first + surname), and a blind getattr would clobber it.
     for attr in (
-        "name",
         "personality",
         "role",
         "status",
@@ -242,6 +404,127 @@ def _resolve_agent(world: Any, target_id: str) -> Dict[str, Any]:
         if hasattr(value, "value"):
             value = value.value
         base[attr] = value
+    # If to_dict didn't set name (rare), fall back to the agent attribute.
+    if "name" not in base:
+        nm = getattr(candidate, "name", None)
+        if nm is not None:
+            base["name"] = nm
+
+    # ---------------------------------------------------------- v6: dossier
+    # Intent string (current "right now" verb). Agents may or may not set it.
+    # Creature.to_dict() already sets a useful intent; fall back to the
+    # creature's own value if the candidate doesn't expose an attribute.
+    intent = getattr(candidate, "intent", "") or base.get("intent", "")
+    if hasattr(intent, "value"):
+        intent = intent.value
+    base["intent"] = str(intent)
+
+    # ---------------------------------------------------------- v9: mind
+    # On-demand only — top beliefs + active goal for the clicked agent.
+    # Cheap to compute (top-3 sort over a tiny dict). Skipped silently when
+    # the agent has no mind attached (creatures, supernaturals, outsiders).
+    mind = getattr(candidate, "mind", None)
+    if mind is not None:
+        try:
+            base["mind"] = mind.to_snapshot()
+        except Exception:
+            base["mind"] = None
+
+    # v8 — surface cult faction in the role text so the dossier reads
+    # "WANDERER · CULTIST · ACTIVE". The frontend renders role · status
+    # already; we just splice the badge into the role.
+    cult = getattr(candidate, "cult_state", None)
+    if cult and cult != "NONE":
+        existing_role = base.get("role") or ""
+        if hasattr(existing_role, "value"):
+            existing_role = existing_role.value
+        existing_role = str(existing_role).strip()
+        tag = "CULTIST" if cult == "CONVERTED" else "WAVERING"
+        base["role"] = (
+            f"{existing_role} · {tag}" if existing_role else tag
+        )
+
+    # v8 — resolve creature target_building_id → human name so the dossier
+    # shows "Lighthouse" / "Colony House" instead of an opaque id.
+    target_b_id = base.get("target")
+    if target_b_id:
+        try:
+            b = world.buildings.get(target_b_id)
+            if b is not None:
+                base["target_name"] = b.name
+        except Exception:
+            pass
+
+    # Inventory: pass through as a plain dict[str, int]. Some agents store an
+    # Enum-keyed dict; coerce keys to strings for the wire.
+    inv_raw = getattr(candidate, "inventory", None) or {}
+    inventory_out: Dict[str, int] = {}
+    try:
+        for k, v in dict(inv_raw).items():
+            key = k.value if hasattr(k, "value") else str(k)
+            try:
+                inventory_out[str(key)] = int(v)
+            except Exception:
+                inventory_out[str(key)] = 0
+    except Exception:
+        inventory_out = {}
+    base["inventory"] = inventory_out
+
+    # Relationships derived from world.trust. Trust is keyed by (a_id, b_id)
+    # tuples with floats in [0, 1] (0.5 == neutral). We compute the target's
+    # scores against every OTHER live agent, then take top-3 above 0.55 as
+    # trusted and bottom-3 below 0.45 as mistrusted.
+    trusted: list[Dict[str, Any]] = []
+    mistrusted: list[Dict[str, Any]] = []
+    try:
+        scores: list[tuple[str, str, float]] = []
+        agents_map = getattr(world, "agents", {}) or {}
+        trust_map = getattr(world, "trust", {}) or {}
+        for other_id, other in agents_map.items():
+            if other_id == target_id:
+                continue
+            score = trust_map.get((target_id, other_id))
+            if score is None:
+                score = trust_map.get((other_id, target_id), 0.5)
+            try:
+                score_f = float(score)
+            except Exception:
+                score_f = 0.5
+            partner_name = getattr(other, "name", None) or other_id
+            scores.append((other_id, str(partner_name), score_f))
+
+        high = sorted(scores, key=lambda r: r[2], reverse=True)
+        for pid, pname, s in high:
+            if s > 0.55 and len(trusted) < 3:
+                trusted.append({"partner_id": pid, "partner_name": pname, "score": round(s, 2)})
+
+        low = sorted(scores, key=lambda r: r[2])
+        for pid, pname, s in low:
+            if s < 0.45 and len(mistrusted) < 3:
+                mistrusted.append({"partner_id": pid, "partner_name": pname, "score": round(s, 2)})
+    except Exception:
+        trusted, mistrusted = [], []
+    base["relationships"] = {"trusted": trusted, "mistrusted": mistrusted}
+
+    # Recent memory: last 5 rows from character_memory across all kinds. Wrap
+    # in try/except so a missing Memory handle (e.g. read-only volume) doesn't
+    # break inspect_reply for the whole UI.
+    memory_recent: list[Dict[str, Any]] = []
+    try:
+        mem = getattr(world, "memory", None)
+        if mem is not None:
+            # recall_for accepts an iterable of kinds; an empty list means
+            # "no kind filter" (the SQL branch drops the IN clause).
+            rows = mem.recall_for(world, target_id, kinds=[], lookback_ticks=2400) or []
+            for r in rows[:5]:
+                memory_recent.append({
+                    "tick": int(r.get("tick", 0)),
+                    "kind": str(r.get("kind", "")),
+                    "detail": str(r.get("detail", "")),
+                })
+    except Exception:
+        memory_recent = []
+    base["memory_recent"] = memory_recent
 
     return base
 

--- a/from-simulation/app/contracts.py
+++ b/from-simulation/app/contracts.py
@@ -68,6 +68,10 @@ class State(str, enum.Enum):
     # NPC mini-FSM
     WORKING = "WORKING"
     SOCIALIZING = "SOCIALIZING"
+    # v2 additions
+    DREAMING = "DREAMING"
+    CALLED = "CALLED"        # heard the lighthouse — biases toward LIGHTHOUSE
+    OUTSIDER_GOAL = "OUTSIDER_GOAL"  # outsiders pursuing their backstory goal
 
 
 class Role(str, enum.Enum):
@@ -96,6 +100,7 @@ class AgentKind(str, enum.Enum):
     NPC = "npc"
     CREATURE = "creature"
     SUPERNATURAL = "supernatural"
+    OUTSIDER = "outsider"
 
 
 class MarkerClass(str, enum.Enum):
@@ -106,6 +111,8 @@ class MarkerClass(str, enum.Enum):
     MAN_IN_YELLOW = "man-in-yellow"
     ANGHKOOEY = "anghkooey"
     FARAWAY_TREE = "faraway-tree"
+    OUTSIDER = "outsider"
+    BUS = "bus"
 
 
 class YellowMode(str, enum.Enum):
@@ -208,6 +215,33 @@ EVENT_TYPES = {
     "food_low",
     # LLM
     "llm_decision",
+    # v2 — cross-cycle memory
+    "journal_entry",
+    "journal_fragment_found",
+    "journal_page_burns",
+    "personality_drift",
+    "hash_mark_added",
+    # v2 — trust
+    "trust_shift",
+    # v2 — dreams
+    "dream_begin",
+    "dream_line",
+    "dream_end",
+    "prophecy_set",
+    "prophecy_fired",
+    # v2 — bus + outsiders
+    "bus_arrival",
+    "bus_depart",
+    "outsider_joined",
+    "outsider_left",
+    "outsider_died",
+    # v2 — yellow hydra
+    "yellow_tendril_added",
+    "yellow_tendril_banished",
+    # v2 — lighthouse
+    "lighthouse_call",
+    "lighthouse_enter",
+    "lighthouse_voice",
 }
 
 
@@ -215,10 +249,71 @@ EVENT_TYPES = {
 class YellowState:
     """State of an active Man in Yellow appearance. Owned by Agent C."""
     mode: YellowMode = YellowMode.DORMANT
-    disguised_as: Optional[str] = None  # npc id when in IMPOSTER mode
+    disguised_as: Optional[str] = None  # npc id when in IMPOSTER mode (the "leader" tendril)
     started_at_tick: int = 0
     deadline_tick: int = 0  # absolute tick; >0 only when active
     path_index: int = 0  # for visible-march mode
+    tendrils: List[str] = field(default_factory=list)  # v2: hydra mode — all imposter NPC ids
+
+
+# ---------------------------------------------------------------------------
+# v2 — cross-cycle memory, dreams, bus, lighthouse
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class JournalFragment:
+    """One line of village history. Lives in Legacy; partially survives wipes."""
+    cycle_recorded: int
+    text: str
+    burned: float = 0.0  # 0=pristine, 1=unreadable
+
+
+@dataclass
+class Prophecy:
+    """A cryptic line set in a dream that may come true 1 cycle later."""
+    set_at_cycle: int
+    fires_at_cycle: int
+    trigger: str  # canonical event-type or pseudo-event key
+    payload: str  # the line the dream visitor spoke
+
+
+@dataclass
+class Dream:
+    """Transient — one active dream per sleeping low-sanity character."""
+    character_id: str
+    started_at_tick: int
+    duration: int  # ticks
+    lines: List[str] = field(default_factory=list)
+    visitor: str = "self"  # "boy_in_white" | "anghkooey" | "self"
+
+
+@dataclass
+class BusState:
+    """Bus arrival schedule. ``next_arrival_cycle`` survives wipes."""
+    next_arrival_cycle: int = 5
+    active: bool = False
+    arrival_tick: int = 0
+    departure_tick: int = 0
+    passengers: List[str] = field(default_factory=list)  # outsider ids currently in town
+    path_index: int = 0  # along YELLOW_MARCH_PATH-like waypoints (reused for bus path)
+    x: float = 0.0
+    y: float = 0.0
+
+
+@dataclass
+class Legacy:
+    """The one thing the universe remembers across wipes.
+
+    ``reset_world`` preserves this object; everything else is bulldozed.
+    """
+    journal_fragments: List[JournalFragment] = field(default_factory=list)
+    building_breach_marks: Dict[str, int] = field(default_factory=dict)  # building_id -> count
+    personality_drift: Dict[str, Dict[str, float]] = field(default_factory=dict)
+    # char_name -> {trait_name: delta}, accumulated forever
+    deaths_by_creature: Dict[str, int] = field(default_factory=dict)
+    cycles_witnessed: int = 0  # incremented once per village_wipe
+    pending_prophecies: List[Prophecy] = field(default_factory=list)
 
 
 @dataclass
@@ -265,6 +360,23 @@ class Config:
     pyroscope_endpoint: str = "http://alloy:9999"
     service_name: str = "from-sim"
     log_level: str = "INFO"
+    # v2 — cross-cycle memory + drift
+    personality_drift_rate: float = 0.04
+    journal_fragment_survival_prob: float = 0.6
+    # v2 — dreams
+    dream_trigger_sanity_threshold: float = 40.0
+    dream_trigger_prob: float = 0.08
+    dream_duration_ticks: int = 30
+    # v2 — bus
+    bus_arrival_cycle_interval: int = 5
+    bus_stay_ticks: int = 1440
+    # v2 — yellow hydra
+    yellow_hydra_min: int = 2
+    yellow_hydra_max: int = 3
+    # v2 — lighthouse
+    lighthouse_call_tick_frac: float = 0.4
+    # v2 — trust
+    trust_baseline: float = 0.5
 
     @classmethod
     def from_env(cls, getenv: Callable[[str, Optional[str]], Optional[str]]) -> "Config":
@@ -305,6 +417,17 @@ class Config:
             pyroscope_endpoint=_s("PYROSCOPE_SERVER_ADDRESS", "http://alloy:9999"),
             service_name=_s("SERVICE_NAME", "from-sim"),
             log_level=_s("LOG_LEVEL", "INFO"),
+            personality_drift_rate=_f("PERSONALITY_DRIFT_RATE", 0.04),
+            journal_fragment_survival_prob=_f("JOURNAL_FRAGMENT_SURVIVAL_PROB", 0.6),
+            dream_trigger_sanity_threshold=_f("DREAM_TRIGGER_SANITY_THRESHOLD", 40.0),
+            dream_trigger_prob=_f("DREAM_TRIGGER_PROB", 0.08),
+            dream_duration_ticks=_i("DREAM_DURATION_TICKS", 30),
+            bus_arrival_cycle_interval=_i("BUS_ARRIVAL_CYCLE_INTERVAL", 5),
+            bus_stay_ticks=_i("BUS_STAY_TICKS", 1440),
+            yellow_hydra_min=_i("YELLOW_HYDRA_MIN", 2),
+            yellow_hydra_max=_i("YELLOW_HYDRA_MAX", 3),
+            lighthouse_call_tick_frac=_f("LIGHTHOUSE_CALL_TICK_FRAC", 0.4),
+            trust_baseline=_f("TRUST_BASELINE", 0.5),
         )
 
 
@@ -400,6 +523,14 @@ class World:
     llm_decider: Optional[Any] = None  # llm.decider.LLMDecider when ANTHROPIC_API_KEY is set
     narrations: List[Dict[str, str]] = field(default_factory=list)  # rolling window of LLM reasons
 
+    # --- v2: cross-cycle memory, dreams, bus, lighthouse, trust ---
+    legacy: "Legacy" = field(default_factory=lambda: Legacy())  # persists through wipes
+    trust: Dict[Tuple[str, str], float] = field(default_factory=dict)  # (id_a, id_b) -> [0,1]
+    active_dreams: List[Dream] = field(default_factory=list)
+    bus: BusState = field(default_factory=BusState)
+    lighthouse_called: Optional[str] = None  # char id when a call is active
+    lighthouse_voice_active: bool = False
+
     @property
     def cycle_number(self) -> int:
         return self.village_wipes + 1
@@ -425,6 +556,21 @@ class World:
 # ---------------------------------------------------------------------------
 
 
+def _enrich_agent(agent: Agent, world: World) -> Dict[str, Any]:
+    """Decorate the bare agent dict with cross-cycle fields known only to World.
+
+    Currently adds a ``drift`` bool for named characters who have any non-zero
+    entry in ``world.legacy.personality_drift``. Outsiders already expose
+    ``backstory`` / ``goal`` via their own to_dict; we don't override those.
+    """
+    d = agent.to_dict()
+    name = getattr(agent, "name", None)
+    if name and getattr(agent, "kind", None) == AgentKind.CHARACTER:
+        deltas = world.legacy.personality_drift.get(name)
+        d["drift"] = bool(deltas) and any(abs(v) > 1e-6 for v in deltas.values())
+    return d
+
+
 def snapshot_dict(world: World) -> Dict[str, Any]:
     """The shape SocketIO emits as a 'tick' event. Frontend (Agent D) renders this.
 
@@ -448,11 +594,42 @@ def snapshot_dict(world: World) -> Dict[str, Any]:
         "yellow": {
             "mode": world.yellow_active.mode.value,
             "disguised_as": world.yellow_active.disguised_as,
+            "tendrils": list(world.yellow_active.tendrils),
             "deadline_in": max(0, world.yellow_active.deadline_tick - world.tick_count)
             if world.yellow_active.deadline_tick
             else 0,
         },
         "narration": list(world.narrations)[-10:],
+        "legacy": {
+            "cycles_witnessed": world.legacy.cycles_witnessed,
+            "journal_fragments": [
+                {"text": j.text, "burned": round(j.burned, 2), "cycle": j.cycle_recorded}
+                for j in world.legacy.journal_fragments[-12:]
+            ],
+            "building_breach_marks": dict(world.legacy.building_breach_marks),
+            "pending_prophecies": len(world.legacy.pending_prophecies),
+        },
+        "dreams": [
+            {"character_id": d.character_id, "lines": list(d.lines),
+             "visitor": d.visitor, "duration_left": max(0, d.duration - (world.tick_count - d.started_at_tick))}
+            for d in world.active_dreams
+        ],
+        "bus": {
+            "active": world.bus.active,
+            "passengers": list(world.bus.passengers),
+            "next_arrival_cycle": world.bus.next_arrival_cycle,
+            "x": round(world.bus.x, 2),
+            "y": round(world.bus.y, 2),
+            "departure_in_ticks": (
+                max(0, world.bus.departure_tick - world.tick_count)
+                if world.bus.active and world.bus.departure_tick
+                else 0
+            ),
+        },
+        "lighthouse": {
+            "called": world.lighthouse_called,
+            "voice_active": world.lighthouse_voice_active,
+        },
         "buildings": [
             {
                 "id": b.id,
@@ -466,7 +643,7 @@ def snapshot_dict(world: World) -> Dict[str, Any]:
             }
             for b in world.buildings.values()
         ],
-        "agents": [a.to_dict() for a in world.agents.values()],
+        "agents": [_enrich_agent(a, world) for a in world.agents.values()],
         "creatures": [c.to_dict() for c in world.creatures],
         "supernaturals": [s.to_dict() for s in world.supernaturals],
         "events": [
@@ -506,6 +683,14 @@ class Metric:
     SANITY_AVG = "from_sim_sanity_avg"                # gauge
     VILLAGE_WIPES_TOTAL = "from_sim_village_wipes_total"  # counter
     YELLOW_ACTIVE = "from_sim_yellow_active"          # gauge 0/1, attr: mode
+    # v2 metrics
+    LEGACY_JOURNAL_FRAGMENTS = "from_sim_legacy_journal_fragments"  # gauge
+    LEGACY_CYCLES_WITNESSED = "from_sim_legacy_cycles_witnessed"    # gauge
+    OUTSIDERS_ACTIVE = "from_sim_outsiders_active"                  # gauge
+    YELLOW_TENDRILS = "from_sim_yellow_tendrils"                    # gauge
+    LIGHTHOUSE_VOICE_ACTIVE = "from_sim_lighthouse_voice_active"    # gauge 0/1
+    DREAMS_ACTIVE = "from_sim_dreams_active"                        # gauge
+    TRUST_AVG = "from_sim_trust_avg"                                # gauge
 
 
 PHASE_TO_NUM = {Phase.DAY: 0, Phase.DUSK: 1, Phase.NIGHT: 2, Phase.DAWN: 3}
@@ -554,4 +739,13 @@ NPC_INTAKE_POINTS: List[Tuple[float, float]] = [
 YELLOW_MARCH_PATH: List[Tuple[float, float]] = [
     (90, 350), (250, 360), (400, 380), (520, 380),
     (680, 360), (800, 320), (900, 280),
+]
+
+# Bus path — drives in along the dirt road, parks near the diner, drives out the other way.
+BUS_PATH_IN: List[Tuple[float, float]] = [
+    (90, 320), (200, 330), (340, 340), (480, 340), (570, 340),
+]
+BUS_PARK: Tuple[float, float] = (600, 330)  # next to the diner
+BUS_PATH_OUT: List[Tuple[float, float]] = [
+    (600, 330), (720, 320), (840, 290), (920, 250),
 ]

--- a/from-simulation/app/contracts.py
+++ b/from-simulation/app/contracts.py
@@ -1,0 +1,557 @@
+"""
+Shared contracts for the From simulation.
+
+This module is the seam between the four subsystems. Every other module
+imports from here — agents must not import from each other directly.
+The project lead owns this file; subagents propose changes via a stop-the-world
+review, never edit unilaterally.
+
+Ownership map (who writes which world fields, who reads which):
+
+  World.time, lighting, buildings, events, food_supply, farm_health    -> Agent A (engine)
+  World.creatures, supernaturals                                       -> Agent A (engine)
+  World.agents (characters)                                            -> Agent B (main characters)
+  World.agents (npcs)                                                  -> Agent C (NPCs)
+  World.yellow_touched_npcs, yellow_active, pending_reset, wipes       -> Agent C (Yellow Man)
+  World.meeting_outcomes, expedition_authorised, recognition_events    -> Agent B (society)
+
+Anyone may READ any World field. WRITES are gated by ownership above.
+"""
+
+from __future__ import annotations
+
+import enum
+import time
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, List, Optional, Set, Tuple
+from abc import ABC, abstractmethod
+
+
+# ---------------------------------------------------------------------------
+# Enums
+# ---------------------------------------------------------------------------
+
+
+class Phase(str, enum.Enum):
+    DAY = "DAY"
+    DUSK = "DUSK"
+    NIGHT = "NIGHT"
+    DAWN = "DAWN"
+
+
+class State(str, enum.Enum):
+    # Solo states
+    SLEEPING = "SLEEPING"
+    EATING = "EATING"
+    SCAVENGING = "SCAVENGING"
+    FARMING = "FARMING"
+    GOSSIPING = "GOSSIPING"
+    PATROLLING = "PATROLLING"
+    SHELTERING = "SHELTERING"
+    PRAYING = "PRAYING"
+    MEDICAL_CARE = "MEDICAL_CARE"
+    MOURNING = "MOURNING"
+    REPAIRING = "REPAIRING"
+    WANDERING = "WANDERING"
+    FLEEING = "FLEEING"
+    HYPNOTIZED = "HYPNOTIZED"
+    INVESTIGATING = "INVESTIGATING"
+    PLAYING = "PLAYING"
+    EXPEDITION = "EXPEDITION"
+    CARETAKING = "CARETAKING"
+    IRRATIONAL = "IRRATIONAL"
+    # Multi-agent states (require a partner / venue)
+    MEETING = "MEETING"
+    ARGUING = "ARGUING"
+    CONVERSING = "CONVERSING"
+    MEDIATING = "MEDIATING"
+    # NPC mini-FSM
+    WORKING = "WORKING"
+    SOCIALIZING = "SOCIALIZING"
+
+
+class Role(str, enum.Enum):
+    SHERIFF = "SHERIFF"
+    DEPUTY = "DEPUTY"
+    LEADER_COLONY = "LEADER_COLONY"
+    ENGINEER = "ENGINEER"
+    CARETAKER = "CARETAKER"
+    BRIDGE = "BRIDGE"  # moves between factions
+    INVESTIGATOR = "INVESTIGATOR"
+    PRIEST = "PRIEST"
+    SEER = "SEER"
+    CHILD = "CHILD"
+
+
+class Status(str, enum.Enum):
+    ACTIVE = "ACTIVE"
+    RETURNING = "RETURNING"
+    ABSENT = "ABSENT"
+    DEAD = "DEAD"
+    INCAPACITATED = "INCAPACITATED"
+
+
+class AgentKind(str, enum.Enum):
+    CHARACTER = "character"
+    NPC = "npc"
+    CREATURE = "creature"
+    SUPERNATURAL = "supernatural"
+
+
+class MarkerClass(str, enum.Enum):
+    CHAR = "char"
+    NPC = "npc"
+    CREATURE = "creature"
+    BOY_IN_WHITE = "boy-in-white"
+    MAN_IN_YELLOW = "man-in-yellow"
+    ANGHKOOEY = "anghkooey"
+    FARAWAY_TREE = "faraway-tree"
+
+
+class YellowMode(str, enum.Enum):
+    DORMANT = "DORMANT"
+    VISIBLE_MARCH = "VISIBLE_MARCH"
+    IMPOSTER = "IMPOSTER"
+
+
+# ---------------------------------------------------------------------------
+# Data models
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class SimTime:
+    day: int = 0
+    hour: int = 6  # sim-day starts at 06:00
+    minute: int = 0
+    phase: Phase = Phase.DAY
+
+    @property
+    def minutes_today(self) -> int:
+        return self.hour * 60 + self.minute
+
+    def label(self) -> str:
+        return f"D{self.day} {self.hour:02d}:{self.minute:02d} {self.phase.value}"
+
+
+@dataclass
+class Building:
+    id: str
+    name: str
+    x: float
+    y: float
+    footprint: int  # capacity hint
+    has_talisman: bool
+    role_tag: str = ""  # e.g. "church", "sheriff", "matthews", "colony", "clinic"
+    locked: bool = False
+    occupants: Set[str] = field(default_factory=set)
+
+
+@dataclass
+class Event:
+    tick: int
+    type: str  # see EVENT_TYPES below
+    subject: str  # agent id or "world"
+    detail: str
+    severity: str = "info"  # info | warn | crit
+
+
+# Canonical event type strings — emit ONLY these.
+EVENT_TYPES = {
+    # Core / engine
+    "tick_warn",
+    "phase_change",
+    "lighting_update",
+    # Creatures
+    "creature_spawn",
+    "creature_breach",
+    "creature_retreat",
+    "hypnosis_attempt",
+    # Supernatural
+    "boy_in_white",
+    "anghkooey_chant",
+    "faraway_portal",
+    # Yellow Man
+    "yellow_appearance",
+    "yellow_imposter_join",
+    "yellow_imposter_acted",
+    "imposter_suspicion",
+    "imposter_vote",
+    "imposter_banished",
+    "village_wipe",
+    "village_reseed",
+    # Population
+    "npc_arrival",
+    "npc_death",
+    "char_death",
+    "char_absent",
+    "char_returning",
+    "homecoming",
+    "char_recognised",
+    "char_restored",
+    # Social
+    "meeting_proposed",
+    "meeting_started",
+    "meeting_outcome",
+    "conversation",
+    "argument",
+    # Fear / irrational
+    "paranormal_break",
+    "irrational_act",
+    "incapacitated",
+    "recovered",
+    # Food / expedition
+    "farm_disaster",
+    "expedition_called",
+    "expedition_departed",
+    "expedition_returned",
+    "food_low",
+    # LLM
+    "llm_decision",
+}
+
+
+@dataclass
+class YellowState:
+    """State of an active Man in Yellow appearance. Owned by Agent C."""
+    mode: YellowMode = YellowMode.DORMANT
+    disguised_as: Optional[str] = None  # npc id when in IMPOSTER mode
+    started_at_tick: int = 0
+    deadline_tick: int = 0  # absolute tick; >0 only when active
+    path_index: int = 0  # for visible-march mode
+
+
+@dataclass
+class MeetingOutcome:
+    """Emitted by Agent B's social loop, consumed by C/A."""
+    tick: int
+    topic: str  # "food_supply" | "creature_breach_review" | "imposter_suspicion" | "mourning_X" | "recognise_returner"
+    venue_id: str
+    attendees: List[str]
+    decision: str  # "agree" | "disagree" | "inconclusive"
+    payload: Dict[str, Any] = field(default_factory=dict)
+    # For imposter votes: payload = {"accused_npc_id": "...", "guilty": bool}
+
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Config:
+    tick_hz: float = 2.0
+    time_scale: float = 1.0
+    seed: Optional[int] = None
+    # LLM
+    anthropic_api_key: Optional[str] = None
+    llm_model: str = "claude-haiku-4-5"
+    llm_decision_rate: float = 0.05
+    llm_yellow_rate: float = 0.25
+    llm_min_tick_gap: int = 30
+    llm_global_rpm: int = 6
+    # Population
+    npc_floor: int = 18
+    resurrection_base_ticks: int = 700
+    resurrection_jitter: int = 150
+    recognition_threshold: int = 3
+    # Yellow Man
+    yellow_appearance_days_min: int = 5
+    yellow_appearance_days_max: int = 10
+    yellow_imposter_prob: float = 0.7
+    yellow_deadline_ticks: int = 1500
+    # Telemetry
+    otlp_endpoint: str = "http://alloy:4318"
+    pyroscope_endpoint: str = "http://alloy:9999"
+    service_name: str = "from-sim"
+    log_level: str = "INFO"
+
+    @classmethod
+    def from_env(cls, getenv: Callable[[str, Optional[str]], Optional[str]]) -> "Config":
+        import os
+        g = lambda k, d=None: os.environ.get(k, d)
+
+        def _f(name, default):
+            v = g(name)
+            return float(v) if v not in (None, "") else default
+
+        def _i(name, default):
+            v = g(name)
+            return int(v) if v not in (None, "") else default
+
+        def _s(name, default):
+            v = g(name)
+            return v if v not in (None, "") else default
+
+        return cls(
+            tick_hz=_f("TICK_HZ", 2.0),
+            time_scale=_f("TIME_SCALE", 1.0),
+            seed=int(g("SEED")) if g("SEED") not in (None, "") else None,
+            anthropic_api_key=g("ANTHROPIC_API_KEY") or None,
+            llm_model=_s("LLM_MODEL", "claude-haiku-4-5"),
+            llm_decision_rate=_f("LLM_DECISION_RATE", 0.05),
+            llm_yellow_rate=_f("LLM_YELLOW_RATE", 0.25),
+            llm_min_tick_gap=_i("LLM_MIN_TICK_GAP", 30),
+            llm_global_rpm=_i("LLM_GLOBAL_RPM", 6),
+            npc_floor=_i("NPC_FLOOR", 18),
+            resurrection_base_ticks=_i("RESURRECTION_BASE_TICKS", 700),
+            resurrection_jitter=_i("RESURRECTION_JITTER", 150),
+            recognition_threshold=_i("RECOGNITION_THRESHOLD", 3),
+            yellow_appearance_days_min=_i("YELLOW_APPEARANCE_DAYS_MIN", 5),
+            yellow_appearance_days_max=_i("YELLOW_APPEARANCE_DAYS_MAX", 10),
+            yellow_imposter_prob=_f("YELLOW_IMPOSTER_PROB", 0.7),
+            yellow_deadline_ticks=_i("YELLOW_DEADLINE_TICKS", 1500),
+            otlp_endpoint=_s("OTEL_EXPORTER_OTLP_ENDPOINT", "http://alloy:4318"),
+            pyroscope_endpoint=_s("PYROSCOPE_SERVER_ADDRESS", "http://alloy:9999"),
+            service_name=_s("SERVICE_NAME", "from-sim"),
+            log_level=_s("LOG_LEVEL", "INFO"),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Agent ABC
+# ---------------------------------------------------------------------------
+
+
+class Agent(ABC):
+    """Base contract every entity in world.agents / world.creatures honours."""
+
+    id: str
+    kind: AgentKind
+    marker_class: MarkerClass
+    x: float
+    y: float
+
+    @abstractmethod
+    def tick(self, world: "World") -> None: ...
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Default snapshot serialisation. Subclasses extend by overriding."""
+        return {
+            "id": self.id,
+            "kind": self.kind.value,
+            "marker_class": self.marker_class.value,
+            "x": round(self.x, 2),
+            "y": round(self.y, 2),
+        }
+
+
+# ---------------------------------------------------------------------------
+# Telemetry interface
+# ---------------------------------------------------------------------------
+
+
+class SimTelemetry:
+    """Interface — concrete implementation lives in telemetry.py (Agent A).
+
+    Subagents B/C/D use these methods; do not import OTel SDK directly elsewhere.
+    """
+
+    def get_logger(self): ...  # returns a stdlib logger wired to OTLP
+    def get_tracer(self): ...  # returns an OTel tracer
+    def gauge_set(self, name: str, value: float, attrs: Optional[Dict[str, str]] = None) -> None: ...
+    def counter_inc(self, name: str, value: float = 1.0, attrs: Optional[Dict[str, str]] = None) -> None: ...
+    def shutdown(self) -> None: ...
+
+
+# ---------------------------------------------------------------------------
+# World
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class World:
+    """The shared mutable state. Ownership of write access documented at top of file."""
+
+    # --- engine fields (Agent A) ---
+    config: Config
+    rng: Any  # random.Random
+    tick_count: int = 0
+    time: SimTime = field(default_factory=SimTime)
+    lighting: float = 1.0  # 0 = dark, 1 = bright
+    buildings: Dict[str, Building] = field(default_factory=dict)
+    creatures: List[Agent] = field(default_factory=list)
+    supernaturals: List[Agent] = field(default_factory=list)  # transient Boy/Tree/Anghkooey markers
+    events: Any = None  # collections.deque[Event] — wired by simulation.py
+    food_supply: float = 100.0
+    food_capacity: float = 200.0
+    farm_health: float = 1.0
+    farm_disaster_until_tick: int = 0
+    last_phase: Phase = Phase.DAY
+
+    # --- character fields (Agent B) ---
+    agents: Dict[str, Agent] = field(default_factory=dict)  # all named characters + NPCs live here
+    meeting_outcomes: List[MeetingOutcome] = field(default_factory=list)
+    expedition_authorised: bool = False
+    expedition_active: bool = False
+    recognition_counts: Dict[str, int] = field(default_factory=dict)  # char_id -> count
+
+    # --- yellow man / npc fields (Agent C) ---
+    yellow_touched_npcs: Set[str] = field(default_factory=set)
+    yellow_active: YellowState = field(default_factory=YellowState)
+    pending_reset: bool = False  # set by C when wipe triggers; A consumes next tick
+    village_wipes: int = 0
+
+    # --- food signal (Agent A writes, B reads) ---
+    food_shortage: bool = False
+
+    # --- shared handles wired by app.py / simulation.start ---
+    telemetry: Optional[SimTelemetry] = None
+    llm_decider: Optional[Any] = None  # llm.decider.LLMDecider when ANTHROPIC_API_KEY is set
+    narrations: List[Dict[str, str]] = field(default_factory=list)  # rolling window of LLM reasons
+
+    @property
+    def cycle_number(self) -> int:
+        return self.village_wipes + 1
+
+    def emit(self, event: Event) -> None:
+        """Append to the rolling log AND mirror to telemetry counter.
+
+        All subagents must use this rather than touching `events` directly.
+        """
+        if event.type not in EVENT_TYPES:
+            # Allow it but mark in telemetry — helps catch typos in dev.
+            tag = "unknown"
+        else:
+            tag = event.type
+        if self.events is not None:
+            self.events.append(event)
+        if self.telemetry is not None:
+            self.telemetry.counter_inc("from_sim_events_total", 1.0, {"type": tag})
+
+
+# ---------------------------------------------------------------------------
+# Snapshot
+# ---------------------------------------------------------------------------
+
+
+def snapshot_dict(world: World) -> Dict[str, Any]:
+    """The shape SocketIO emits as a 'tick' event. Frontend (Agent D) renders this.
+
+    Agent A owns this function but B/C contribute via Agent.to_dict() overrides.
+    """
+    return {
+        "tick": world.tick_count,
+        "time": {
+            "day": world.time.day,
+            "hour": world.time.hour,
+            "minute": world.time.minute,
+            "phase": world.time.phase.value,
+            "label": world.time.label(),
+        },
+        "lighting": round(world.lighting, 3),
+        "cycle_number": world.cycle_number,
+        "village_wipes": world.village_wipes,
+        "food_supply": round(world.food_supply, 2),
+        "food_capacity": world.food_capacity,
+        "farm_health": round(world.farm_health, 3),
+        "yellow": {
+            "mode": world.yellow_active.mode.value,
+            "disguised_as": world.yellow_active.disguised_as,
+            "deadline_in": max(0, world.yellow_active.deadline_tick - world.tick_count)
+            if world.yellow_active.deadline_tick
+            else 0,
+        },
+        "narration": list(world.narrations)[-10:],
+        "buildings": [
+            {
+                "id": b.id,
+                "name": b.name,
+                "x": b.x,
+                "y": b.y,
+                "has_talisman": b.has_talisman,
+                "locked": b.locked,
+                "occupants": len(b.occupants),
+                "role_tag": b.role_tag,
+            }
+            for b in world.buildings.values()
+        ],
+        "agents": [a.to_dict() for a in world.agents.values()],
+        "creatures": [c.to_dict() for c in world.creatures],
+        "supernaturals": [s.to_dict() for s in world.supernaturals],
+        "events": [
+            {"tick": e.tick, "type": e.type, "subject": e.subject, "detail": e.detail, "severity": e.severity}
+            for e in (list(world.events)[-50:] if world.events is not None else [])
+        ],
+    }
+
+
+# ---------------------------------------------------------------------------
+# SocketIO event names
+# ---------------------------------------------------------------------------
+
+
+class SocketEvent:
+    TICK = "tick"            # server -> client: snapshot_dict payload
+    INSPECT = "inspect"      # client -> server: {"id": "..."}
+    INSPECT_REPLY = "inspect_reply"  # server -> client: full agent state
+    CYCLE_RESET = "cycle_reset"      # server -> client: village wipe overlay trigger
+
+
+# ---------------------------------------------------------------------------
+# Metric names — keep in lockstep with telemetry.py and any dashboards
+# ---------------------------------------------------------------------------
+
+
+class Metric:
+    AGENTS_ACTIVE = "from_sim_agents_active"          # gauge, attr: role
+    NPCS_ACTIVE = "from_sim_npcs_active"              # gauge
+    CREATURES_ACTIVE = "from_sim_creatures_active"    # gauge
+    EVENTS_TOTAL = "from_sim_events_total"            # counter, attr: type
+    LLM_CALLS_TOTAL = "from_sim_llm_calls_total"      # counter, attr: outcome, actor
+    PHASE = "from_sim_phase"                          # gauge 0..3
+    FOOD_SUPPLY = "from_sim_food_supply"              # gauge
+    FARM_HEALTH = "from_sim_farm_health"              # gauge 0..1
+    FEAR_AVG = "from_sim_fear_avg"                    # gauge
+    SANITY_AVG = "from_sim_sanity_avg"                # gauge
+    VILLAGE_WIPES_TOTAL = "from_sim_village_wipes_total"  # counter
+    YELLOW_ACTIVE = "from_sim_yellow_active"          # gauge 0/1, attr: mode
+
+
+PHASE_TO_NUM = {Phase.DAY: 0, Phase.DUSK: 1, Phase.NIGHT: 2, Phase.DAWN: 3}
+
+
+# ---------------------------------------------------------------------------
+# Map layout — fixed coordinates baked into the SVG (viewBox 0 0 1000 700)
+# ---------------------------------------------------------------------------
+
+
+BUILDING_LAYOUT: List[Tuple[str, str, float, float, int, bool, str]] = [
+    # (id, name, x, y, footprint, has_talisman, role_tag)
+    ("sheriff_house", "Sheriff's House", 350, 360, 4, True, "sheriff"),
+    ("matthews_house", "Matthews House", 520, 380, 5, True, "matthews"),
+    ("church", "Church", 430, 310, 6, True, "church"),
+    ("diner", "Diner", 580, 330, 4, False, "diner"),
+    ("clinic", "Clinic", 470, 420, 4, True, "clinic"),
+    ("camper", "Boyd's Camper", 300, 420, 2, False, "camper"),
+    ("colony_house", "Colony House", 780, 180, 10, True, "colony"),
+    ("lighthouse", "Lighthouse", 500, 560, 1, False, "lighthouse"),
+]
+
+# Faraway Trees scattered around the forest perimeter
+FARAWAY_TREES: List[Tuple[float, float]] = [
+    (80, 120),
+    (920, 150),
+    (60, 560),
+    (940, 580),
+    (500, 40),
+]
+
+# Forest-edge spawn points for creatures (inner edge of forest ring)
+FOREST_SPAWN_POINTS: List[Tuple[float, float]] = [
+    (140, 110), (300, 90), (500, 85), (700, 95), (860, 130),
+    (920, 280), (940, 430), (900, 580),
+    (700, 620), (500, 640), (300, 625), (130, 590),
+    (90, 440), (70, 290), (180, 200), (820, 220),
+]
+
+# NPC "intake" points — where new arrivals appear from the forest
+NPC_INTAKE_POINTS: List[Tuple[float, float]] = [
+    (140, 350), (860, 350), (500, 90), (500, 620),
+]
+
+# Yellow Man visible-march path (sequence of waypoints)
+YELLOW_MARCH_PATH: List[Tuple[float, float]] = [
+    (90, 350), (250, 360), (400, 380), (520, 380),
+    (680, 360), (800, 320), (900, 280),
+]

--- a/from-simulation/app/contracts.py
+++ b/from-simulation/app/contracts.py
@@ -126,6 +126,16 @@ class YellowMode(str, enum.Enum):
     IMPOSTER = "IMPOSTER"
 
 
+class Item(str, enum.Enum):
+    """v5 — canonical inventory items characters and NPCs can hold."""
+    FOOD = "food"
+    MUSIC_BOX = "music_box"
+    CLUE = "clue"
+    JOURNAL_PAGE = "journal_page"
+    TORCH = "torch"
+    TALISMAN_FRAGMENT = "talisman_fragment"
+
+
 # ---------------------------------------------------------------------------
 # Data models
 # ---------------------------------------------------------------------------
@@ -275,6 +285,16 @@ EVENT_TYPES = {
     "steal_event",
     "worms_passed",
     "ballerina_vision",
+    # v5 — memory + inventory + promotion
+    "item_picked_up",
+    "item_dropped",
+    "item_used",
+    "item_transferred",
+    "npc_promoted",
+    "sub_main_died",
+    "memory_recall",
+    "db_pruned",
+    "memory_hydrated",
 }
 
 
@@ -423,6 +443,12 @@ class Config:
     npc_sanity_break_prob: float = 0.04
     house_cooling_off_ticks: int = 800
     npc_breach_death_prob: float = 0.30
+    # v5 — SQLite memory + promotion
+    db_path: str = "/data/from.db"
+    memory_cycle_window: int = 50
+    memory_flush_every_ticks: int = 60
+    memory_recall_window_ticks: int = 1200
+    npc_promotion_score_threshold: float = 1.0
 
     @classmethod
     def from_env(cls, getenv: Callable[[str, Optional[str]], Optional[str]]) -> "Config":
@@ -485,6 +511,11 @@ class Config:
             npc_sanity_break_prob=_f("NPC_SANITY_BREAK_PROB", 0.04),
             house_cooling_off_ticks=_i("HOUSE_COOLING_OFF_TICKS", 800),
             npc_breach_death_prob=_f("NPC_BREACH_DEATH_PROB", 0.30),
+            db_path=_s("FROM_DB_PATH", "/data/from.db"),
+            memory_cycle_window=_i("MEMORY_CYCLE_WINDOW", 50),
+            memory_flush_every_ticks=_i("MEMORY_FLUSH_EVERY_TICKS", 60),
+            memory_recall_window_ticks=_i("MEMORY_RECALL_WINDOW_TICKS", 1200),
+            npc_promotion_score_threshold=_f("NPC_PROMOTION_SCORE_THRESHOLD", 1.0),
         )
 
 
@@ -597,12 +628,16 @@ class World:
     worms_infected: Set[str] = field(default_factory=set)  # agent ids
     rhyme_heard: List[str] = field(default_factory=list)  # rhyme lines surfaced so far
 
+    # --- v5: SQLite memory + sub-main NPC promotion ---
+    memory: Optional[Any] = None  # storage.Memory; attached by app.py at boot
+    sub_mains: Set[str] = field(default_factory=set)  # npc ids that have been promoted
+
     @property
     def cycle_number(self) -> int:
         return self.village_wipes + 1
 
     def emit(self, event: Event) -> None:
-        """Append to the rolling log AND mirror to telemetry counter.
+        """Append to the rolling log, mirror to telemetry, persist to memory.
 
         All subagents must use this rather than touching `events` directly.
         """
@@ -615,6 +650,13 @@ class World:
             self.events.append(event)
         if self.telemetry is not None:
             self.telemetry.counter_inc("from_sim_events_total", 1.0, {"type": tag})
+        # v5 — persist to SQLite via Memory (if attached). Memory swallows
+        # its own errors so a busted DB never kills a tick.
+        if self.memory is not None:
+            try:
+                self.memory.record_event(self, event)
+            except Exception:
+                pass
 
 
 # ---------------------------------------------------------------------------
@@ -625,15 +667,21 @@ class World:
 def _enrich_agent(agent: Agent, world: World) -> Dict[str, Any]:
     """Decorate the bare agent dict with cross-cycle fields known only to World.
 
-    Currently adds a ``drift`` bool for named characters who have any non-zero
-    entry in ``world.legacy.personality_drift``. Outsiders already expose
-    ``backstory`` / ``goal`` via their own to_dict; we don't override those.
+    Adds:
+      * ``drift`` bool for named characters with non-zero personality drift.
+      * ``is_sub_main`` for promoted NPCs (v5).
+      * ``inventory`` summary (item id → count) for characters and sub-mains.
     """
     d = agent.to_dict()
     name = getattr(agent, "name", None)
     if name and getattr(agent, "kind", None) == AgentKind.CHARACTER:
         deltas = world.legacy.personality_drift.get(name)
         d["drift"] = bool(deltas) and any(abs(v) > 1e-6 for v in deltas.values())
+    if agent.id in world.sub_mains:
+        d["is_sub_main"] = True
+    inv = getattr(agent, "inventory", None)
+    if isinstance(inv, dict) and inv:
+        d["inventory"] = {k: v for k, v in inv.items() if v}
     return d
 
 
@@ -705,6 +753,10 @@ def snapshot_dict(world: World) -> Dict[str, Any]:
             "rhyme": list(world.rhyme_heard),
             "worms_count": len(world.worms_infected),
         },
+        "memory": {
+            "db_attached": world.memory is not None,
+            "sub_mains_alive": len(world.sub_mains),
+        },
         "buildings": [
             {
                 "id": b.id,
@@ -774,6 +826,11 @@ class Metric:
     HOUSES_COOLING_OFF = "from_sim_houses_cooling_off"              # gauge
     NPC_HOMES_FULL = "from_sim_npc_homes_full"                      # gauge
     WORMS_INFECTED = "from_sim_worms_infected"                      # gauge
+    # v5
+    MEMORY_ROWS = "from_sim_memory_rows"                            # gauge: rows in character_memory
+    SUB_MAINS_ALIVE = "from_sim_sub_mains_alive"                    # gauge
+    SUB_MAINS_DEAD_TOTAL = "from_sim_sub_mains_dead_total"          # gauge cumulative
+    INVENTORY_ITEMS = "from_sim_inventory_items"                    # gauge: total items held
 
 
 PHASE_TO_NUM = {Phase.DAY: 0, Phase.DUSK: 1, Phase.NIGHT: 2, Phase.DAWN: 3}

--- a/from-simulation/app/contracts.py
+++ b/from-simulation/app/contracts.py
@@ -72,6 +72,8 @@ class State(str, enum.Enum):
     DREAMING = "DREAMING"
     CALLED = "CALLED"        # heard the lighthouse — biases toward LIGHTHOUSE
     OUTSIDER_GOAL = "OUTSIDER_GOAL"  # outsiders pursuing their backstory goal
+    # v4 additions
+    CARRYING_BOX = "CARRYING_BOX"    # holding a Music Box — sticky, compelled
 
 
 class Role(str, enum.Enum):
@@ -93,6 +95,7 @@ class Status(str, enum.Enum):
     ABSENT = "ABSENT"
     DEAD = "DEAD"
     INCAPACITATED = "INCAPACITATED"
+    STOLEN = "STOLEN"  # v4: catatonic — taken by the Music Box monster (STEAL phase)
 
 
 class AgentKind(str, enum.Enum):
@@ -113,6 +116,8 @@ class MarkerClass(str, enum.Enum):
     FARAWAY_TREE = "faraway-tree"
     OUTSIDER = "outsider"
     BUS = "bus"
+    MUSIC_BOX = "music-box"
+    CICADA = "cicada"  # transient swarm sprites during STEAL phase
 
 
 class YellowMode(str, enum.Enum):
@@ -152,6 +157,14 @@ class Building:
     role_tag: str = ""  # e.g. "church", "sheriff", "matthews", "colony", "clinic"
     locked: bool = False
     occupants: Set[str] = field(default_factory=set)
+    # v4: cooling-off period after a breach or music-box damage. While
+    # ``world.tick_count < cooling_off_until_tick`` the talisman is treated
+    # as failed and NPCs won't pick this building as a new home.
+    cooling_off_until_tick: int = 0
+
+    def is_protected(self, tick: int) -> bool:
+        """True only when the building has its talisman AND isn't in cool-off."""
+        return self.has_talisman and tick >= self.cooling_off_until_tick
 
 
 @dataclass
@@ -242,6 +255,26 @@ EVENT_TYPES = {
     "lighthouse_call",
     "lighthouse_enter",
     "lighthouse_voice",
+    # v4 — NPC lives + house cooling-off
+    "npc_sanity_break",
+    "npc_displaced",
+    "npc_settled",
+    "npc_contribution",
+    "house_cooling_off",
+    "house_cleared",
+    # v4 — music box monster
+    "music_box_appeared",
+    "music_box_picked_up",
+    "music_box_dropped",
+    "music_box_in_house",
+    "music_box_compulsion",
+    "music_box_destroyed",
+    "rhyme_line",
+    "rhyme_heard",
+    "break_death",
+    "steal_event",
+    "worms_passed",
+    "ballerina_vision",
 }
 
 
@@ -377,6 +410,19 @@ class Config:
     lighthouse_call_tick_frac: float = 0.4
     # v2 — trust
     trust_baseline: float = 0.5
+    # v4 — music box monster
+    music_box_interval_days: int = 3
+    music_box_curiosity_radius: float = 80.0
+    music_box_talisman_fail_prob: float = 0.05
+    music_box_sanity_drain: float = 0.5
+    music_box_destroy_radius: float = 40.0
+    music_box_phase_ticks: int = 600  # ticks between phase escalations
+    # v4 — NPC problems
+    npc_sanity_break_sanity: float = 30.0
+    npc_sanity_break_fear: float = 70.0
+    npc_sanity_break_prob: float = 0.04
+    house_cooling_off_ticks: int = 800
+    npc_breach_death_prob: float = 0.30
 
     @classmethod
     def from_env(cls, getenv: Callable[[str, Optional[str]], Optional[str]]) -> "Config":
@@ -428,6 +474,17 @@ class Config:
             yellow_hydra_max=_i("YELLOW_HYDRA_MAX", 3),
             lighthouse_call_tick_frac=_f("LIGHTHOUSE_CALL_TICK_FRAC", 0.4),
             trust_baseline=_f("TRUST_BASELINE", 0.5),
+            music_box_interval_days=_i("MUSIC_BOX_INTERVAL_DAYS", 3),
+            music_box_curiosity_radius=_f("MUSIC_BOX_CURIOSITY_RADIUS", 80.0),
+            music_box_talisman_fail_prob=_f("MUSIC_BOX_TALISMAN_FAIL_PROB", 0.05),
+            music_box_sanity_drain=_f("MUSIC_BOX_SANITY_DRAIN", 0.5),
+            music_box_destroy_radius=_f("MUSIC_BOX_DESTROY_RADIUS", 40.0),
+            music_box_phase_ticks=_i("MUSIC_BOX_PHASE_TICKS", 600),
+            npc_sanity_break_sanity=_f("NPC_SANITY_BREAK_SANITY", 30.0),
+            npc_sanity_break_fear=_f("NPC_SANITY_BREAK_FEAR", 70.0),
+            npc_sanity_break_prob=_f("NPC_SANITY_BREAK_PROB", 0.04),
+            house_cooling_off_ticks=_i("HOUSE_COOLING_OFF_TICKS", 800),
+            npc_breach_death_prob=_f("NPC_BREACH_DEATH_PROB", 0.30),
         )
 
 
@@ -531,6 +588,15 @@ class World:
     lighthouse_called: Optional[str] = None  # char id when a call is active
     lighthouse_voice_active: bool = False
 
+    # --- v4: music box monster + cooling-off ---
+    # Phase machine: "DORMANT" | "TOUCH" | "BREAK" | "STEAL" | "TERMINAL"
+    music_box_phase: str = "DORMANT"
+    music_box_phase_until_tick: int = 0  # absolute tick; >0 only when armed
+    music_box_id: Optional[str] = None   # id of the active MusicBox in world.supernaturals
+    music_box_carrier: Optional[str] = None  # agent id currently holding it
+    worms_infected: Set[str] = field(default_factory=set)  # agent ids
+    rhyme_heard: List[str] = field(default_factory=list)  # rhyme lines surfaced so far
+
     @property
     def cycle_number(self) -> int:
         return self.village_wipes + 1
@@ -630,6 +696,15 @@ def snapshot_dict(world: World) -> Dict[str, Any]:
             "called": world.lighthouse_called,
             "voice_active": world.lighthouse_voice_active,
         },
+        "music_box": {
+            "phase": world.music_box_phase,
+            "phase_left": max(0, world.music_box_phase_until_tick - world.tick_count)
+            if world.music_box_phase_until_tick else 0,
+            "id": world.music_box_id,
+            "carrier": world.music_box_carrier,
+            "rhyme": list(world.rhyme_heard),
+            "worms_count": len(world.worms_infected),
+        },
         "buildings": [
             {
                 "id": b.id,
@@ -640,6 +715,8 @@ def snapshot_dict(world: World) -> Dict[str, Any]:
                 "locked": b.locked,
                 "occupants": len(b.occupants),
                 "role_tag": b.role_tag,
+                "cooling_off": max(0, b.cooling_off_until_tick - world.tick_count),
+                "protected": b.is_protected(world.tick_count),
             }
             for b in world.buildings.values()
         ],
@@ -691,6 +768,12 @@ class Metric:
     LIGHTHOUSE_VOICE_ACTIVE = "from_sim_lighthouse_voice_active"    # gauge 0/1
     DREAMS_ACTIVE = "from_sim_dreams_active"                        # gauge
     TRUST_AVG = "from_sim_trust_avg"                                # gauge
+    # v4
+    MUSIC_BOX_ACTIVE = "from_sim_music_box_active"                  # gauge 0/1
+    MUSIC_BOX_PHASE = "from_sim_music_box_phase"                    # gauge 0..4
+    HOUSES_COOLING_OFF = "from_sim_houses_cooling_off"              # gauge
+    NPC_HOMES_FULL = "from_sim_npc_homes_full"                      # gauge
+    WORMS_INFECTED = "from_sim_worms_infected"                      # gauge
 
 
 PHASE_TO_NUM = {Phase.DAY: 0, Phase.DUSK: 1, Phase.NIGHT: 2, Phase.DAWN: 3}
@@ -706,23 +789,23 @@ PHASE_TO_NUM = {Phase.DAY: 0, Phase.DUSK: 1, Phase.NIGHT: 2, Phase.DAWN: 3}
 BUILDING_LAYOUT: List[Tuple[str, str, float, float, int, bool, str]] = [
     # (id, name, x, y, footprint, has_talisman, role_tag)
     ("colony_house",     "Colony House",            385, 420, 10, True,  "colony"),
-    ("green_house",      "Green House",             418, 400,  3, False, "house"),
+    ("green_house",      "Green House",             418, 400,  3, True,  "house"),
     ("shed",             "Shed",                    442, 388,  1, False, "shed"),
     ("clinic",           "Clinic",                  478, 402,  4, True,  "clinic"),
     ("root_cellar",      "Root Cellar",             495, 432,  2, False, "cellar"),
     ("choosing_stone",   "Choosing Ceremony Stone", 390, 470,  0, False, "stone"),
     ("church",           "Church",                  385, 510,  6, True,  "church"),
-    ("grey_house",       "Grey House",              420, 490,  3, False, "house"),
-    ("blue_house",       "Blue House",              440, 490,  3, False, "house"),
+    ("grey_house",       "Grey House",              420, 490,  3, True,  "house"),
+    ("blue_house",       "Blue House",              440, 490,  3, True,  "house"),
     ("pool",             "Pool",                    462, 478,  0, False, "pool"),
-    ("lius_home",        "Liu's Home",              478, 462,  4, False, "house"),
+    ("lius_home",        "Liu's Home",              478, 462,  4, True,  "house"),
     ("bar",              "Bar",                     510, 458,  3, False, "bar"),
     ("barn",             "Barn",                    555, 454,  5, False, "barn"),
     ("sheriff_office",   "Sheriff's Office",        490, 510,  4, True,  "sheriff"),
     ("abandoned_bus",    "Abandoned Bus",           460, 538,  0, False, "wreck"),
     ("matthews_home",    "Matthews' Home",          430, 545,  5, True,  "matthews"),
     ("diner",            "Diner",                   405, 530,  4, False, "diner"),
-    ("myers_home",       "Myers' Home",             382, 552,  3, False, "house"),
+    ("myers_home",       "Myers' Home",             382, 552,  3, True,  "house"),
     # Lighthouse lives in its own clearing south-west of town.
     ("lighthouse",       "Lighthouse",              140, 585,  1, False, "lighthouse"),
 ]
@@ -776,3 +859,15 @@ BUS_PATH_OUT: List[Tuple[float, float]] = [
 
 # Lighthouse direct-coord alias (lighthouse.py and bus.py read this).
 LIGHTHOUSE_XY: Tuple[float, float] = (140.0, 585.0)
+
+# v4: the Dungeon ruins — where the Music Box monster's power is anchored
+# and where the box can be destroyed. Maps to the DUNGEON landmark on the map.
+RUINS_XY: Tuple[float, float] = (240.0, 650.0)
+
+# v4: talisman residential houses NPCs may pick as home (subset of layout).
+# Order matters for stable home-assignment; colony_house listed first so the
+# 4× weight in npcs.py preserves "the big house" feel.
+NPC_HOME_BUILDINGS: List[str] = [
+    "colony_house", "matthews_home", "lius_home", "myers_home",
+    "green_house", "grey_house", "blue_house",
+]

--- a/from-simulation/app/contracts.py
+++ b/from-simulation/app/contracts.py
@@ -74,6 +74,10 @@ class State(str, enum.Enum):
     OUTSIDER_GOAL = "OUTSIDER_GOAL"  # outsiders pursuing their backstory goal
     # v4 additions
     CARRYING_BOX = "CARRYING_BOX"    # holding a Music Box — sticky, compelled
+    # v6 additions
+    EXPLORING_CAVES = "EXPLORING_CAVES"  # DAY-only investigative state — walks to CAVE_ENTRY_XY
+    # v7 additions
+    FORAGING = "FORAGING"  # walks to the windmill / lakeside river to gather food when the barn is down
 
 
 class Role(str, enum.Enum):
@@ -116,6 +120,9 @@ class MarkerClass(str, enum.Enum):
     FARAWAY_TREE = "faraway-tree"
     OUTSIDER = "outsider"
     BUS = "bus"
+    CAR = "car"  # v6 — survivor arrival vehicles; turn into permanent wrecks
+    CREATURE_SWARM = "creature-swarm"  # v6 — smaller, faster swarmer-type creature
+    WRECK = "wreck"  # v6 — permanent abandoned-car static markers
     MUSIC_BOX = "music-box"
     CICADA = "cicada"  # transient swarm sprites during STEAL phase
 
@@ -134,6 +141,7 @@ class Item(str, enum.Enum):
     JOURNAL_PAGE = "journal_page"
     TORCH = "torch"
     TALISMAN_FRAGMENT = "talisman_fragment"
+    CAVE_CLUE = "cave_clue"  # v6 — found by EXPLORING_CAVES outcomes
 
 
 # ---------------------------------------------------------------------------
@@ -171,10 +179,38 @@ class Building:
     # ``world.tick_count < cooling_off_until_tick`` the talisman is treated
     # as failed and NPCs won't pick this building as a new home.
     cooling_off_until_tick: int = 0
+    # v8 — damage / destruction / rebuild. Each unprotected breach increments
+    # ``damage``. Once ``damage >= HOUSE_DESTRUCTION_THRESHOLD`` the building
+    # is ``destroyed`` and creatures stop targeting it. Survivors can spend
+    # ticks rebuilding it (see _tick_house_repair); progress is tracked in
+    # ``rebuild_progress``. When the rebuild completes both flags clear.
+    damage: int = 0
+    destroyed: bool = False
+    rebuild_progress: float = 0.0
+    # v8 — talisman crack: a separate flag from has_talisman so that we can
+    # restore the original talisman state when the building is rebuilt
+    # (rebuilt houses come back without a talisman; survivors must find a
+    # new one). ``original_talisman`` is captured at world init / reseed.
+    original_talisman: bool = False
 
     def is_protected(self, tick: int) -> bool:
         """True only when the building has its talisman AND isn't in cool-off."""
         return self.has_talisman and tick >= self.cooling_off_until_tick
+
+    @property
+    def capacity(self) -> int:
+        """v8 — max simultaneous occupants. Currently mirrors ``footprint``.
+
+        The hand-drawn map's footprint sizes already encode "big house" vs
+        "small house": Colony House is 10, Matthews / Liu / Barn are 4-5,
+        and the smaller dwellings are 3. Non-residential structures
+        (choosing stone, pool, abandoned bus) are 0 — they accept no one.
+        """
+        return max(0, int(self.footprint))
+
+    def has_room(self) -> bool:
+        """True when at least one slot is still free."""
+        return self.capacity > 0 and len(self.occupants) < self.capacity
 
 
 @dataclass
@@ -295,6 +331,42 @@ EVENT_TYPES = {
     "memory_recall",
     "db_pruned",
     "memory_hydrated",
+    # v6 — purposeful movement + caves + cars
+    "cave_explored",
+    "cave_clue_found",
+    "cave_fragment_found",
+    "cave_scare",
+    "cave_lost",
+    "lighthouse_walking",
+    "creature_swarm_spawn",
+    "car_arrival",
+    "car_departure",
+    "car_broke_down",
+    "intent_change",
+    # v7 — barn / forage / cave-dwelling creatures
+    "barn_destroyed",
+    "barn_rebuilt",
+    "forage_started",
+    "forage_returned",
+    "creature_cave_spawn",
+    "creature_hunting",
+    # v9.1 — danger-pass: night surge + multi-kill rampage
+    "creature_night_wave",
+    "creature_kill_streak",
+    # v8 — house destruction + talisman crack
+    "talisman_cracked",
+    "house_destroyed",
+    "house_rebuilt",
+    # v8 — cult faction + endgame
+    "cult_joined",
+    "cult_recruited",
+    "cult_sacrifice_called",
+    "cult_suppressed",
+    "cult_sacrifice",
+    # v8 — construction
+    "construction_started",
+    "construction_progress",
+    "house_built",
 }
 
 
@@ -367,6 +439,15 @@ class Legacy:
     deaths_by_creature: Dict[str, int] = field(default_factory=dict)
     cycles_witnessed: int = 0  # incremented once per village_wipe
     pending_prophecies: List[Prophecy] = field(default_factory=list)
+    # v6 — permanent abandoned vehicles. Each entry is (x, y, cycle_recorded).
+    # Capped at MAX_PERMANENT_WRECKS; oldest evicted FIFO. Persists across wipes.
+    permanent_wrecks: List[Tuple[float, float, int]] = field(default_factory=list)
+    # v6 — running count of cave fragments / clues discovered. Story progress.
+    cave_clues_found: int = 0
+    # v9 — adaptive antagonist: per-building creature pressure that survives
+    # village wipes so the forest "learns" which talismans bend. Bumped on
+    # every ``creature_breach``, decayed on clean nights by the Director.
+    talisman_failure_count: Dict[str, float] = field(default_factory=dict)
 
 
 @dataclass
@@ -431,7 +512,7 @@ class Config:
     # v2 — trust
     trust_baseline: float = 0.5
     # v4 — music box monster
-    music_box_interval_days: int = 3
+    music_box_interval_days: int = 8
     music_box_curiosity_radius: float = 80.0
     music_box_talisman_fail_prob: float = 0.05
     music_box_sanity_drain: float = 0.5
@@ -442,13 +523,19 @@ class Config:
     npc_sanity_break_fear: float = 70.0
     npc_sanity_break_prob: float = 0.04
     house_cooling_off_ticks: int = 800
-    npc_breach_death_prob: float = 0.30
+    npc_breach_death_prob: float = 0.50
     # v5 — SQLite memory + promotion
     db_path: str = "/data/from.db"
     memory_cycle_window: int = 50
     memory_flush_every_ticks: int = 60
     memory_recall_window_ticks: int = 1200
     npc_promotion_score_threshold: float = 1.0
+    # v9 — cognitive layer (Mind + Director + reflective thinking)
+    mind_reflect_every_ticks: int = 600
+    mind_goal_ttl_ticks: int = 3600
+    mind_npc_enabled: bool = True
+    llm_thinking_rpm: int = 2
+    deterministic_mode: bool = False
 
     @classmethod
     def from_env(cls, getenv: Callable[[str, Optional[str]], Optional[str]]) -> "Config":
@@ -500,7 +587,7 @@ class Config:
             yellow_hydra_max=_i("YELLOW_HYDRA_MAX", 3),
             lighthouse_call_tick_frac=_f("LIGHTHOUSE_CALL_TICK_FRAC", 0.4),
             trust_baseline=_f("TRUST_BASELINE", 0.5),
-            music_box_interval_days=_i("MUSIC_BOX_INTERVAL_DAYS", 3),
+            music_box_interval_days=_i("MUSIC_BOX_INTERVAL_DAYS", 8),
             music_box_curiosity_radius=_f("MUSIC_BOX_CURIOSITY_RADIUS", 80.0),
             music_box_talisman_fail_prob=_f("MUSIC_BOX_TALISMAN_FAIL_PROB", 0.05),
             music_box_sanity_drain=_f("MUSIC_BOX_SANITY_DRAIN", 0.5),
@@ -516,6 +603,11 @@ class Config:
             memory_flush_every_ticks=_i("MEMORY_FLUSH_EVERY_TICKS", 60),
             memory_recall_window_ticks=_i("MEMORY_RECALL_WINDOW_TICKS", 1200),
             npc_promotion_score_threshold=_f("NPC_PROMOTION_SCORE_THRESHOLD", 1.0),
+            mind_reflect_every_ticks=_i("MIND_REFLECT_EVERY_TICKS", 600),
+            mind_goal_ttl_ticks=_i("MIND_GOAL_TTL_TICKS", 3600),
+            mind_npc_enabled=(_s("MIND_NPC_ENABLED", "true").lower() in ("1", "true", "yes")),
+            llm_thinking_rpm=_i("LLM_THINKING_RPM", 2),
+            deterministic_mode=(_s("DETERMINISTIC_MODE", "false").lower() in ("1", "true", "yes")),
         )
 
 
@@ -632,6 +724,34 @@ class World:
     memory: Optional[Any] = None  # storage.Memory; attached by app.py at boot
     sub_mains: Set[str] = field(default_factory=set)  # npc ids that have been promoted
 
+    # --- v9: cognitive layer + AI Director ---
+    director: Optional[Any] = None  # agents.director.DirectorState; lazily attached
+
+    # --- v6: arrival cars + cave exploration ---
+    # Only one Car may be live in the world at a time; the model mirrors BusState.
+    active_car_id: Optional[str] = None  # id of the live Car in supernaturals, or None
+    # Holds the NPC arrival id while the car is in transit. When the car parks
+    # the NPC alights and is moved into world.agents.
+    car_pending_npc_id: Optional[str] = None
+
+    # --- v7: barn = food store; while destroyed, food regen collapses and
+    # characters must FORAGE at the windmill / lake area. Set by creatures.py
+    # when the barn is breached; cleared after engineers rebuild OR the timer
+    # expires (whichever comes first). Reset on village wipe.
+    barn_destroyed_until_tick: int = 0
+    # Pending engineer rebuild progress on the barn. Increments while an
+    # ENGINEER character is REPAIRING near the barn. When it reaches the
+    # threshold, barn_destroyed_until_tick clears early.
+    barn_repair_progress: float = 0.0
+
+    # --- v8: per-lot construction progress for newly-built houses. Each
+    # entry maps an EMPTY_LOTS lot_id to the accumulated build progress;
+    # once it crosses CONSTRUCTION_THRESHOLD the lot is converted to a
+    # Building and removed from the map. Cleared on wipe.
+    construction_progress: Dict[str, float] = field(default_factory=dict)
+    # Lots already turned into buildings — so we don't re-render or reuse.
+    consumed_lots: Set[str] = field(default_factory=set)
+
     @property
     def cycle_number(self) -> int:
         return self.village_wipes + 1
@@ -685,6 +805,37 @@ def _enrich_agent(agent: Agent, world: World) -> Dict[str, Any]:
     return d
 
 
+def _mind_aggregate(world: World) -> Dict[str, Any]:
+    """v9 — compact mind summary for the broadcast snapshot.
+
+    Aggregate-only: no per-actor PII on the wire. Dossier reads detail on
+    demand via the inspect endpoint.
+    """
+    director = getattr(world, "director", None)
+    pressure = float(getattr(director, "pressure", 0.0)) if director is not None else 0.0
+    spawn_mult = float(getattr(director, "spawn_rate_mult", 1.0)) if director is not None else 1.0
+    pop_stress = float(getattr(director, "pop_relief", 0.0)) if director is not None else 0.0
+    goals: Dict[str, int] = {}
+    beliefs_active = 0
+    for a in world.agents.values():
+        mind = getattr(a, "mind", None)
+        if mind is None:
+            continue
+        goal = getattr(mind, "active_goal", None)
+        if goal is not None:
+            key = getattr(getattr(goal, "kind", None), "value", "unknown")
+            goals[key] = goals.get(key, 0) + 1
+        bb = getattr(mind, "beliefs", None) or {}
+        beliefs_active += len(bb)
+    return {
+        "director_pressure": round(pressure, 3),
+        "spawn_rate_mult": round(spawn_mult, 2),
+        "pop_stress": round(pop_stress, 3),
+        "goals_by_kind": goals,
+        "beliefs_active": beliefs_active,
+    }
+
+
 def snapshot_dict(world: World) -> Dict[str, Any]:
     """The shape SocketIO emits as a 'tick' event. Frontend (Agent D) renders this.
 
@@ -705,6 +856,12 @@ def snapshot_dict(world: World) -> Dict[str, Any]:
         "food_supply": round(world.food_supply, 2),
         "food_capacity": world.food_capacity,
         "farm_health": round(world.farm_health, 3),
+        # v7 — barn status so the UI can flag the food-store outage.
+        "barn_destroyed_in_ticks": max(
+            0,
+            int(getattr(world, "barn_destroyed_until_tick", 0)) - world.tick_count,
+        ),
+        "barn_repair_progress": round(getattr(world, "barn_repair_progress", 0.0), 1),
         "yellow": {
             "mode": world.yellow_active.mode.value,
             "disguised_as": world.yellow_active.disguised_as,
@@ -722,6 +879,12 @@ def snapshot_dict(world: World) -> Dict[str, Any]:
             ],
             "building_breach_marks": dict(world.legacy.building_breach_marks),
             "pending_prophecies": len(world.legacy.pending_prophecies),
+            # v6 — permanent abandoned vehicles painted on the map every tick.
+            "permanent_wrecks": [
+                {"x": w[0], "y": w[1], "cycle": w[2]}
+                for w in world.legacy.permanent_wrecks
+            ],
+            "cave_clues_found": world.legacy.cave_clues_found,
         },
         "dreams": [
             {"character_id": d.character_id, "lines": list(d.lines),
@@ -757,6 +920,7 @@ def snapshot_dict(world: World) -> Dict[str, Any]:
             "db_attached": world.memory is not None,
             "sub_mains_alive": len(world.sub_mains),
         },
+        "mind": _mind_aggregate(world),
         "buildings": [
             {
                 "id": b.id,
@@ -831,6 +995,15 @@ class Metric:
     SUB_MAINS_ALIVE = "from_sim_sub_mains_alive"                    # gauge
     SUB_MAINS_DEAD_TOTAL = "from_sim_sub_mains_dead_total"          # gauge cumulative
     INVENTORY_ITEMS = "from_sim_inventory_items"                    # gauge: total items held
+    # v9 — cognitive layer
+    MIND_BELIEFS_ACTIVE = "from_sim_mind_beliefs_active"            # gauge: live beliefs across all minds
+    MIND_GOALS_ACTIVE = "from_sim_mind_goals_active"                # gauge: live goals (attr: kind)
+    MIND_REFLECTIONS_TOTAL = "from_sim_mind_reflections_total"      # counter (attr: actor)
+    DIRECTOR_PRESSURE = "from_sim_director_pressure"                # gauge 0..1
+    DIRECTOR_SPAWN_MULT = "from_sim_director_spawn_mult"            # gauge
+    DIRECTOR_POP_STRESS = "from_sim_director_population_stress"     # gauge 0..0.4
+    YELLOW_TARGET_ROLE = "from_sim_yellow_target_role"              # counter (attr: role)
+    CREATURES_NIGHT_WAVES_TOTAL = "from_sim_creatures_night_waves_total"  # counter
 
 
 PHASE_TO_NUM = {Phase.DAY: 0, Phase.DUSK: 1, Phase.NIGHT: 2, Phase.DAWN: 3}
@@ -845,7 +1018,7 @@ PHASE_TO_NUM = {Phase.DAY: 0, Phase.DUSK: 1, Phase.NIGHT: 2, Phase.DAWN: 3}
 # Coordinates match the hand-drawn Fromville map (viewBox 0 0 1000 700).
 BUILDING_LAYOUT: List[Tuple[str, str, float, float, int, bool, str]] = [
     # (id, name, x, y, footprint, has_talisman, role_tag)
-    ("colony_house",     "Colony House",            385, 420, 10, True,  "colony"),
+    ("colony_house",     "Colony House",            385, 420, 14, True,  "colony"),
     ("green_house",      "Green House",             418, 400,  3, True,  "house"),
     ("shed",             "Shed",                    442, 388,  1, False, "shed"),
     ("clinic",           "Clinic",                  478, 402,  4, True,  "clinic"),
@@ -921,6 +1094,71 @@ LIGHTHOUSE_XY: Tuple[float, float] = (140.0, 585.0)
 # and where the box can be destroyed. Maps to the DUNGEON landmark on the map.
 RUINS_XY: Tuple[float, float] = (240.0, 650.0)
 
+# v6 — landmarks that previously sat unused on the map. Lifted from the SVG so
+# Python code can target them directly. Each one drives a distinct character
+# state's destination (see ``_target_for_role_and_state`` in characters.py).
+CAVE_ENTRY_XY: Tuple[float, float] = (260.0, 510.0)
+CRASH_SITE_XY: Tuple[float, float] = (615.0, 335.0)
+HIDEOUT_TRUCK_XY: Tuple[float, float] = (275.0, 610.0)
+CHOOSING_STONE_XY: Tuple[float, float] = (390.0, 670.0)
+WINDMILL_XY: Tuple[float, float] = (465.0, 195.0)
+GRAVE_MOUNDS: List[Tuple[float, float]] = [(240.0, 650.0), (390.0, 670.0)]
+CAR_GRAVEYARD_XY: Tuple[float, float] = (470.0, 615.0)
+
+# v7 — forage zones. When the barn is destroyed the village can't store
+# harvest, so foragers walk to one of these (the windmill area for game and
+# berries, the lakeside river for fish) and bring food back. Two locations so
+# the foragers spread out instead of all clustering on the same point.
+FORAGE_ZONES: List[Tuple[float, float]] = [
+    (465.0, 195.0),   # near the windmill — wild game / berries
+    (745.0, 240.0),   # lakeside "river" — fish
+    (155.0, 220.0),   # the small western pond — secondary game route
+]
+# How much food a single completed forage run returns to the larder.
+FORAGE_FOOD_PAYOFF = 18.0
+# How long an agent spends gathering once they arrive at a forage zone.
+FORAGE_TICKS_TO_GATHER = 35
+# Engineer barn-repair: progress per ENGINEER-REPAIRING tick near the barn,
+# threshold to clear the destroyed flag.
+BARN_REPAIR_PER_TICK = 0.6
+BARN_REPAIR_THRESHOLD = 60.0
+# How long the barn stays out of action by default if no repair happens.
+# 2 sim-days at the current 2 sim-minutes/tick. ~1440 ticks total.
+BARN_DOWN_DEFAULT_TICKS = 1440
+
+# v8 — house destruction + rebuild thresholds. Each unprotected breach
+# increments damage by 1; at the threshold the house collapses. Engineers
+# (or any character in REPAIRING state) near a destroyed house contribute
+# to rebuild_progress; once it crosses HOUSE_REBUILD_THRESHOLD the house
+# is rebuilt without its original talisman.
+HOUSE_DESTRUCTION_THRESHOLD = 3
+HOUSE_REBUILD_PER_TICK = 0.4
+HOUSE_REBUILD_THRESHOLD = 50.0
+
+# v8 — talisman crack. Every tick, an occupant whose sanity is below
+# TALISMAN_CRACK_SANITY and fear is above TALISMAN_CRACK_FEAR has this
+# probability of cracking and letting a creature concept past the
+# threshold. The talisman is permanently removed from that house until
+# rebuild + re-find.
+TALISMAN_CRACK_SANITY = 0.18    # 0..1 scale
+TALISMAN_CRACK_FEAR = 78.0      # 0..100 scale
+TALISMAN_CRACK_PROB = 0.0015    # ~1 in 670 ticks per qualifying occupant
+
+# v6 — Car arrival path. Shares the S-curve in/out with the bus but parks at a
+# different spur point so the two vehicles can both be on-map without overlap.
+CAR_PATH_IN: List[Tuple[float, float]] = [
+    (-20, 200), (80, 240), (240, 320), (395, 405), (490, 415),
+]
+CAR_PARK_XY: Tuple[float, float] = (495, 430)
+CAR_PATH_OUT: List[Tuple[float, float]] = [
+    (495, 430), (565, 425), (640, 555), (740, 680),
+]
+# After this many path-out waypoints, the car breaks down and becomes a wreck.
+CAR_BREAKDOWN_AFTER_WAYPOINTS = 2
+# How many permanent abandoned wrecks the map can carry before the oldest is
+# evicted. Five is enough that long-running sessions feel scarred.
+MAX_PERMANENT_WRECKS = 5
+
 # v4: talisman residential houses NPCs may pick as home (subset of layout).
 # Order matters for stable home-assignment; colony_house listed first so the
 # 4× weight in npcs.py preserves "the big house" feel.
@@ -928,3 +1166,26 @@ NPC_HOME_BUILDINGS: List[str] = [
     "colony_house", "matthews_home", "lius_home", "myers_home",
     "green_house", "grey_house", "blue_house",
 ]
+
+# v8 — empty lots that survivors can build into new houses when the existing
+# residences fill up. Each tuple is (lot_id, x, y) on the painted map in
+# spots that aren't already a building. tick_construction in
+# agents/construction.py consumes these one at a time as homeless NPCs
+# accumulate and engineers spend ticks at the lot.
+EMPTY_LOTS: List[Tuple[str, float, float]] = [
+    ("lot_north_east",  525.0, 410.0),
+    ("lot_south_east",  550.0, 535.0),
+    ("lot_south_west",  355.0, 575.0),
+    ("lot_north_west",  340.0, 395.0),
+    ("lot_far_east",    595.0, 470.0),
+    ("lot_far_west",    295.0, 460.0),
+]
+
+# Each new house starts as a small structure: 4-slot capacity, no talisman.
+NEW_HOUSE_CAPACITY = 4
+# Construction is intentionally slow so the user can see it happen over a
+# sim-day. ~80 ticks of survivor work to finish a house.
+CONSTRUCTION_PER_TICK = 1.0
+CONSTRUCTION_THRESHOLD = 80.0
+# Min distance an engineer must be from the lot to count as "on site".
+CONSTRUCTION_RADIUS_PX = 32.0

--- a/from-simulation/app/contracts.py
+++ b/from-simulation/app/contracts.py
@@ -701,51 +701,78 @@ PHASE_TO_NUM = {Phase.DAY: 0, Phase.DUSK: 1, Phase.NIGHT: 2, Phase.DAWN: 3}
 # ---------------------------------------------------------------------------
 
 
+# 18 town buildings + the Lighthouse (separate clearing). 5 talisman-protected.
+# Coordinates match the hand-drawn Fromville map (viewBox 0 0 1000 700).
 BUILDING_LAYOUT: List[Tuple[str, str, float, float, int, bool, str]] = [
     # (id, name, x, y, footprint, has_talisman, role_tag)
-    ("sheriff_house", "Sheriff's House", 350, 360, 4, True, "sheriff"),
-    ("matthews_house", "Matthews House", 520, 380, 5, True, "matthews"),
-    ("church", "Church", 430, 310, 6, True, "church"),
-    ("diner", "Diner", 580, 330, 4, False, "diner"),
-    ("clinic", "Clinic", 470, 420, 4, True, "clinic"),
-    ("camper", "Boyd's Camper", 300, 420, 2, False, "camper"),
-    ("colony_house", "Colony House", 780, 180, 10, True, "colony"),
-    ("lighthouse", "Lighthouse", 500, 560, 1, False, "lighthouse"),
+    ("colony_house",     "Colony House",            385, 420, 10, True,  "colony"),
+    ("green_house",      "Green House",             418, 400,  3, False, "house"),
+    ("shed",             "Shed",                    442, 388,  1, False, "shed"),
+    ("clinic",           "Clinic",                  478, 402,  4, True,  "clinic"),
+    ("root_cellar",      "Root Cellar",             495, 432,  2, False, "cellar"),
+    ("choosing_stone",   "Choosing Ceremony Stone", 390, 470,  0, False, "stone"),
+    ("church",           "Church",                  385, 510,  6, True,  "church"),
+    ("grey_house",       "Grey House",              420, 490,  3, False, "house"),
+    ("blue_house",       "Blue House",              440, 490,  3, False, "house"),
+    ("pool",             "Pool",                    462, 478,  0, False, "pool"),
+    ("lius_home",        "Liu's Home",              478, 462,  4, False, "house"),
+    ("bar",              "Bar",                     510, 458,  3, False, "bar"),
+    ("barn",             "Barn",                    555, 454,  5, False, "barn"),
+    ("sheriff_office",   "Sheriff's Office",        490, 510,  4, True,  "sheriff"),
+    ("abandoned_bus",    "Abandoned Bus",           460, 538,  0, False, "wreck"),
+    ("matthews_home",    "Matthews' Home",          430, 545,  5, True,  "matthews"),
+    ("diner",            "Diner",                   405, 530,  4, False, "diner"),
+    ("myers_home",       "Myers' Home",             382, 552,  3, False, "house"),
+    # Lighthouse lives in its own clearing south-west of town.
+    ("lighthouse",       "Lighthouse",              140, 585,  1, False, "lighthouse"),
 ]
 
-# Faraway Trees scattered around the forest perimeter
+# Faraway / Bottle Trees scattered around the surrounding land.
+# Tree 1 (Boyd / Sara), Tree 2 (Victor / Ethan), Tree 3 (south).
 FARAWAY_TREES: List[Tuple[float, float]] = [
-    (80, 120),
-    (920, 150),
-    (60, 560),
-    (940, 580),
-    (500, 40),
+    (560, 55),
+    (735, 485),
+    (575, 660),
 ]
 
-# Forest-edge spawn points for creatures (inner edge of forest ring)
+# Creature spawn points — 16 around a ring centred on the town cluster
+# (cx=465, cy=475, rx=220, ry=165), matching the generated wedges in the
+# hand-drawn map's spawn-toggle overlay.
+import math as _math
+_RING_CX, _RING_CY, _RING_RX, _RING_RY = 465.0, 475.0, 220.0, 165.0
 FOREST_SPAWN_POINTS: List[Tuple[float, float]] = [
-    (140, 110), (300, 90), (500, 85), (700, 95), (860, 130),
-    (920, 280), (940, 430), (900, 580),
-    (700, 620), (500, 640), (300, 625), (130, 590),
-    (90, 440), (70, 290), (180, 200), (820, 220),
+    (
+        _RING_CX + _math.cos((i / 16.0) * _math.tau - _math.pi / 2) * _RING_RX,
+        _RING_CY + _math.sin((i / 16.0) * _math.tau - _math.pi / 2) * _RING_RY,
+    )
+    for i in range(16)
 ]
+del _math, _RING_CX, _RING_CY, _RING_RX, _RING_RY
 
-# NPC "intake" points — where new arrivals appear from the forest
+# NPC arrival points — the S-curve road enters from the west, leaves to the
+# south-east, and has a spur into town. New arrivals appear at road edges.
 NPC_INTAKE_POINTS: List[Tuple[float, float]] = [
-    (140, 350), (860, 350), (500, 90), (500, 620),
+    (20, 210),    # west end of the road, off-map entry
+    (760, 720),   # south-east end of the road, off-map exit
+    (240, 320),   # along the road between the two
+    (565, 540),   # spur into town from the south
 ]
 
-# Yellow Man visible-march path (sequence of waypoints)
+# Yellow Man visible-march path — west to east along the road through town.
 YELLOW_MARCH_PATH: List[Tuple[float, float]] = [
-    (90, 350), (250, 360), (400, 380), (520, 380),
-    (680, 360), (800, 320), (900, 280),
+    (0, 200), (160, 280), (240, 320), (395, 405),
+    (555, 405), (575, 425), (565, 555), (720, 690),
 ]
 
-# Bus path — drives in along the dirt road, parks near the diner, drives out the other way.
+# Bus path — drives in along the S-curve, parks just off the spur near the
+# diner (NOT the abandoned wreck, which is a static map feature), drives out.
 BUS_PATH_IN: List[Tuple[float, float]] = [
-    (90, 320), (200, 330), (340, 340), (480, 340), (570, 340),
+    (-20, 200), (80, 240), (240, 320), (395, 405), (520, 410),
 ]
-BUS_PARK: Tuple[float, float] = (600, 330)  # next to the diner
+BUS_PARK: Tuple[float, float] = (520, 425)   # on the road spur near the diner
 BUS_PATH_OUT: List[Tuple[float, float]] = [
-    (600, 330), (720, 320), (840, 290), (920, 250),
+    (520, 425), (575, 425), (565, 555), (720, 690), (760, 720),
 ]
+
+# Lighthouse direct-coord alias (lighthouse.py and bus.py read this).
+LIGHTHOUSE_XY: Tuple[float, float] = (140.0, 585.0)

--- a/from-simulation/app/events.py
+++ b/from-simulation/app/events.py
@@ -1,0 +1,28 @@
+"""
+Event buffer factory.
+
+A small module that returns the rolling event buffer used by World.events.
+CPython's `collections.deque` has thread-safe `append` semantics with the GIL,
+which is all the simulation thread + Flask request thread need. No explicit
+lock is required for `append`, `popleft`, or iteration with `list(deque)`.
+
+The buffer is bounded so memory never grows unboundedly across long cycles.
+"""
+
+from __future__ import annotations
+
+import collections
+from typing import Deque
+
+from contracts import Event
+
+
+_BUFFER_MAX = 200
+
+
+def make_event_buffer() -> Deque[Event]:
+    """Return a new bounded deque to plug into ``World.events``.
+
+    Wired into the world by ``simulation.start()`` after telemetry is up.
+    """
+    return collections.deque(maxlen=_BUFFER_MAX)

--- a/from-simulation/app/legacy.py
+++ b/from-simulation/app/legacy.py
@@ -1,0 +1,229 @@
+"""
+Cross-cycle memory — the only thing the universe remembers across wipes.
+
+Two responsibilities:
+
+1. ``distill_legacy_from(world)`` — called by ``reset_world`` *before* it
+   bulldozes the world. Scans the dying cycle's events and applies their
+   lessons to ``world.legacy``: hash marks for every breach, drift deltas
+   for every named character who died, survival rolls for journal fragments,
+   trauma counters for repeated deaths.
+
+2. ``record(world, template_key, **slots)`` — the journal narrator. Agent B
+   calls this on canonical events (creature_breach, char_death, homecoming,
+   imposter_banished, village_wipe, outsider_died). Each call appends a one-
+   line ``JournalFragment`` keyed off short lyrical templates.
+
+The legacy object lives on World and survives reset. After many cycles it
+becomes the only continuous thread linking otherwise-isolated universes.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from contracts import (
+    Event,
+    JournalFragment,
+    Legacy,
+    World,
+)
+
+
+# ---------------------------------------------------------------------------
+# Journal templates — one-line lyrical summaries, slot interpolation.
+# ---------------------------------------------------------------------------
+
+
+# Each template family has multiple variants; the rng picks one. Templates use
+# ``{slot}`` substitution. Slot names match the kwargs passed to ``record``.
+_TEMPLATES: Dict[str, List[str]] = {
+    "creature_breach": [
+        "The {building} door did not hold this night.",
+        "A creature found a way in through the {building}.",
+        "Talisman or no, the {building} was breached.",
+    ],
+    "char_death": [
+        "{name} did not live to see another dawn.",
+        "We lost {name} in the dark.",
+        "{name} was taken from us. Again, perhaps. None of us is sure.",
+    ],
+    "homecoming": [
+        "{name} came back along the forest road.",
+        "{name} returned. Older somehow. Quieter.",
+        "{name} walked out of the trees. We did not ask where they had been.",
+    ],
+    "imposter_banished": [
+        "We sent the yellow thing away from the {building}.",
+        "The imposter was named, and named, and named again. It left.",
+        "We voted. Whatever it was, it is gone.",
+    ],
+    "village_wipe": [
+        "And then there was nothing.",
+        "The town went quiet in a way it should not be possible to go quiet.",
+        "We failed. The cycle closed. Pages from this one will not all be saved.",
+    ],
+    "outsider_died": [
+        "The {name} from the bus did not get back on it.",
+        "{name} came here looking for {goal}, and found something else.",
+    ],
+    "expedition_returned": [
+        "Boyd brought food back from the trees, and most of the party.",
+        "We ate that night. We tried not to count the empty chairs.",
+    ],
+    "lighthouse_enter": [
+        "{name} walked into the Lighthouse and did not walk out.",
+        "{name} answered the Lighthouse. We heard them on the wind after.",
+    ],
+}
+
+
+def _pick_template(world: World, key: str) -> Optional[str]:
+    pool = _TEMPLATES.get(key)
+    if not pool:
+        return None
+    return world.rng.choice(pool)
+
+
+# ---------------------------------------------------------------------------
+# Public: record a journal fragment
+# ---------------------------------------------------------------------------
+
+
+def record(world: World, key: str, **slots: Any) -> None:
+    """Append one journal fragment about a canonical event.
+
+    Quietly skips if the key is unknown — keeps callers from blowing up on a
+    typo. The fragment is pristine on creation; ``distill_legacy_from`` rolls
+    survival/burning at each wipe.
+    """
+    template = _pick_template(world, key)
+    if template is None:
+        return
+    try:
+        text = template.format(**slots)
+    except (KeyError, IndexError):
+        text = template  # missing slot — just keep the raw template
+    world.legacy.journal_fragments.append(
+        JournalFragment(
+            cycle_recorded=world.legacy.cycles_witnessed + 1,  # the cycle currently being lived
+            text=text,
+            burned=0.0,
+        )
+    )
+    world.emit(
+        Event(
+            tick=world.tick_count,
+            type="journal_entry",
+            subject="khatri",
+            detail=text,
+            severity="info",
+        )
+    )
+
+
+# ---------------------------------------------------------------------------
+# Distillation — what the dying cycle teaches the Legacy.
+# ---------------------------------------------------------------------------
+
+
+def distill_legacy_from(world: World) -> None:
+    """Apply the dying cycle's lessons to ``world.legacy``.
+
+    Called from ``reset_world`` BEFORE any bulldozing happens. Reads the current
+    event buffer + character state. Writes to:
+
+      * ``legacy.building_breach_marks``     (every creature_breach this cycle)
+      * ``legacy.personality_drift``         (every char who died — small drift)
+      * ``legacy.deaths_by_creature``        (per-character death counter)
+      * ``legacy.journal_fragments[*].burned`` (each fragment rolls a survival)
+
+    Pending prophecies do NOT get burned — they're the bridge between cycles.
+    """
+    cfg = world.config
+    rng = world.rng
+
+    # --- Hash marks: scan THIS cycle's events for creature_breach.
+    for evt in list(world.events):
+        if evt.type == "creature_breach":
+            # The subject is the building id (per agents/creatures.py convention).
+            bid = evt.subject
+            world.legacy.building_breach_marks[bid] = (
+                world.legacy.building_breach_marks.get(bid, 0) + 1
+            )
+            world.emit(
+                Event(
+                    tick=world.tick_count,
+                    type="hash_mark_added",
+                    subject=bid,
+                    detail=f"hash mark count now {world.legacy.building_breach_marks[bid]}",
+                    severity="info",
+                )
+            )
+
+    # --- Personality drift: every named character who died THIS cycle.
+    # We read directly off the agents dict — DEAD characters are still there.
+    for agent in list(world.agents.values()):
+        kind = getattr(agent, "kind", None)
+        # Match only named characters by kind.value to avoid an enum import dance.
+        if kind is None or getattr(kind, "value", "") != "character":
+            continue
+        status_val = getattr(getattr(agent, "status", None), "value", None)
+        if status_val != "DEAD":
+            continue
+        name = getattr(agent, "name", agent.id)
+        drift = world.legacy.personality_drift.setdefault(name, {})
+        # Trauma rules: a creature death raises paranoid + drops brave;
+        # an irrational-act death raises devout (the show's logic).
+        cause = getattr(agent, "death_cause", "creature")
+        if cause == "creature":
+            drift["paranoid"] = drift.get("paranoid", 0.0) + cfg.personality_drift_rate
+            drift["brave"] = drift.get("brave", 0.0) - cfg.personality_drift_rate * 0.5
+            world.legacy.deaths_by_creature[name] = world.legacy.deaths_by_creature.get(name, 0) + 1
+        else:
+            drift["devout"] = drift.get("devout", 0.0) + cfg.personality_drift_rate
+            drift["paranoid"] = drift.get("paranoid", 0.0) + cfg.personality_drift_rate * 0.3
+        # Cap drift magnitudes — personalities don't pendulum past +/- 0.4.
+        for trait, v in list(drift.items()):
+            drift[trait] = max(-0.4, min(0.4, v))
+        world.emit(
+            Event(
+                tick=world.tick_count,
+                type="personality_drift",
+                subject=name,
+                detail=f"drift now {drift}",
+                severity="info",
+            )
+        )
+
+    # --- Journal fragment survival: each pristine fragment rolls.
+    survived: List[JournalFragment] = []
+    for frag in world.legacy.journal_fragments:
+        # Fragments already burned past 0.85 are too far gone — drop them.
+        if frag.burned > 0.85:
+            world.emit(
+                Event(
+                    tick=world.tick_count,
+                    type="journal_page_burns",
+                    subject="khatri",
+                    detail=f"page from cycle {frag.cycle_recorded} crumbled to ash",
+                    severity="info",
+                )
+            )
+            continue
+        if rng.random() <= cfg.journal_fragment_survival_prob:
+            # Survived but partially burned.
+            frag.burned = min(1.0, frag.burned + rng.uniform(0.05, 0.2))
+            survived.append(frag)
+        else:
+            world.emit(
+                Event(
+                    tick=world.tick_count,
+                    type="journal_page_burns",
+                    subject="khatri",
+                    detail=f"page from cycle {frag.cycle_recorded} lost to the wipe",
+                    severity="info",
+                )
+            )
+    # Cap to last 40 fragments overall so the legacy doesn't grow unboundedly.
+    world.legacy.journal_fragments = survived[-40:]

--- a/from-simulation/app/legacy.py
+++ b/from-simulation/app/legacy.py
@@ -95,6 +95,10 @@ _TEMPLATES: Dict[str, List[str]] = {
         "{npc} opened the door at {building}. Not knowing what they did.",
         "{npc} unlocked the {building} from the inside. Fear made them do it.",
     ],
+    "npc_promoted": [
+        "We found a name for {new_name}. {reason}.",
+        "{new_name} did something we will remember. {reason}.",
+    ],
     "destroy_music_box_called": [
         "The Father called a meeting. Sara had told them where to take it.",
         "We voted to destroy the box. Most of us, anyway.",
@@ -135,6 +139,15 @@ def record(world: World, key: str, **slots: Any) -> None:
             burned=0.0,
         )
     )
+    # v5 — persist immediately to the durable journal table. Journal records
+    # are small + rare, so we don't bother buffering them.
+    if getattr(world, "memory", None) is not None:
+        try:
+            world.memory.record_journal_fragment(
+                world, world.legacy.journal_fragments[-1]
+            )
+        except Exception:
+            pass
     world.emit(
         Event(
             tick=world.tick_count,

--- a/from-simulation/app/legacy.py
+++ b/from-simulation/app/legacy.py
@@ -103,6 +103,42 @@ _TEMPLATES: Dict[str, List[str]] = {
         "The Father called a meeting. Sara had told them where to take it.",
         "We voted to destroy the box. Most of us, anyway.",
     ],
+    # v6 — cave exploration outcomes.
+    "cave_fragment_found": [
+        "{name} brought back something from the caves. Old script we don't recognise.",
+        "{name} returned from the cave with a relic. Khatri studied it for hours.",
+        "{name} dug something out of the cave wall. The dust would not brush off.",
+    ],
+    "cave_clue_found": [
+        "{name} pocketed something from the caves. They won't say what.",
+        "{name} came back from the caves quiet. Their hands were closed too tight.",
+    ],
+    "cave_lost": [
+        "{name} did not return from the caves. We waited at the entrance till dawn.",
+        "We searched the caves for {name}. We did not find them.",
+    ],
+    # v6 — car arrivals + their slow deaths on the road.
+    "car_arrival": [
+        "A car came down the road. We weren't expecting one. {name} stepped out.",
+        "Another one tried the road. {name} survived the drive.",
+    ],
+    "car_broke_down": [
+        "They tried to leave. The car gave up halfway. It joins the others now.",
+        "The engine died on the bend. Nothing leaves Fromville on wheels.",
+    ],
+    # v7 — barn destroyed + foraging fallback.
+    "barn_destroyed": [
+        "The barn is gone. The food store with it. We will go hungry until it's rebuilt.",
+        "They came through the barn. The harvest is open to the rain.",
+    ],
+    "barn_rebuilt": [
+        "{name} put the barn back up. We can stop the foraging runs.",
+        "The barn stands again. We slept easier that night.",
+    ],
+    "forage_returned": [
+        "{name} came back from the river with food.",
+        "{name} found enough by the windmill to get us through the day.",
+    ],
 }
 
 

--- a/from-simulation/app/legacy.py
+++ b/from-simulation/app/legacy.py
@@ -75,6 +75,30 @@ _TEMPLATES: Dict[str, List[str]] = {
         "{name} walked into the Lighthouse and did not walk out.",
         "{name} answered the Lighthouse. We heard them on the wind after.",
     ],
+    "music_box_appeared": [
+        "A music box appeared by the {location}.",
+        "Something old and gold was left for us to find.",
+    ],
+    "break_death": [
+        "{name} screamed in their sleep and broke.",
+        "{name} did not wake. The music had reached them.",
+    ],
+    "steal_event": [
+        "Three did not wake. The cicadas came.",
+        "They were taken. Their breath was still in their chests but they were not in them.",
+    ],
+    "music_box_destroyed": [
+        "{carrier} brought it back to the Dungeon. The melody stopped.",
+        "We ended it where it began. {carrier} held the torch.",
+    ],
+    "npc_sanity_break": [
+        "{npc} opened the door at {building}. Not knowing what they did.",
+        "{npc} unlocked the {building} from the inside. Fear made them do it.",
+    ],
+    "destroy_music_box_called": [
+        "The Father called a meeting. Sara had told them where to take it.",
+        "We voted to destroy the box. Most of us, anyway.",
+    ],
 }
 
 

--- a/from-simulation/app/llm/actions.py
+++ b/from-simulation/app/llm/actions.py
@@ -1,0 +1,50 @@
+"""
+Anthropic tool-schema construction for the LLM decider.
+
+The simulation exposes a single tool — ``choose_action`` — whose ``state``
+parameter is an enum constrained to the *menu* of plausible next states the
+calling agent has scored. This module produces the JSON-schema-style dict the
+Anthropic SDK expects.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from contracts import State
+
+
+def build_tool_schema(menu: List[State]) -> Dict[str, Any]:
+    """Build the ``tools=[...]`` element for an Anthropic Messages call.
+
+    ``menu`` is the enum-constrained list of allowed next states. We pass each
+    state's ``.value`` (string) so the model returns canonical strings the
+    caller can map back to ``State[...]``.
+    """
+    if not menu:
+        raise ValueError("build_tool_schema requires a non-empty menu")
+    enum_values = [s.value for s in menu]
+    return {
+        "name": "choose_action",
+        "description": (
+            "Choose the agent's next FSM state from the provided menu, based on "
+            "the world context. Always pick exactly one state and explain the "
+            "rationale in one short sentence."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "state": {
+                    "type": "string",
+                    "enum": enum_values,
+                    "description": "Next FSM state for this agent.",
+                },
+                "reason": {
+                    "type": "string",
+                    "description": "One-sentence rationale (<= 140 chars).",
+                },
+            },
+            "required": ["state", "reason"],
+            "additionalProperties": False,
+        },
+    }

--- a/from-simulation/app/llm/decider.py
+++ b/from-simulation/app/llm/decider.py
@@ -68,7 +68,14 @@ class LLMDecider:
     def __init__(self, config: Config, telemetry: Optional[SimTelemetry] = None) -> None:
         self.config = config
         self.telemetry = telemetry
-        self.enabled = bool(config.anthropic_api_key) and anthropic is not None
+        # Honour the deterministic-mode gate: even if a key is set, refuse to
+        # call out so SEED-pinned runs stay byte-identical.
+        deterministic = bool(getattr(config, "deterministic_mode", False))
+        self.enabled = (
+            bool(config.anthropic_api_key)
+            and anthropic is not None
+            and not deterministic
+        )
         self._client = None
         if self.enabled:
             try:
@@ -76,8 +83,20 @@ class LLMDecider:
             except Exception:
                 _log.exception("anthropic client init failed; disabling LLM decider")
                 self.enabled = False
-        self._bucket = _TokenBucket(config.llm_global_rpm)
+        # v9 — split the budget. State-choice keeps the lion's share, the
+        # rest funds reflective "thinking" calls (Yellow Man tactics, Mind
+        # reflection labels). If the split would zero out either bucket, we
+        # back off to the legacy single bucket sized at ``llm_global_rpm``.
+        thinking_rpm = max(0, int(getattr(config, "llm_thinking_rpm", 0)))
+        state_rpm = max(1, int(config.llm_global_rpm) - thinking_rpm)
+        self._state_bucket = _TokenBucket(state_rpm)
+        self._thinking_bucket = _TokenBucket(max(1, thinking_rpm)) if thinking_rpm > 0 else self._state_bucket
+        # Compat alias — some callers still reach for ``_bucket``.
+        self._bucket = self._state_bucket
         self._last_tick_by_actor: dict[str, int] = {}
+        # Separate cooldown table for thinking calls so a reflection doesn't
+        # block the next state choice (and vice versa).
+        self._last_think_tick_by_actor: dict[str, int] = {}
         # Bind the cache to the instance, keyed on the parts we want.
         self._cached = functools.lru_cache(maxsize=2048)(self._call_uncached)
         # World handle for pushing narrations; attached lazily by app.py.
@@ -108,9 +127,9 @@ class LLMDecider:
         if current_tick - last < self.config.llm_min_tick_gap:
             return None
 
-        # Token bucket guard.
-        if not self._bucket.try_consume():
-            self._inc_counter("rate_limited", actor_id)
+        # Token bucket guard (state-choice slice).
+        if not self._state_bucket.try_consume():
+            self._inc_counter("rate_limited", actor_id, purpose="state_choice")
             return None
 
         fear_bucket = int(min(100.0, max(0.0, fear))) // 25  # 0..4
@@ -118,26 +137,26 @@ class LLMDecider:
         try:
             result = self._cached(actor_id, current_state.value, phase.value, fear_bucket, menu_key, extra_context)
         except Exception:
-            self._inc_counter("error", actor_id)
+            self._inc_counter("error", actor_id, purpose="state_choice")
             return None
 
         # Cooldown is consumed whether or not we got a usable answer.
         self._last_tick_by_actor[actor_id] = current_tick
 
         if result is None:
-            self._inc_counter("no_decision", actor_id)
+            self._inc_counter("no_decision", actor_id, purpose="state_choice")
             return None
 
         state_str, reason = result
         try:
             chosen = State(state_str)
         except ValueError:
-            self._inc_counter("invalid_state", actor_id)
+            self._inc_counter("invalid_state", actor_id, purpose="state_choice")
             return None
         if chosen not in menu:
-            self._inc_counter("off_menu", actor_id)
+            self._inc_counter("off_menu", actor_id, purpose="state_choice")
             return None
-        self._inc_counter("ok", actor_id)
+        self._inc_counter("ok", actor_id, purpose="state_choice")
         # Publish the narration line if we've been attached to a world.
         if self._world is not None and reason:
             try:
@@ -149,13 +168,57 @@ class LLMDecider:
                 pass
         return chosen, reason
 
+    # --------------------------------------------- public API — generic picker
+    def maybe_pick_string(
+        self,
+        actor_id: str,
+        options: List[str],
+        current_tick: int,
+        system: str,
+        prompt: str,
+    ) -> Optional[str]:
+        """Pick one of ``options`` for a non-State decision (e.g. Yellow Man
+        imposter action). Uses the thinking bucket and a longer cooldown so
+        these calls never starve the state-choice budget.
+
+        Returns the chosen string (must be a member of ``options``) or None
+        when disabled / rate-limited / off-menu.
+        """
+        if not self.enabled or not options:
+            return None
+        # Per-actor thinking cooldown — 4x the state cooldown so reflective
+        # calls are rarer than tactical ones.
+        last = self._last_think_tick_by_actor.get(actor_id, -10**9)
+        cd = max(60, int(self.config.llm_min_tick_gap) * 4)
+        if current_tick - last < cd:
+            return None
+        if not self._thinking_bucket.try_consume():
+            self._inc_counter("rate_limited", actor_id, purpose="thinking")
+            return None
+        try:
+            chosen = self._call_pick_string(actor_id, tuple(options), system, prompt)
+        except Exception:
+            self._inc_counter("error", actor_id, purpose="thinking")
+            return None
+        self._last_think_tick_by_actor[actor_id] = current_tick
+        if chosen is None:
+            self._inc_counter("no_decision", actor_id, purpose="thinking")
+            return None
+        if chosen not in options:
+            self._inc_counter("off_menu", actor_id, purpose="thinking")
+            return None
+        self._inc_counter("ok", actor_id, purpose="thinking")
+        return chosen
+
     # ------------------------------------------------------- internals
-    def _inc_counter(self, outcome: str, actor: str) -> None:
+    def _inc_counter(self, outcome: str, actor: str, *, purpose: str = "state_choice") -> None:
         if self.telemetry is None:
             return
         try:
             self.telemetry.counter_inc(
-                Metric.LLM_CALLS_TOTAL, 1.0, {"outcome": outcome, "actor": actor}
+                Metric.LLM_CALLS_TOTAL,
+                1.0,
+                {"outcome": outcome, "actor": actor, "purpose": purpose},
             )
         except Exception:
             pass
@@ -209,4 +272,60 @@ class LLMDecider:
                 reason = inp.get("reason", "") or ""
                 if isinstance(state_str, str):
                     return state_str, reason
+        return None
+
+    def _call_pick_string(
+        self,
+        actor_id: str,
+        options: Tuple[str, ...],
+        system: str,
+        prompt: str,
+    ) -> Optional[str]:
+        """Generic single-choice picker. Uses a dynamic tool whose ``choice``
+        enum is the options tuple, so the model is structurally constrained
+        to a member of the menu. Returns the chosen string or None."""
+        if self._client is None or not options:
+            return None
+        tool = {
+            "name": "pick",
+            "description": "Pick one option from the menu.",
+            "input_schema": {
+                "type": "object",
+                "properties": {
+                    "choice": {"type": "string", "enum": list(options)},
+                    "reason": {"type": "string"},
+                },
+                "required": ["choice"],
+                "additionalProperties": False,
+            },
+        }
+        try:
+            resp = self._client.messages.create(
+                model=self.config.llm_model,
+                max_tokens=200,
+                system=system,
+                tools=[tool],
+                tool_choice={"type": "tool", "name": "pick"},
+                messages=[{"role": "user", "content": prompt}],
+            )
+        except Exception:
+            _log.debug("LLM pick_string failed", exc_info=True)
+            return None
+        for block in getattr(resp, "content", []) or []:
+            if getattr(block, "type", None) == "tool_use" and getattr(block, "name", None) == "pick":
+                inp = getattr(block, "input", {}) or {}
+                choice = inp.get("choice")
+                reason = inp.get("reason", "") or ""
+                if isinstance(choice, str):
+                    # Optionally surface a one-line rationale to the UI narration.
+                    if self._world is not None and reason:
+                        try:
+                            self._world.narrations.append(
+                                {"actor": actor_id, "reason": reason, "state": choice}
+                            )
+                            if len(self._world.narrations) > 50:
+                                del self._world.narrations[: len(self._world.narrations) - 50]
+                        except Exception:
+                            pass
+                    return choice
         return None

--- a/from-simulation/app/llm/decider.py
+++ b/from-simulation/app/llm/decider.py
@@ -1,0 +1,212 @@
+"""
+Optional Anthropic-powered action picker.
+
+When ``Config.anthropic_api_key`` is None, ``LLMDecider`` is a no-op: every
+``maybe_decide(...)`` call returns None and no network requests are made.
+
+When enabled:
+  * A token-bucket caps global throughput at ``LLM_GLOBAL_RPM``.
+  * A per-actor cooldown (``LLM_MIN_TICK_GAP`` ticks) prevents one chatty
+    character from monopolising the budget.
+  * Results are cached by ``functools.lru_cache`` keyed by
+    ``(actor_id, current_state, phase, fear_bucket, tuple(menu))`` so identical
+    decision contexts within a short window reuse the model's answer.
+  * The model is called with a single tool (``choose_action`` — see
+    ``llm/actions.py``) whose ``state`` enum is the supplied menu.
+  * Every call increments ``from_sim_llm_calls_total{outcome,actor}``.
+
+The decider is "best effort": any exception (network, JSON, missing SDK)
+returns None. The caller falls back to the weighted transition table.
+"""
+
+from __future__ import annotations
+
+import functools
+import logging
+import threading
+import time
+from typing import List, Optional, Tuple
+
+from contracts import Config, Metric, Phase, SimTelemetry, State
+
+try:
+    import anthropic  # type: ignore
+except Exception:  # pragma: no cover — sdk may be absent locally
+    anthropic = None  # type: ignore
+
+from llm.actions import build_tool_schema
+
+
+_log = logging.getLogger(__name__)
+
+
+class _TokenBucket:
+    """Minute-window token bucket. Thread-safe."""
+
+    def __init__(self, rpm: int) -> None:
+        self.capacity = max(1, int(rpm))
+        self.tokens = float(self.capacity)
+        self.last_refill = time.monotonic()
+        self._lock = threading.Lock()
+
+    def try_consume(self, n: float = 1.0) -> bool:
+        with self._lock:
+            now = time.monotonic()
+            elapsed = now - self.last_refill
+            # Refill linearly: capacity tokens per 60 s.
+            self.tokens = min(self.capacity, self.tokens + elapsed * (self.capacity / 60.0))
+            self.last_refill = now
+            if self.tokens >= n:
+                self.tokens -= n
+                return True
+            return False
+
+
+class LLMDecider:
+    """Decides the next FSM state for an actor using Claude. Optional."""
+
+    def __init__(self, config: Config, telemetry: Optional[SimTelemetry] = None) -> None:
+        self.config = config
+        self.telemetry = telemetry
+        self.enabled = bool(config.anthropic_api_key) and anthropic is not None
+        self._client = None
+        if self.enabled:
+            try:
+                self._client = anthropic.Anthropic(api_key=config.anthropic_api_key)
+            except Exception:
+                _log.exception("anthropic client init failed; disabling LLM decider")
+                self.enabled = False
+        self._bucket = _TokenBucket(config.llm_global_rpm)
+        self._last_tick_by_actor: dict[str, int] = {}
+        # Bind the cache to the instance, keyed on the parts we want.
+        self._cached = functools.lru_cache(maxsize=2048)(self._call_uncached)
+        # World handle for pushing narrations; attached lazily by app.py.
+        self._world = None
+
+    def attach_world(self, world) -> None:
+        """Hook the decider up to a World so successful decisions can
+        publish a one-line 'reason' to the UI narration panel."""
+        self._world = world
+
+    # --------------------------------------------------------- public API
+    def maybe_decide(
+        self,
+        actor_id: str,
+        current_state: State,
+        phase: Phase,
+        fear: float,
+        menu: List[State],
+        current_tick: int,
+        extra_context: str = "",
+    ) -> Optional[Tuple[State, str]]:
+        """Return (chosen state, reason) or None if we should fall back."""
+        if not self.enabled or not menu:
+            return None
+
+        # Per-actor cooldown.
+        last = self._last_tick_by_actor.get(actor_id, -10**9)
+        if current_tick - last < self.config.llm_min_tick_gap:
+            return None
+
+        # Token bucket guard.
+        if not self._bucket.try_consume():
+            self._inc_counter("rate_limited", actor_id)
+            return None
+
+        fear_bucket = int(min(100.0, max(0.0, fear))) // 25  # 0..4
+        menu_key = tuple(s.value for s in menu)
+        try:
+            result = self._cached(actor_id, current_state.value, phase.value, fear_bucket, menu_key, extra_context)
+        except Exception:
+            self._inc_counter("error", actor_id)
+            return None
+
+        # Cooldown is consumed whether or not we got a usable answer.
+        self._last_tick_by_actor[actor_id] = current_tick
+
+        if result is None:
+            self._inc_counter("no_decision", actor_id)
+            return None
+
+        state_str, reason = result
+        try:
+            chosen = State(state_str)
+        except ValueError:
+            self._inc_counter("invalid_state", actor_id)
+            return None
+        if chosen not in menu:
+            self._inc_counter("off_menu", actor_id)
+            return None
+        self._inc_counter("ok", actor_id)
+        # Publish the narration line if we've been attached to a world.
+        if self._world is not None and reason:
+            try:
+                self._world.narrations.append({"actor": actor_id, "reason": reason, "state": chosen.value})
+                # Cap the rolling window — snapshot only emits the last 10 anyway.
+                if len(self._world.narrations) > 50:
+                    del self._world.narrations[: len(self._world.narrations) - 50]
+            except Exception:  # never let narration bookkeeping kill a tick
+                pass
+        return chosen, reason
+
+    # ------------------------------------------------------- internals
+    def _inc_counter(self, outcome: str, actor: str) -> None:
+        if self.telemetry is None:
+            return
+        try:
+            self.telemetry.counter_inc(
+                Metric.LLM_CALLS_TOTAL, 1.0, {"outcome": outcome, "actor": actor}
+            )
+        except Exception:
+            pass
+
+    def _call_uncached(
+        self,
+        actor_id: str,
+        current_state_str: str,
+        phase_str: str,
+        fear_bucket: int,
+        menu_key: Tuple[str, ...],
+        extra_context: str,
+    ) -> Optional[Tuple[str, str]]:
+        """The cache-miss path. Returns (state_str, reason) or None."""
+        if self._client is None:
+            return None
+        menu = [State(s) for s in menu_key]
+        tool = build_tool_schema(menu)
+        system = (
+            "You are the inner voice of a villager in the small mountain town of From. "
+            "It is forever beset by creatures from the forest. "
+            "Pick the single best next action from the provided tool. "
+            "Be terse — under 140 characters in the 'reason' field."
+        )
+        prompt = (
+            f"Actor: {actor_id}\n"
+            f"Current state: {current_state_str}\n"
+            f"Phase: {phase_str}\n"
+            f"Fear bucket (0=calm, 4=panic): {fear_bucket}\n"
+            f"Menu: {', '.join(menu_key)}\n"
+            f"{extra_context}".strip()
+        )
+        try:
+            resp = self._client.messages.create(
+                model=self.config.llm_model,
+                max_tokens=256,
+                system=system,
+                tools=[tool],
+                tool_choice={"type": "tool", "name": "choose_action"},
+                messages=[{"role": "user", "content": prompt}],
+            )
+        except Exception:
+            _log.debug("LLM call failed", exc_info=True)
+            return None
+
+        # Find the tool_use block in the response.
+        for block in getattr(resp, "content", []) or []:
+            if getattr(block, "type", None) == "tool_use" and getattr(block, "name", None) == "choose_action":
+                inp = getattr(block, "input", {}) or {}
+                state_str = inp.get("state")
+                reason = inp.get("reason", "") or ""
+                if isinstance(state_str, str):
+                    return state_str, reason
+        return None

--- a/from-simulation/app/requirements.txt
+++ b/from-simulation/app/requirements.txt
@@ -1,0 +1,10 @@
+flask==3.1.3
+flask-socketio==5.4.1
+eventlet==0.37.0
+python-dotenv==1.2.2
+anthropic==0.45.0
+opentelemetry-api==1.41.1
+opentelemetry-sdk==1.41.1
+opentelemetry-exporter-otlp==1.41.1
+pyroscope-io==1.0.6
+pyroscope-otel==1.0.0

--- a/from-simulation/app/requirements.txt
+++ b/from-simulation/app/requirements.txt
@@ -1,5 +1,5 @@
 flask==3.1.3
-flask-socketio==5.4.1
+flask-socketio==5.6.1
 eventlet==0.37.0
 python-dotenv==1.2.2
 anthropic==0.45.0

--- a/from-simulation/app/schema.sql
+++ b/from-simulation/app/schema.sql
@@ -1,0 +1,100 @@
+-- v5 SQLite schema for the From simulation Memory subsystem.
+--
+-- Open with WAL so the tick thread and any read-only consumer don't block
+-- each other. Foreign keys ON so a pruned cycle cascades to its dependent
+-- per-cycle rows (sub_main_characters and personality_drift intentionally
+-- do NOT use a cycle FK — they outlive any one cycle).
+
+PRAGMA journal_mode=WAL;
+PRAGMA foreign_keys=ON;
+
+-- One row per cycle that the universe has lived through. The currently
+-- ongoing cycle's row has outcome="ongoing"; older rows are "wiped".
+CREATE TABLE IF NOT EXISTS cycles (
+    cycle_no            INTEGER PRIMARY KEY,
+    started_real_ts     TEXT NOT NULL,
+    ended_real_ts       TEXT,
+    outcome             TEXT NOT NULL DEFAULT 'ongoing'
+);
+
+-- Journal fragments — the one thing legacy.py persists outside of the
+-- in-memory Legacy list. Burned [0,1].
+CREATE TABLE IF NOT EXISTS journal_fragments (
+    id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+    cycle_no            INTEGER NOT NULL,
+    text                TEXT NOT NULL,
+    burned              REAL NOT NULL DEFAULT 0.0,
+    real_ts             TEXT NOT NULL,
+    FOREIGN KEY (cycle_no) REFERENCES cycles(cycle_no) ON DELETE CASCADE
+);
+
+-- Character memory rows — the canonical "what happened to this agent"
+-- store. Buffered + executemany-flushed on tick.
+CREATE TABLE IF NOT EXISTS character_memory (
+    id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+    cycle_no            INTEGER NOT NULL,
+    tick                INTEGER NOT NULL,
+    character_id        TEXT NOT NULL,
+    kind                TEXT NOT NULL,
+    subject             TEXT NOT NULL DEFAULT '',
+    detail              TEXT NOT NULL DEFAULT '',
+    payload             TEXT NOT NULL DEFAULT '',
+    real_ts             TEXT NOT NULL,
+    FOREIGN KEY (cycle_no) REFERENCES cycles(cycle_no) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_char_mem_lookup
+    ON character_memory (character_id, kind, tick DESC);
+
+-- Inventory churn log — every pickup/drop/use writes a row with the new
+-- post-change total. Agent B uses this for recall + the snapshot summary
+-- is derived directly off the live Character.inventory dict.
+CREATE TABLE IF NOT EXISTS character_inventory (
+    id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+    cycle_no            INTEGER NOT NULL,
+    tick                INTEGER NOT NULL,
+    character_id        TEXT NOT NULL,
+    item                TEXT NOT NULL,
+    delta               INTEGER NOT NULL,
+    total               INTEGER NOT NULL,
+    real_ts             TEXT NOT NULL,
+    FOREIGN KEY (cycle_no) REFERENCES cycles(cycle_no) ON DELETE CASCADE
+);
+
+-- Sub-main characters: promoted NPCs that survive across wipes as
+-- tombstones (died_at_cycle non-null means they were lost). These rows
+-- are NOT cascade-deleted by cycle prune.
+CREATE TABLE IF NOT EXISTS sub_main_characters (
+    npc_id              TEXT PRIMARY KEY,
+    full_name           TEXT NOT NULL,
+    promoted_at_cycle   INTEGER NOT NULL,
+    promoted_at_tick    INTEGER NOT NULL,
+    reason              TEXT NOT NULL DEFAULT '',
+    score               REAL NOT NULL DEFAULT 0.0,
+    died_at_cycle       INTEGER,
+    died_at_tick        INTEGER,
+    cause_of_death      TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_submain_alive
+    ON sub_main_characters (died_at_cycle);
+
+-- Personality drift: persistent per-character trait deltas, mirrored from
+-- the in-memory Legacy each flush. Never pruned.
+CREATE TABLE IF NOT EXISTS personality_drift (
+    character_name      TEXT NOT NULL,
+    trait               TEXT NOT NULL,
+    delta               REAL NOT NULL,
+    updated_at_cycle    INTEGER NOT NULL,
+    PRIMARY KEY (character_name, trait)
+);
+
+-- Building breach marks — per-cycle so the post-prune Legacy reflects
+-- only the cycles we still remember.
+CREATE TABLE IF NOT EXISTS building_breach_marks (
+    cycle_no            INTEGER NOT NULL,
+    building_id         TEXT NOT NULL,
+    count               INTEGER NOT NULL DEFAULT 0,
+    PRIMARY KEY (cycle_no, building_id),
+    FOREIGN KEY (cycle_no) REFERENCES cycles(cycle_no) ON DELETE CASCADE
+);

--- a/from-simulation/app/simulation.py
+++ b/from-simulation/app/simulation.py
@@ -60,6 +60,13 @@ from agents import music_box as _music_box     # A v4: tick_music_box
 from agents import cooling_off as _cooling_off # A v4: tick_cooling_off
 from agents import npc_problems as _npc_problems  # C v4: tick_npc_problems
 from agents import promotion as _promotion        # C v5: tick_promotion
+from agents import caves as _caves                # A v6: tick_caves
+from agents import cars as _cars                  # A v6: tick_cars
+from agents import forage as _forage              # A v7: tick_forage
+from agents import cult as _cult                  # C v8: cult faction + endgame
+from agents import construction as _construction  # A v8: build new houses
+from agents import director as _director           # A v9: AI Director (tension monitor)
+from agents import mind as _mind                   # A v9: per-agent cognition (gauges only here)
 from time_cycle import phase_for, update_lighting
 from world import reset_world
 
@@ -229,6 +236,19 @@ class Simulation:
         # reaping so the deaths and displacements it creates land same-tick.
         _npc_problems.tick_npc_problems(world)
         _population.tick_population(world)
+        # A v6: drive any live arrival car forward one step. Runs right after
+        # population so the same-tick alighting handoff (car parks -> NPC
+        # flips ACTIVE) lines up with the population pass that finalises it.
+        _cars.tick_cars(world)
+        # A v6: tick the cave exploration mechanic. Runs after population so
+        # any character who flipped to EXPLORING_CAVES this tick gets their
+        # first progress increment immediately, and before the social /
+        # supernatural passes that read agent state.
+        _caves.tick_caves(world)
+        # A v7: foraging mechanic. Like caves it owns a per-agent progress
+        # counter; we tick it once per tick alongside caves so foragers can
+        # accrue progress while sitting at their forage zone.
+        _forage.tick_forage(world)
         # C v5: promotion sweep runs immediately after population reaping so
         # we never promote a corpse and the sub-main gauge stays honest.
         _promotion.tick_promotion(world)
@@ -241,7 +261,27 @@ class Simulation:
         _lighthouse.tick_lighthouse(world)
         # Back to Agent A: food drains, dusk creature spawn, dumb supernaturals.
         _food.tick(world)
+        # v9 — AI Director: recompute pressure + spawn/yellow knobs BEFORE the
+        # creature/yellow spawn paths read them. Cheap (gated cadence inside).
+        _director.tick_director(world)
         _creatures.maybe_spawn(world)  # reads world.last_phase before we bump it
+        # v7 — cave-dwelling spawn at NIGHT + barn repair progress.
+        _creatures.tick_cave_spawn(world)
+        # v9.1 — sustained NIGHT pressure: a second wave at midnight so the
+        # dusk cohort isn't the entire night's threat budget.
+        _creatures.tick_night_wave(world)
+        _creatures.tick_barn_repair(world)
+        # v8 — house destruction rebuild + talisman crack.
+        _creatures.tick_house_repair(world)
+        _creatures.tick_talisman_crack(world)
+        # v8 — cult conversion + endgame. Re-scan the event deque each tick;
+        # on_loss is idempotent per victim via _cult_loss_seen_* attrs so we
+        # can safely walk the full buffer (capped at 200) without double
+        # counting prior losses.
+        _cult.consume_events_for_pressure(world, list(world.events))
+        _cult.tick(world)
+        # v8 — homeless-driven construction of new houses.
+        _construction.tick_construction(world)
         _supernatural.roll(world)
 
         # 6) Bump last_phase now that maybe_spawn has consumed the edge.
@@ -253,6 +293,11 @@ class Simulation:
 
         # 7) Gauges + counters.
         self._emit_metrics(world)
+        # 7a) v9 — mind aggregate gauges (beliefs_active + goals_active by kind).
+        try:
+            _mind.emit_mind_gauges(world)
+        except Exception:
+            pass
 
         # 7b) v5 — drain Memory buffers if it's time. Swallow exceptions so a
         # DB hiccup never kills a tick.

--- a/from-simulation/app/simulation.py
+++ b/from-simulation/app/simulation.py
@@ -53,6 +53,9 @@ from agents import supernatural as _supernatural
 from agents import characters as _characters  # B: tick_societies + build_characters
 from agents import population as _population   # C: tick_population + clear_npcs
 from agents import yellow_man as _yellow_man   # C: tick_yellow + reset_yellow_scheduling
+from agents import dreams as _dreams           # A v2: tick_dreams + fire_due_prophecies
+from agents import lighthouse as _lighthouse   # A v2: tick_lighthouse
+from agents import bus as _bus                 # C v2: tick_bus + clear_outsiders
 from time_cycle import phase_for, update_lighting
 from world import reset_world
 
@@ -211,12 +214,17 @@ class Simulation:
         # Fear runs first so anyone who died from a paranormal break this tick
         # gets reaped by the population/resurrection passes below.
         _fear.propagate(world)
+        # A v2: dream lifecycle BEFORE tick_societies so B sees DREAMING flips.
+        _dreams.tick_dreams(world)
         # Agent B: social rituals, resurrection countdown, expedition lifecycle.
         _characters.tick_societies(world)
-        # Agent C: NPC arrivals/deaths, then Yellow Man (consumes any vote
-        # outcomes Agent B just produced inside tick_societies).
+        # Agent C: bus arrivals/departures FIRST so survivors boarding are
+        # gone before NPC reaping; then NPC arrivals/deaths; then Yellow Man.
+        _bus.tick_bus(world)
         _population.tick_population(world)
         _yellow_man.tick_yellow(world)
+        # A v2: lighthouse runs AFTER yellow so a wipe can't race a call.
+        _lighthouse.tick_lighthouse(world)
         # Back to Agent A: food drains, dusk creature spawn, dumb supernaturals.
         _food.tick(world)
         _creatures.maybe_spawn(world)  # reads world.last_phase before we bump it
@@ -224,6 +232,10 @@ class Simulation:
 
         # 6) Bump last_phase now that maybe_spawn has consumed the edge.
         world.last_phase = world.time.phase
+
+        # 6b) Fire any prophecies whose moment has come, AFTER all the
+        # systems that might satisfy a trigger have run this tick.
+        _dreams.fire_due_prophecies(world)
 
         # 7) Gauges + counters.
         self._emit_metrics(world)
@@ -300,6 +312,21 @@ class Simulation:
             sanity_avg = 0.0
         tele.gauge_set(Metric.FEAR_AVG, fear_avg)
         tele.gauge_set(Metric.SANITY_AVG, sanity_avg)
+
+        # v2 gauges — dreams, lighthouse, legacy.
+        tele.gauge_set(Metric.DREAMS_ACTIVE, float(len(world.active_dreams)))
+        tele.gauge_set(
+            Metric.LIGHTHOUSE_VOICE_ACTIVE,
+            1.0 if world.lighthouse_voice_active else 0.0,
+        )
+        tele.gauge_set(
+            Metric.LEGACY_JOURNAL_FRAGMENTS,
+            float(len(world.legacy.journal_fragments)),
+        )
+        tele.gauge_set(
+            Metric.LEGACY_CYCLES_WITNESSED,
+            float(world.legacy.cycles_witnessed),
+        )
 
     def _broadcast(self, world: World) -> None:
         # Prefer the registered emitter (decoupled from any transport); fall

--- a/from-simulation/app/simulation.py
+++ b/from-simulation/app/simulation.py
@@ -56,6 +56,9 @@ from agents import yellow_man as _yellow_man   # C: tick_yellow + reset_yellow_s
 from agents import dreams as _dreams           # A v2: tick_dreams + fire_due_prophecies
 from agents import lighthouse as _lighthouse   # A v2: tick_lighthouse
 from agents import bus as _bus                 # C v2: tick_bus + clear_outsiders
+from agents import music_box as _music_box     # A v4: tick_music_box
+from agents import cooling_off as _cooling_off # A v4: tick_cooling_off
+from agents import npc_problems as _npc_problems  # C v4: tick_npc_problems
 from time_cycle import phase_for, update_lighting
 from world import reset_world
 
@@ -221,7 +224,14 @@ class Simulation:
         # Agent C: bus arrivals/departures FIRST so survivors boarding are
         # gone before NPC reaping; then NPC arrivals/deaths; then Yellow Man.
         _bus.tick_bus(world)
+        # C v4: NPC sanity-break unlocks the door — fires before population
+        # reaping so the deaths and displacements it creates land same-tick.
+        _npc_problems.tick_npc_problems(world)
         _population.tick_population(world)
+        # A v4: music box runs between population and yellow_man so a wipe-y
+        # cool-off sweep happens before yellow re-evaluates the talisman map.
+        _music_box.tick_music_box(world)
+        _cooling_off.tick_cooling_off(world)
         _yellow_man.tick_yellow(world)
         # A v2: lighthouse runs AFTER yellow so a wipe can't race a call.
         _lighthouse.tick_lighthouse(world)
@@ -327,6 +337,29 @@ class Simulation:
             Metric.LEGACY_CYCLES_WITNESSED,
             float(world.legacy.cycles_witnessed),
         )
+
+        # v4 — music box + cooling-off gauges.
+        box_active = (
+            1.0
+            if world.music_box_phase != "DORMANT" or world.music_box_id is not None
+            else 0.0
+        )
+        tele.gauge_set(Metric.MUSIC_BOX_ACTIVE, box_active)
+        tele.gauge_set(
+            Metric.MUSIC_BOX_PHASE,
+            float(_music_box.PHASE_NUM.get(world.music_box_phase, 0)),
+        )
+        tele.gauge_set(
+            Metric.HOUSES_COOLING_OFF,
+            float(
+                sum(
+                    1
+                    for b in world.buildings.values()
+                    if b.cooling_off_until_tick > world.tick_count
+                )
+            ),
+        )
+        tele.gauge_set(Metric.WORMS_INFECTED, float(len(world.worms_infected)))
 
     def _broadcast(self, world: World) -> None:
         # Prefer the registered emitter (decoupled from any transport); fall

--- a/from-simulation/app/simulation.py
+++ b/from-simulation/app/simulation.py
@@ -1,0 +1,326 @@
+"""
+Simulation engine — the 2 Hz background tick loop.
+
+The ``Simulation`` class owns a single daemon ``threading.Thread`` that ticks
+at ``config.tick_hz``. Per tick we:
+
+  1. Open an OTel span (``sim.tick``) so traces show one root per tick.
+  2. Honour ``world.pending_reset`` (set by Agent C on a wipe) by calling
+     ``world.reset_world`` BEFORE advancing time. We emit ``village_reseed``
+     and bump the ``village_wipes_total`` counter.
+  3. Advance ``world.time`` by ``2 * config.time_scale`` sim-minutes.
+  4. Recompute lighting + phase. On a phase boundary, emit ``phase_change``
+     and update ``last_phase``.
+  5. Tick every entity:
+       * world.agents (characters + NPCs — owned by B/C, ticked by us)
+       * world.creatures (us — agents/creatures.py)
+       * world.supernaturals (us — agents/supernatural.py via roll())
+  6. Call ``fear.propagate``, ``food.tick``, ``creatures.maybe_spawn``,
+     ``supernatural.roll``.
+  7. Set per-tick gauges (phase, food_supply, farm_health, creatures_active,
+     fear_avg, sanity_avg) and the cumulative counter for wipes.
+  8. Broadcast the SocketIO snapshot to all connected clients (if a SocketIO
+     handle has been attached via ``set_socketio``).
+
+Module-level singleton ``simulation`` is exposed so ``app.py`` (Agent D) can
+import and call ``simulation.start(world, socketio)`` / ``simulation.stop()``.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from typing import Any, Optional
+
+from opentelemetry import trace
+
+from contracts import (
+    Event,
+    Metric,
+    PHASE_TO_NUM,
+    Phase,
+    SimTelemetry,
+    SocketEvent,
+    Status,
+    World,
+    snapshot_dict,
+)
+from agents import creatures as _creatures
+from agents import fear as _fear
+from agents import food as _food
+from agents import supernatural as _supernatural
+from agents import characters as _characters  # B: tick_societies + build_characters
+from agents import population as _population   # C: tick_population + clear_npcs
+from agents import yellow_man as _yellow_man   # C: tick_yellow + reset_yellow_scheduling
+from time_cycle import phase_for, update_lighting
+from world import reset_world
+
+
+_log = logging.getLogger(__name__)
+
+
+class Simulation:
+    """Background tick driver. One instance per process; see ``simulation``."""
+
+    def __init__(self, world: Optional[World] = None) -> None:
+        self._thread: Optional[threading.Thread] = None
+        self._stop = threading.Event()
+        self._world: Optional[World] = world
+        self._socketio: Any = None
+        self._emitter: Optional[Any] = None  # callable(payload: dict) -> None
+        self._cycle_reset_emitter: Optional[Any] = None  # callable(payload: dict) -> None
+        self._telemetry: Optional[SimTelemetry] = None
+
+    # ----------------------------------------------------- lifecycle
+    def start(self, world: Optional[World] = None, socketio: Any = None, telemetry: Optional[SimTelemetry] = None) -> None:
+        """Begin ticking. Idempotent — calling twice is a no-op.
+
+        ``world`` may be passed here or via the constructor. ``socketio`` is
+        optional; ``set_emitter`` / ``set_cycle_reset_emitter`` are the preferred
+        API since they decouple the engine from Flask.
+        """
+        if self._thread is not None and self._thread.is_alive():
+            return
+        if world is not None:
+            self._world = world
+        if self._world is None:
+            raise RuntimeError("Simulation.start(): no world supplied")
+        if socketio is not None:
+            self._socketio = socketio
+        self._telemetry = telemetry or self._world.telemetry
+        if self._world.telemetry is None and self._telemetry is not None:
+            self._world.telemetry = self._telemetry
+        self._stop.clear()
+        self._thread = threading.Thread(target=self._run, name="sim-tick", daemon=True)
+        self._thread.start()
+        _log.info("simulation thread started (tick_hz=%.2f)", self._world.config.tick_hz)
+
+    def stop(self, timeout: float = 5.0) -> None:
+        """Signal the tick thread to exit and join it."""
+        self._stop.set()
+        if self._thread is not None:
+            self._thread.join(timeout=timeout)
+            self._thread = None
+        if self._telemetry is not None:
+            try:
+                self._telemetry.shutdown()
+            except Exception:
+                pass
+
+    def set_socketio(self, socketio: Any) -> None:
+        """Attach (or replace) the SocketIO handle used for snapshot broadcasts."""
+        self._socketio = socketio
+
+    def set_emitter(self, callback: Any) -> None:
+        """Register a ``callable(payload_dict)`` to receive every tick snapshot.
+
+        Preferred over ``set_socketio`` because it decouples the engine from
+        any specific transport. ``app.py`` wires a closure that wraps
+        ``socketio.emit("tick", payload)``.
+        """
+        self._emitter = callback
+
+    def set_cycle_reset_emitter(self, callback: Any) -> None:
+        """Register a ``callable(payload_dict)`` invoked on village wipe."""
+        self._cycle_reset_emitter = callback
+
+    # ----------------------------------------------------- main loop
+    def _run(self) -> None:
+        assert self._world is not None
+        world = self._world
+        tracer = self._telemetry.get_tracer() if self._telemetry is not None else trace.get_tracer(__name__)
+        period = 1.0 / max(0.1, world.config.tick_hz)
+
+        next_deadline = time.monotonic()
+        while not self._stop.is_set():
+            tick_started = time.monotonic()
+            try:
+                with tracer.start_as_current_span("sim.tick") as span:
+                    span.set_attribute("sim.tick", world.tick_count)
+                    span.set_attribute("sim.phase", world.time.phase.value)
+                    self._do_tick(world)
+            except Exception:
+                _log.exception("tick failed")
+                if self._telemetry is not None:
+                    self._telemetry.counter_inc("from_sim_tick_errors_total", 1.0)
+
+            # Schedule next tick on a fixed cadence; warn if we ran long.
+            elapsed = time.monotonic() - tick_started
+            if elapsed > period:
+                world.emit(
+                    Event(
+                        tick=world.tick_count,
+                        type="tick_warn",
+                        subject="world",
+                        detail=f"tick took {elapsed*1000:.0f}ms (budget {period*1000:.0f}ms)",
+                        severity="warn",
+                    )
+                )
+            next_deadline += period
+            sleep_for = next_deadline - time.monotonic()
+            if sleep_for > 0:
+                # Wake early on stop signal.
+                self._stop.wait(sleep_for)
+            else:
+                # We're behind — reset the schedule to "now" to avoid runaway catch-up.
+                next_deadline = time.monotonic()
+
+    # ----------------------------------------------------- one tick
+    def _do_tick(self, world: World) -> None:
+        # 1) Honour wipe first — the rest of this tick runs on a fresh world.
+        if world.pending_reset:
+            self._handle_reset(world)
+
+        # 2) Advance time.
+        self._advance_time(world)
+
+        # 3) Lighting + phase.
+        update_lighting(world)
+        new_phase = phase_for(world.time)
+        if new_phase != world.time.phase:
+            world.time.phase = new_phase
+        if new_phase != world.last_phase:
+            world.emit(
+                Event(
+                    tick=world.tick_count,
+                    type="phase_change",
+                    subject="world",
+                    detail=f"{world.last_phase.value} -> {new_phase.value}",
+                    severity="info",
+                )
+            )
+            # last_phase is updated AFTER creatures.maybe_spawn reads it
+            # (see below) so the edge detector fires exactly once.
+
+        # 4) Tick every entity. Iterate over snapshots so .tick() can mutate
+        # the underlying collection without raising RuntimeError.
+        for agent in list(world.agents.values()):
+            try:
+                agent.tick(world)
+            except Exception:
+                _log.exception("agent %s tick failed", getattr(agent, "id", "?"))
+
+        for creature in list(world.creatures):
+            try:
+                creature.tick(world)
+            except Exception:
+                _log.exception("creature %s tick failed", getattr(creature, "id", "?"))
+
+        # 5) Subsystems.
+        # Fear runs first so anyone who died from a paranormal break this tick
+        # gets reaped by the population/resurrection passes below.
+        _fear.propagate(world)
+        # Agent B: social rituals, resurrection countdown, expedition lifecycle.
+        _characters.tick_societies(world)
+        # Agent C: NPC arrivals/deaths, then Yellow Man (consumes any vote
+        # outcomes Agent B just produced inside tick_societies).
+        _population.tick_population(world)
+        _yellow_man.tick_yellow(world)
+        # Back to Agent A: food drains, dusk creature spawn, dumb supernaturals.
+        _food.tick(world)
+        _creatures.maybe_spawn(world)  # reads world.last_phase before we bump it
+        _supernatural.roll(world)
+
+        # 6) Bump last_phase now that maybe_spawn has consumed the edge.
+        world.last_phase = world.time.phase
+
+        # 7) Gauges + counters.
+        self._emit_metrics(world)
+
+        # 8) Broadcast.
+        self._broadcast(world)
+
+        world.tick_count += 1
+
+    # ----------------------------------------------------- helpers
+    def _advance_time(self, world: World) -> None:
+        """Add ``2 * time_scale`` sim-minutes per tick."""
+        step = max(1, int(round(2.0 * world.config.time_scale)))
+        total = world.time.hour * 60 + world.time.minute + step
+        days_carry, mins = divmod(total, 24 * 60)
+        world.time.hour, world.time.minute = divmod(mins, 60)
+        if days_carry:
+            world.time.day += days_carry
+
+    def _handle_reset(self, world: World) -> None:
+        _log.warning("village wipe detected; reseeding world")
+        if self._telemetry is not None:
+            self._telemetry.counter_inc(Metric.VILLAGE_WIPES_TOTAL, 1.0)
+        # reset_world clears world.agents + most cross-slice state. After that
+        # the cross-slice owners need to rebuild their own state on top:
+        reset_world(world)
+        _population.clear_npcs(world)              # resets internal NPC id counter
+        _yellow_man.reset_yellow_scheduling(world) # resets module-local schedule
+        _characters.build_characters(world)        # repopulate named characters
+
+        # The reset cleared world.events — emit reseed AFTER so it shows up
+        # in the fresh buffer rather than the (now-discarded) old one.
+        world.emit(
+            Event(
+                tick=world.tick_count,
+                type="village_reseed",
+                subject="world",
+                detail=f"cycle {world.cycle_number} begins",
+                severity="info",
+            )
+        )
+        payload = {"cycle": world.cycle_number}
+        if self._cycle_reset_emitter is not None:
+            try:
+                self._cycle_reset_emitter(payload)
+            except Exception:
+                _log.exception("cycle_reset emitter failed")
+        elif self._socketio is not None:
+            try:
+                self._socketio.emit(SocketEvent.CYCLE_RESET, payload)
+            except Exception:
+                _log.exception("cycle_reset broadcast failed")
+
+    def _emit_metrics(self, world: World) -> None:
+        tele = self._telemetry
+        if tele is None:
+            return
+        tele.gauge_set(Metric.PHASE, float(PHASE_TO_NUM.get(world.time.phase, 0)))
+        tele.gauge_set(Metric.FOOD_SUPPLY, float(world.food_supply))
+        tele.gauge_set(Metric.FARM_HEALTH, float(world.farm_health))
+        tele.gauge_set(Metric.CREATURES_ACTIVE, float(len(world.creatures)))
+        tele.gauge_set(Metric.VILLAGE_WIPES_TOTAL, float(world.village_wipes))
+
+        # Fear / sanity averages over "alive and present" agents.
+        live = [
+            a for a in world.agents.values()
+            if getattr(a, "status", Status.ACTIVE) in (Status.ACTIVE, Status.RETURNING)
+        ]
+        if live:
+            fear_avg = sum(float(getattr(a, "fear", 0.0)) for a in live) / len(live)
+            sanity_avg = sum(float(getattr(a, "sanity", 100.0)) for a in live) / len(live)
+        else:
+            fear_avg = 0.0
+            sanity_avg = 0.0
+        tele.gauge_set(Metric.FEAR_AVG, fear_avg)
+        tele.gauge_set(Metric.SANITY_AVG, sanity_avg)
+
+    def _broadcast(self, world: World) -> None:
+        # Prefer the registered emitter (decoupled from any transport); fall
+        # back to a raw SocketIO handle if one was attached via set_socketio.
+        try:
+            payload = snapshot_dict(world)
+        except Exception:
+            _log.exception("snapshot build failed")
+            return
+        if self._emitter is not None:
+            try:
+                self._emitter(payload)
+            except Exception:
+                _log.exception("emitter callback failed")
+            return
+        if self._socketio is not None:
+            try:
+                self._socketio.emit(SocketEvent.TICK, payload)
+            except Exception:
+                _log.exception("snapshot broadcast failed")
+
+
+# Module-level singleton used by app.py.
+simulation = Simulation()

--- a/from-simulation/app/simulation.py
+++ b/from-simulation/app/simulation.py
@@ -59,6 +59,7 @@ from agents import bus as _bus                 # C v2: tick_bus + clear_outsider
 from agents import music_box as _music_box     # A v4: tick_music_box
 from agents import cooling_off as _cooling_off # A v4: tick_cooling_off
 from agents import npc_problems as _npc_problems  # C v4: tick_npc_problems
+from agents import promotion as _promotion        # C v5: tick_promotion
 from time_cycle import phase_for, update_lighting
 from world import reset_world
 
@@ -228,6 +229,9 @@ class Simulation:
         # reaping so the deaths and displacements it creates land same-tick.
         _npc_problems.tick_npc_problems(world)
         _population.tick_population(world)
+        # C v5: promotion sweep runs immediately after population reaping so
+        # we never promote a corpse and the sub-main gauge stays honest.
+        _promotion.tick_promotion(world)
         # A v4: music box runs between population and yellow_man so a wipe-y
         # cool-off sweep happens before yellow re-evaluates the talisman map.
         _music_box.tick_music_box(world)
@@ -249,6 +253,14 @@ class Simulation:
 
         # 7) Gauges + counters.
         self._emit_metrics(world)
+
+        # 7b) v5 — drain Memory buffers if it's time. Swallow exceptions so a
+        # DB hiccup never kills a tick.
+        if world.memory is not None:
+            try:
+                world.memory.tick_flush(world)
+            except Exception:
+                pass
 
         # 8) Broadcast.
         self._broadcast(world)

--- a/from-simulation/app/static/css/style.css
+++ b/from-simulation/app/static/css/style.css
@@ -828,6 +828,48 @@ svg#world.dream-mode {
   fill: #1a1611;
 }
 
+/* ----- v4: music box, cicada, cooling-off haze --------------------------- */
+#entities .music-box {
+  fill: #d8a83a;
+  stroke: #1a1611;
+  stroke-width: 0.8;
+  cursor: pointer;
+  filter: drop-shadow(0 0 4px rgba(216, 168, 58, 0.6));
+  animation: musicBoxPulse 2.2s ease-in-out infinite;
+  transition: transform 400ms linear;
+}
+@keyframes musicBoxPulse {
+  0%, 100% { filter: drop-shadow(0 0 4px rgba(216, 168, 58, 0.55)); }
+  50%      { filter: drop-shadow(0 0 9px rgba(216, 168, 58, 0.95)); }
+}
+
+#entities .cicada {
+  fill: #6b5b3a;
+  opacity: 0.85;
+  stroke: #1a1611;
+  stroke-width: 0.3;
+  pointer-events: none;
+  animation: cicadaTwitch 0.4s steps(2) infinite;
+}
+@keyframes cicadaTwitch {
+  0%   { transform: translate(0, 0); }
+  50%  { transform: translate(1px, -1px); }
+  100% { transform: translate(-1px, 0); }
+}
+
+#overlays .cooling-off rect {
+  fill: rgba(168, 58, 42, 0.18);
+  stroke: rgba(168, 58, 42, 0.55);
+  stroke-width: 0.8;
+  stroke-dasharray: 3 4;
+  pointer-events: none;
+  animation: coolingPulse 3s ease-in-out infinite;
+}
+@keyframes coolingPulse {
+  0%, 100% { opacity: 0.55; }
+  50%      { opacity: 0.95; }
+}
+
 /* ----- Township Index panel ----- */
 #township-index .index-list {
   font-family: "JetBrains Mono", "SF Mono", Menlo, monospace;

--- a/from-simulation/app/static/css/style.css
+++ b/from-simulation/app/static/css/style.css
@@ -1,0 +1,464 @@
+/* ============================================================
+ * Fromville — UI styles
+ * Dark Americana / gothic dread theme. Sans-serif body,
+ * serif accents in HUD chips. Panels are scrollable.
+ * ============================================================ */
+
+:root {
+  --bg-0: #08080a;
+  --bg-1: #11121a;
+  --bg-2: #181a24;
+  --bg-3: #20232f;
+  --line: #2a2d3a;
+  --text: #cfd1da;
+  --muted: #8a8e9c;
+  --warn: #c8a14a;
+  --crit: #b94747;
+  --ok: #5a8a5a;
+
+  --char: #f3e3c2;        /* warm cream */
+  --npc: #8a8e9c;          /* muted grey */
+  --creature: #c44141;     /* blood red */
+  --boy-in-white: #f6f3e2; /* luminous */
+  --man-in-yellow: #d8b340;
+  --anghkooey: #6c4a90;
+  --faraway-tree: #3f9b8a;
+  --talisman: #cda74d;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  padding: 0;
+  background: var(--bg-0);
+  color: var(--text);
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+    "Helvetica Neue", Arial, sans-serif;
+  font-size: 14px;
+  height: 100%;
+}
+
+body.theme-dread {
+  background:
+    radial-gradient(ellipse at top, #1a1525 0%, #08080a 60%) fixed,
+    var(--bg-0);
+  min-height: 100vh;
+}
+
+/* ============================== topbar HUD ============================== */
+.topbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 16px;
+  background: linear-gradient(180deg, rgba(20, 18, 32, 0.95), rgba(8, 8, 12, 0.95));
+  border-bottom: 1px solid var(--line);
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  gap: 16px;
+}
+
+.brand {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+}
+.brand-mark {
+  font-family: "Georgia", serif;
+  font-size: 22px;
+  letter-spacing: 6px;
+  color: var(--talisman);
+}
+.brand-sub {
+  font-size: 11px;
+  letter-spacing: 2px;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.hud {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  flex-wrap: wrap;
+}
+.hud-cell {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 8px;
+  background: rgba(0, 0, 0, 0.3);
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  min-height: 28px;
+}
+.hud-label {
+  font-size: 10px;
+  letter-spacing: 1.5px;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+.hud-value {
+  font-family: "Georgia", serif;
+  font-size: 13px;
+  color: var(--text);
+}
+.hud-badge {
+  display: inline-block;
+  background: var(--bg-3);
+  color: var(--talisman);
+  border: 1px solid var(--talisman);
+  padding: 2px 8px;
+  border-radius: 10px;
+  font-size: 12px;
+  font-weight: 600;
+}
+.hud-chip {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 10px;
+  font-size: 11px;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+  border: 1px solid var(--line);
+}
+.phase-day { background: rgba(218, 192, 121, 0.18); color: #f5e3a8; border-color: #6a5524; }
+.phase-dusk { background: rgba(180, 88, 56, 0.2); color: #f0b48a; border-color: #6e3a24; }
+.phase-night { background: rgba(40, 36, 80, 0.45); color: #b8b1ff; border-color: #3a3460; }
+.phase-dawn { background: rgba(120, 92, 130, 0.25); color: #e7c4ed; border-color: #5a3b66; }
+
+.yellow-visible_march {
+  background: rgba(216, 179, 64, 0.18);
+  border-color: var(--man-in-yellow);
+  color: var(--man-in-yellow);
+}
+.yellow-imposter {
+  background: rgba(216, 179, 64, 0.12);
+  border-color: var(--man-in-yellow);
+  color: #f4d77a;
+  animation: pulse-yellow 1.8s ease-in-out infinite;
+}
+.yellow-dormant { opacity: 0.4; }
+@keyframes pulse-yellow {
+  0%, 100% { opacity: 0.75; }
+  50% { opacity: 1; box-shadow: 0 0 8px rgba(216, 179, 64, 0.6); }
+}
+
+.bar {
+  position: relative;
+  width: 80px;
+  height: 6px;
+  background: var(--bg-3);
+  border-radius: 3px;
+  overflow: hidden;
+}
+.bar-fill {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  background: linear-gradient(90deg, #5a8a5a, #cda74d);
+  transition: width 600ms ease-out;
+}
+.bar-text {
+  font-variant-numeric: tabular-nums;
+  font-size: 11px;
+  color: var(--muted);
+}
+
+/* ============================== layout ============================== */
+.layout {
+  display: grid;
+  grid-template-columns: 1fr 380px;
+  gap: 12px;
+  padding: 12px;
+  height: calc(100vh - 56px);
+}
+
+.map-pane {
+  position: relative;
+  background: #0a0a0e;
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  overflow: hidden;
+  box-shadow: inset 0 0 80px rgba(0, 0, 0, 0.6);
+}
+
+#world {
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
+.side-pane {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  overflow-y: auto;
+  padding-right: 4px;
+}
+
+/* ============================== panels ============================== */
+.panel {
+  background: var(--bg-1);
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  overflow: hidden;
+}
+.panel > summary {
+  padding: 8px 12px;
+  cursor: pointer;
+  font-size: 11px;
+  letter-spacing: 2px;
+  text-transform: uppercase;
+  color: var(--muted);
+  background: var(--bg-2);
+  border-bottom: 1px solid var(--line);
+  list-style: none;
+  user-select: none;
+}
+.panel > summary::-webkit-details-marker { display: none; }
+.panel > summary::after {
+  content: "−";
+  float: right;
+  color: var(--talisman);
+}
+.panel:not([open]) > summary::after { content: "+"; }
+.panel > *:not(summary) {
+  padding: 8px 12px;
+  max-height: 280px;
+  overflow-y: auto;
+}
+
+/* scrollbars */
+.panel > *:not(summary)::-webkit-scrollbar,
+.side-pane::-webkit-scrollbar {
+  width: 8px;
+}
+.panel > *:not(summary)::-webkit-scrollbar-track,
+.side-pane::-webkit-scrollbar-track {
+  background: transparent;
+}
+.panel > *:not(summary)::-webkit-scrollbar-thumb,
+.side-pane::-webkit-scrollbar-thumb {
+  background: var(--bg-3);
+  border-radius: 4px;
+}
+
+/* ============================== event log ============================== */
+.event-log {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  font-size: 12px;
+}
+.event-log li {
+  padding: 4px 0;
+  border-bottom: 1px dotted var(--line);
+  display: grid;
+  grid-template-columns: 60px 110px 1fr;
+  gap: 6px;
+  align-items: baseline;
+}
+.event-log .ev-tick {
+  color: var(--muted);
+  font-variant-numeric: tabular-nums;
+}
+.event-log .ev-type {
+  font-size: 10px;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+  color: var(--talisman);
+}
+.event-log .ev-detail {
+  color: var(--text);
+  word-break: break-word;
+}
+.event-log li.sev-warn .ev-type { color: var(--warn); }
+.event-log li.sev-crit .ev-type { color: var(--crit); }
+.event-log li.sev-crit .ev-detail { color: #f6c5c5; }
+
+.event-log .ev-type.t-creature_spawn,
+.event-log .ev-type.t-creature_breach,
+.event-log .ev-type.t-hypnosis_attempt { color: var(--creature); }
+.event-log .ev-type.t-boy_in_white { color: var(--boy-in-white); }
+.event-log .ev-type.t-anghkooey_chant { color: var(--anghkooey); }
+.event-log .ev-type.t-yellow_appearance,
+.event-log .ev-type.t-yellow_imposter_join,
+.event-log .ev-type.t-yellow_imposter_acted { color: var(--man-in-yellow); }
+.event-log .ev-type.t-village_wipe,
+.event-log .ev-type.t-village_reseed { color: var(--crit); font-weight: 700; }
+
+/* ============================== roster ============================== */
+.roster-summary {
+  display: flex;
+  gap: 10px;
+  font-size: 11px;
+  color: var(--muted);
+  margin-bottom: 6px;
+}
+.roster-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  font-size: 12px;
+  max-height: 120px;
+  overflow-y: auto;
+  border: 1px solid var(--line);
+  border-radius: 4px;
+}
+.roster-list li {
+  padding: 3px 8px;
+  cursor: pointer;
+  border-bottom: 1px dotted var(--line);
+}
+.roster-list li:hover { background: var(--bg-2); }
+.roster-list li.selected { background: var(--bg-3); }
+.roster-detail {
+  margin-top: 8px;
+  padding: 8px;
+  background: var(--bg-2);
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  font-size: 12px;
+  min-height: 60px;
+}
+.roster-detail h4 {
+  margin: 0 0 6px 0;
+  font-family: "Georgia", serif;
+  color: var(--talisman);
+}
+.roster-detail .kv {
+  display: grid;
+  grid-template-columns: 80px 1fr;
+  gap: 4px;
+  font-variant-numeric: tabular-nums;
+}
+.roster-detail .kv dt { color: var(--muted); }
+.roster-detail .kv dd { margin: 0; word-break: break-word; }
+.roster-empty { color: var(--muted); font-style: italic; }
+
+/* ============================== stats ============================== */
+.stats {
+  display: grid;
+  grid-template-columns: 130px 1fr;
+  gap: 4px 12px;
+  margin: 0;
+  font-size: 12px;
+}
+.stats dt {
+  color: var(--muted);
+  letter-spacing: 0.5px;
+}
+.stats dd {
+  margin: 0;
+  color: var(--text);
+  font-variant-numeric: tabular-nums;
+}
+
+/* ============================== narration ============================== */
+.narration {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  font-family: "Georgia", serif;
+  font-size: 12px;
+  font-style: italic;
+  color: #d8d0bd;
+}
+.narration li {
+  padding: 6px 0;
+  border-bottom: 1px dotted var(--line);
+}
+
+/* ============================== entities (SVG dots) ============================== */
+#entities circle {
+  cursor: pointer;
+  transition: cx 500ms linear, cy 500ms linear, r 250ms ease, opacity 400ms ease;
+  stroke: rgba(0, 0, 0, 0.6);
+  stroke-width: 0.6;
+}
+#entities circle:hover {
+  stroke: var(--talisman);
+  stroke-width: 1.4;
+}
+#entities .char       { fill: var(--char); }
+#entities .npc        { fill: var(--npc); }
+#entities .creature   { fill: var(--creature); }
+#entities .boy-in-white {
+  fill: var(--boy-in-white);
+  filter: drop-shadow(0 0 4px rgba(246, 243, 226, 0.8));
+}
+#entities .man-in-yellow {
+  fill: var(--man-in-yellow);
+  filter: drop-shadow(0 0 4px rgba(216, 179, 64, 0.6));
+}
+#entities .anghkooey  { fill: var(--anghkooey); }
+#entities .faraway-tree { fill: var(--faraway-tree); opacity: 0.85; }
+
+#entities text.label {
+  font-size: 8px;
+  fill: var(--muted);
+  pointer-events: none;
+  text-anchor: middle;
+}
+
+/* talisman runes (drawn into the SVG itself) — pulse */
+.talisman {
+  animation: rune-glow 6s ease-in-out infinite;
+  transform-origin: center;
+}
+@keyframes rune-glow {
+  0%, 100% { opacity: 0.55; }
+  50% { opacity: 0.95; }
+}
+
+/* lighthouse glow class — toggled by lighting.js when phase != DAY */
+#lighthouse-area.lit circle[fill="#f4d77a"] {
+  filter: drop-shadow(0 0 6px rgba(244, 215, 122, 0.95));
+}
+
+/* lighting overlay rectangle — transition the alpha smoothly */
+#lighting rect {
+  transition: fill 1000ms linear;
+  pointer-events: none;
+}
+
+/* ============================== cycle-reset overlay ============================== */
+.cycle-reset {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.96);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  opacity: 1;
+  transition: opacity 1800ms ease;
+}
+.cycle-reset.hidden {
+  opacity: 0;
+  pointer-events: none;
+}
+.cycle-reset-inner {
+  text-align: center;
+}
+.cycle-reset-title {
+  font-family: "Georgia", serif;
+  color: var(--crit);
+  font-size: 42px;
+  letter-spacing: 8px;
+  text-shadow: 0 0 12px rgba(185, 71, 71, 0.6);
+}
+.cycle-reset-sub {
+  margin-top: 12px;
+  color: #c0a070;
+  font-size: 14px;
+  letter-spacing: 4px;
+}
+
+.hidden { display: none !important; }

--- a/from-simulation/app/static/css/style.css
+++ b/from-simulation/app/static/css/style.css
@@ -47,6 +47,8 @@ body.theme-dread {
     radial-gradient(ellipse at top, #1a1525 0%, #08080a 60%) fixed,
     var(--bg-0);
   min-height: 100vh;
+  display: flex;
+  flex-direction: column;
 }
 
 /* ============================== topbar HUD ============================== */
@@ -54,13 +56,15 @@ body.theme-dread {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 10px 16px;
+  flex-wrap: wrap;
+  padding: 8px 14px;
   background: linear-gradient(180deg, rgba(20, 18, 32, 0.95), rgba(8, 8, 12, 0.95));
   border-bottom: 1px solid var(--line);
   position: sticky;
   top: 0;
   z-index: 10;
-  gap: 16px;
+  gap: 12px;
+  flex: 0 0 auto;
 }
 
 .brand {
@@ -84,8 +88,9 @@ body.theme-dread {
 .hud {
   display: flex;
   align-items: center;
-  gap: 14px;
+  gap: 10px;
   flex-wrap: wrap;
+  row-gap: 6px;
 }
 .hud-cell {
   display: flex;
@@ -96,6 +101,13 @@ body.theme-dread {
   border: 1px solid var(--line);
   border-radius: 4px;
   min-height: 28px;
+}
+/* Hide HUD cells whose only child is .hidden (keeps the bar from
+   showing an empty 18px-wide bordered box when e.g. the yellow chip
+   is dormant-hidden). */
+.hud-cell:empty,
+.hud-cell:has(> .hidden:only-child) {
+  display: none;
 }
 .hud-label {
   font-size: 10px;
@@ -176,7 +188,8 @@ body.theme-dread {
   grid-template-columns: 1fr 380px;
   gap: 12px;
   padding: 12px;
-  height: calc(100vh - 56px);
+  flex: 1 1 auto;
+  min-height: 0;
 }
 
 .map-pane {
@@ -200,6 +213,13 @@ body.theme-dread {
   gap: 10px;
   overflow-y: auto;
   padding-right: 4px;
+  min-height: 0;
+}
+/* Panels are flex items in the side-pane. Without flex-shrink: 0
+   they would be squashed to fit the column's available height,
+   which silently hides content. Let the side-pane scroll instead. */
+.side-pane > .panel {
+  flex: 0 0 auto;
 }
 
 /* ============================== panels ============================== */
@@ -230,7 +250,16 @@ body.theme-dread {
 .panel:not([open]) > summary::after { content: "+"; }
 .panel > *:not(summary) {
   padding: 8px 12px;
-  max-height: 280px;
+}
+/* Lists that grow unbounded over the run get capped so they don't
+   dominate the side-pane scroll. Static / short panels (Stats,
+   Township Index, Roster, Bus) size to their content and the
+   side-pane is the single scroll container. */
+#event-log,
+#journal-list,
+#lighthouse-voice-list,
+#narration {
+  max-height: 320px;
   overflow-y: auto;
 }
 
@@ -306,7 +335,7 @@ body.theme-dread {
   margin: 0;
   padding: 0;
   font-size: 12px;
-  max-height: 120px;
+  max-height: 220px;
   overflow-y: auto;
   border: 1px solid var(--line);
   border-radius: 4px;
@@ -398,7 +427,20 @@ body.theme-dread {
   filter: drop-shadow(0 0 4px rgba(216, 179, 64, 0.6));
 }
 #entities .anghkooey  { fill: var(--anghkooey); }
-#entities .faraway-tree { fill: var(--faraway-tree); opacity: 0.85; }
+#entities .faraway-tree {
+  fill: none;
+  stroke: var(--faraway-tree);
+  stroke-width: 1.2;
+  opacity: 0.85;
+  pointer-events: none;
+  transform-box: fill-box;
+  transform-origin: center;
+  animation: faraway-pulse 1.6s ease-in-out infinite;
+}
+@keyframes faraway-pulse {
+  0%, 100% { transform: scale(0.8); opacity: 0.3; }
+  50%      { transform: scale(1.8); opacity: 0.9; }
+}
 
 #entities text.label {
   font-size: 8px;
@@ -468,6 +510,152 @@ body.theme-dread {
  * lighthouse-called, dream mode, journal / voice / bus panels.
  * ============================================================ */
 
+/* v9 — Minds heatmap HUD cell + dossier mind section. */
+.hud-cell.minds {
+  min-width: 280px;
+}
+.minds-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-variant-numeric: tabular-nums;
+}
+.minds-pressure {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 110px;
+}
+.minds-pressure .bar {
+  width: 80px;
+  height: 6px;
+  background: #1a1611;
+  border: 1px solid #3a3024;
+  border-radius: 3px;
+  overflow: hidden;
+}
+.minds-pressure .bar-fill.pressure {
+  height: 100%;
+  width: 0%;
+  background: #4a8a4a;
+  transition: width 0.3s ease, background-color 0.3s ease;
+}
+.minds-goals {
+  display: flex;
+  gap: 4px;
+}
+.minds-goals .goal-pip {
+  font-size: 9px;
+  letter-spacing: 0.3px;
+  padding: 1px 4px;
+  border-radius: 8px;
+  background: #2a2418;
+  color: #c0a070;
+  border: 1px solid #3a3024;
+}
+.minds-goals .goal-pip.goal-protect      { color: #8ed8a4; border-color: #2a5a3a; }
+.minds-goals .goal-pip.goal-investigate  { color: #a4b8d8; border-color: #2a3a5a; }
+.minds-goals .goal-pip.goal-revenge      { color: #d88a8a; border-color: #5a2a2a; }
+.minds-goals .goal-pip.goal-flee         { color: #d8b070; border-color: #5a4a2a; }
+.minds-goals .goal-pip.goal-find_item    { color: #d8d090; border-color: #5a5024; }
+.minds-goals .goal-pip span { margin-left: 2px; font-weight: bold; }
+.minds-beliefs,
+.minds-popstress {
+  font-size: 10px;
+  color: #c0a070;
+  display: flex;
+  gap: 4px;
+}
+.minds-popstress {
+  font-variant-numeric: tabular-nums;
+}
+.minds-beliefs .minds-label {
+  text-transform: uppercase;
+  font-size: 9px;
+  letter-spacing: 0.5px;
+  opacity: 0.7;
+}
+
+/* Mind section inside the dossier — beliefs list + active goal. */
+.dossier .mind-section {
+  margin-top: 10px;
+  padding-top: 10px;
+  border-top: 1px dashed #3a3024;
+}
+.dossier .mind-section h4 {
+  margin: 0 0 6px 0;
+  font-size: 10px;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+  color: #c0a070;
+}
+.dossier .mind-goal {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 11px;
+  margin-bottom: 6px;
+}
+.dossier .mind-goal .goal-kind {
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  padding: 1px 5px;
+  border-radius: 8px;
+  font-size: 9px;
+  background: #2a2418;
+  color: #d8a83a;
+  border: 1px solid #3a3024;
+}
+.dossier .mind-goal .goal-target {
+  font-family: "Georgia", serif;
+  font-style: italic;
+}
+.dossier .mind-goal .goal-priority {
+  margin-left: auto;
+  font-size: 9px;
+  opacity: 0.7;
+}
+.dossier .mind-beliefs {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.dossier .mind-beliefs li {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 10px;
+  padding: 2px 0;
+  border-bottom: 1px dotted #2a2418;
+}
+.dossier .mind-beliefs li:last-child {
+  border-bottom: none;
+}
+.dossier .mind-beliefs .belief-key {
+  font-family: "Menlo", monospace;
+  font-size: 9px;
+  color: #8a9a78;
+}
+.dossier .mind-beliefs .belief-polarity-positive { color: #b94747; }
+.dossier .mind-beliefs .belief-polarity-negative { color: #4a8a8a; }
+.dossier .mind-beliefs .belief-conf {
+  margin-left: auto;
+  width: 32px;
+  height: 4px;
+  background: #1a1611;
+  border-radius: 2px;
+  overflow: hidden;
+}
+.dossier .mind-beliefs .belief-conf-fill {
+  height: 100%;
+  background: linear-gradient(90deg, #6a5524, #d8a83a);
+}
+.dossier .mind-empty {
+  font-size: 10px;
+  font-style: italic;
+  color: #6a5f48;
+}
+
 /* HUD: cycles_witnessed badge + fragments indicator */
 .hud-fragments {
   margin-left: 8px;
@@ -482,7 +670,7 @@ body.theme-dread {
   font-size: 11px;
   color: #c0a070;
   letter-spacing: 0.5px;
-  max-width: 240px;
+  max-width: 220px;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -731,18 +919,21 @@ svg#world.dream-mode {
 .lighting.dusk {
   opacity: 1;
   background:
-    radial-gradient(60% 70% at 47% 65%,
-      rgba(70, 40, 60, 0.0) 0%,
-      rgba(40, 25, 55, 0.55) 60%,
-      rgba(15, 10, 30, 0.78) 100%);
+    radial-gradient(75% 85% at 47% 65%,
+      rgba(110, 70, 90, 0.0) 0%,
+      rgba(50, 28, 56, 0.18) 55%,
+      rgba(20, 14, 36, 0.32) 100%);
 }
+/* v8 — was darkened to near-pitch and silhouettes vanished. Dropped
+   the gradient stops so the village is still visibly dim but tokens
+   read clearly. Mood survives via the cool-blue tint, not opacity. */
 .lighting.night {
   opacity: 1;
   background:
-    radial-gradient(45% 55% at 47% 65%,
-      rgba(10, 12, 30, 0.55) 0%,
-      rgba(8, 10, 26, 0.85) 50%,
-      rgba(4, 6, 18, 0.96) 100%);
+    radial-gradient(75% 85% at 47% 65%,
+      rgba(12, 16, 36, 0.18) 0%,
+      rgba(8, 12, 28, 0.38) 55%,
+      rgba(4, 6, 18, 0.55) 100%);
 }
 
 /* Building windows light up at DUSK / NIGHT — controlled by mapWrap[data-time]. */
@@ -798,14 +989,15 @@ svg#world.dream-mode {
 #entities .npc:hover { stroke: var(--talisman); stroke-width: 1.4; }
 
 #entities .creature {
-  fill: #a83a2a;
-  stroke: #1a1611;
-  stroke-width: 0.7;
-  opacity: 0.92;
+  fill: #8a2418;
+  stroke: #ffb4a0;
+  stroke-width: 0.6;
+  opacity: 0.95;
   cursor: pointer;
   transition: transform 500ms linear;
+  filter: drop-shadow(0 0 3px rgba(255, 80, 50, 0.7));
 }
-#entities .creature:hover { stroke: #f4a884; stroke-width: 1.2; }
+#entities .creature:hover { stroke: #ffd4c0; stroke-width: 1.2; }
 
 #entities .anghkooey {
   fill: #7d6dc0;
@@ -941,4 +1133,358 @@ svg#world.dream-mode {
 #world.dream-mode,
 .map-wrap.dream-mode {
   filter: hue-rotate(80deg) saturate(0.6) brightness(0.85);
+}
+
+/* ============================================================
+ * v6 additions — dossier popup, swarmer creatures, car + wrecks,
+ * roster intent line.
+ * ============================================================ */
+
+/* ----- dossier popup (overlays the map, anchored top-right) ------------- */
+.dossier {
+  position: fixed;
+  right: 408px;            /* sits to the left of the 380px side-pane */
+  top: 80px;
+  width: 360px;
+  max-height: 80vh;
+  overflow-y: auto;
+  padding: 16px 16px 14px;
+  background: rgba(20, 18, 14, 0.96);
+  border: 1px solid var(--talisman);
+  border-radius: 8px;
+  color: #e8e1d0;
+  box-shadow: 0 10px 36px rgba(0, 0, 0, 0.7);
+  z-index: 100;
+  font-size: 12px;
+  line-height: 1.45;
+  animation: dossierIn 220ms ease-out;
+}
+@keyframes dossierIn {
+  from { opacity: 0; transform: translateY(-6px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+.dossier.hidden { display: none; }
+
+.dossier .header {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  border-bottom: 1px dotted #5a4528;
+  padding-bottom: 10px;
+}
+.dossier .header svg {
+  width: 60px;
+  height: 80px;
+  filter: drop-shadow(0 2px 4px rgba(0, 0, 0, 0.55));
+  flex: 0 0 auto;
+}
+.dossier .header-text {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
+}
+.dossier .header h2 {
+  margin: 0;
+  font-family: "Georgia", serif;
+  font-size: 18px;
+  color: var(--talisman);
+  letter-spacing: 0.5px;
+}
+.dossier .header .role {
+  font-size: 10px;
+  letter-spacing: 1.4px;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.dossier .intent {
+  margin: 10px 0 12px;
+  font-family: "Georgia", serif;
+  font-style: italic;
+  font-size: 13px;
+  color: #d8c89a;
+  line-height: 1.4;
+}
+
+.dossier h3 {
+  margin: 14px 0 6px;
+  font-size: 10px;
+  letter-spacing: 2px;
+  text-transform: uppercase;
+  color: var(--muted);
+  border-bottom: 1px dotted #3a2e1a;
+  padding-bottom: 3px;
+}
+
+/* ----- vitals (overrides the topbar .bar layout in dossier scope) ------- */
+.dossier .vitals { display: flex; flex-direction: column; gap: 6px; }
+.dossier .vital {
+  display: grid;
+  grid-template-columns: 60px 1fr 40px;
+  align-items: center;
+  gap: 8px;
+  font-size: 11px;
+}
+.dossier .vital-label {
+  color: var(--muted);
+  letter-spacing: 1px;
+  text-transform: uppercase;
+  font-size: 10px;
+}
+.dossier .vital-val {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+  color: var(--text);
+}
+.dossier .bar {
+  position: relative;
+  width: auto;
+  height: 8px;
+  background: rgba(0, 0, 0, 0.4);
+  border: 1px solid #2a1f12;
+  border-radius: 3px;
+  overflow: hidden;
+}
+.dossier .bar .bar-fill {
+  position: absolute;
+  inset: 0;
+  width: 0%;
+  transition: width 400ms ease-out;
+}
+.dossier .bar.fear   .bar-fill { background: linear-gradient(90deg, #6a2a22, #b94747); }
+.dossier .bar.sanity .bar-fill { background: linear-gradient(90deg, #1f6240, #6bd3a1); }
+.dossier .bar.hunger .bar-fill { background: linear-gradient(90deg, #6a5524, #d8a83a); }
+
+/* ----- inventory --------------------------------------------------------- */
+.dossier .inventory {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.dossier .inventory li {
+  display: flex;
+  justify-content: space-between;
+  padding: 2px 6px;
+  background: rgba(0, 0, 0, 0.25);
+  border-radius: 3px;
+  font-variant-numeric: tabular-nums;
+}
+.dossier .inventory li .item-name { color: #e8e1d0; text-transform: capitalize; }
+.dossier .inventory li .item-qty  { color: var(--talisman); }
+.dossier .inventory li.muted { color: var(--muted); font-style: italic; justify-content: flex-start; }
+
+/* ----- relationships ----------------------------------------------------- */
+.dossier .relationships .rel-list {
+  list-style: none;
+  margin: 0 0 4px;
+  padding: 0;
+}
+.dossier .relationships .rel-list li {
+  display: flex;
+  justify-content: space-between;
+  padding: 2px 6px;
+  font-size: 11px;
+  border-bottom: 1px dotted #2a2418;
+}
+.dossier .relationships .rel-list li:last-child { border-bottom: none; }
+.dossier .relationships .rel-list li.muted { color: var(--muted); font-style: italic; }
+.dossier .relationships .rel-name { color: #e8e1d0; }
+.dossier .relationships .rel-score {
+  font-variant-numeric: tabular-nums;
+  padding: 0 6px;
+  border-radius: 8px;
+  font-size: 10px;
+}
+.dossier .relationships .pos { color: #7dd1a8; }
+.dossier .relationships .neg { color: #d87878; }
+.dossier .relationships .rel-score.pos {
+  background: rgba(125, 209, 168, 0.12);
+  border: 1px solid rgba(125, 209, 168, 0.4);
+}
+.dossier .relationships .rel-score.neg {
+  background: rgba(216, 120, 120, 0.12);
+  border: 1px solid rgba(216, 120, 120, 0.4);
+}
+
+/* ----- memory feed ------------------------------------------------------- */
+.dossier .memory {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  font-size: 11px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.dossier .memory li {
+  display: grid;
+  grid-template-columns: 40px minmax(0, 1fr);
+  gap: 2px 6px;
+  padding: 4px 6px;
+  background: rgba(0, 0, 0, 0.25);
+  border-radius: 3px;
+  line-height: 1.35;
+}
+.dossier .memory .mem-tick {
+  color: var(--muted);
+  font-variant-numeric: tabular-nums;
+  font-size: 10px;
+}
+.dossier .memory .kind {
+  color: var(--talisman);
+  font-size: 9px;
+  letter-spacing: 1px;
+  grid-column: 2;
+  word-break: break-all;
+}
+.dossier .memory .detail {
+  color: #d8d0bd;
+  word-break: break-word;
+  grid-column: 2;
+}
+.dossier .memory li.muted { color: var(--muted); font-style: italic; display: block; }
+
+/* ----- close button + error state --------------------------------------- */
+.dossier .close {
+  position: absolute;
+  top: 6px;
+  right: 8px;
+  width: 24px;
+  height: 24px;
+  background: transparent;
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  color: var(--muted);
+  cursor: pointer;
+  font-size: 16px;
+  line-height: 1;
+  font-family: "Georgia", serif;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: color 150ms ease, border-color 150ms ease;
+}
+.dossier .close:hover {
+  color: var(--talisman);
+  border-color: var(--talisman);
+}
+.dossier .error {
+  color: #d87878;
+  font-style: italic;
+  padding: 6px 0;
+}
+
+/* ----- v6 token: car + permanent wrecks --------------------------------- */
+.token-car {
+  cursor: pointer;
+  filter: drop-shadow(0 1px 2px rgba(0, 0, 0, 0.55));
+  transition: transform 500ms linear;
+}
+#overlays #wrecks .wreck {
+  opacity: 0.65;
+  filter: grayscale(0.5) brightness(0.85);
+  pointer-events: none;
+}
+
+/* ----- v8 building dossier (occupant list) ------------------------------- */
+.dossier .building-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  font-size: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.dossier .building-list li {
+  padding: 3px 6px;
+  background: rgba(0, 0, 0, 0.25);
+  border-radius: 3px;
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+}
+.dossier .building-list .rel-name {
+  color: #e8e1d0;
+}
+.dossier .building-list .building-role {
+  color: var(--muted);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+.dossier .muted-line {
+  color: var(--muted);
+  font-style: italic;
+  font-size: 12px;
+  padding: 4px 0 6px;
+}
+
+/* ----- v8 creature dossier facts (replaces vitals/inventory for creatures) - */
+.dossier .creature-facts {
+  display: grid;
+  grid-template-columns: 80px 1fr;
+  gap: 4px 12px;
+  margin: 6px 0 4px;
+  font-size: 12px;
+}
+.dossier .creature-facts dt {
+  color: var(--muted);
+  letter-spacing: 1px;
+  text-transform: uppercase;
+  font-size: 10px;
+  align-self: center;
+}
+.dossier .creature-facts dd {
+  margin: 0;
+  color: #e8e1d0;
+  font-variant-numeric: tabular-nums;
+  word-break: break-word;
+}
+
+/* ----- v8 cultist NPC marker ------------------------------------------- */
+#entities .npc.cultist {
+  fill: #6a1f24;
+  stroke: #d8a83a;
+  stroke-width: 1.4;
+  filter: drop-shadow(0 0 4px rgba(216, 168, 58, 0.7));
+  animation: cultPulse 2.4s ease-in-out infinite;
+}
+@keyframes cultPulse {
+  0%, 100% { filter: drop-shadow(0 0 3px rgba(216, 168, 58, 0.55)); }
+  50%      { filter: drop-shadow(0 0 7px rgba(216, 168, 58, 0.95)); }
+}
+
+/* ----- v6 swarmer creature (smaller, hotter, faster pulse) -------------- */
+#entities .creature-swarm {
+  fill: #b8413a;
+  stroke: #ffd4c0;
+  stroke-width: 0.5;
+  opacity: 0.95;
+  cursor: pointer;
+  transition: transform 320ms linear;
+  filter: drop-shadow(0 0 2px rgba(255, 80, 50, 0.65));
+  animation: swarmPulse 0.9s ease-in-out infinite;
+}
+#entities .creature-swarm:hover { stroke: #ffe7d8; stroke-width: 1; }
+@keyframes swarmPulse {
+  0%, 100% { filter: drop-shadow(0 0 2px rgba(255, 80, 50, 0.55)); }
+  50%      { filter: drop-shadow(0 0 5px rgba(255, 100, 60, 0.95)); }
+}
+
+/* ----- roster intent muted second line ---------------------------------- */
+.roster-list li .roster-title {
+  font-size: 12px;
+}
+.roster-list li .intent {
+  font-size: 10px;
+  font-style: italic;
+  color: var(--muted);
+  margin-top: 1px;
+  line-height: 1.35;
+  word-break: break-word;
 }

--- a/from-simulation/app/static/css/style.css
+++ b/from-simulation/app/static/css/style.css
@@ -870,6 +870,38 @@ svg#world.dream-mode {
   50%      { opacity: 0.95; }
 }
 
+/* ----- v5: sub-main NPCs and tombstones --------------------------------- */
+#entities circle.sub-main {
+  fill: #b8946c;                /* warmer than the base NPC grey */
+  stroke: #d8a83a;              /* gold ring so they read as "promoted" */
+  stroke-width: 1.4;
+  filter: drop-shadow(0 0 3px rgba(216, 168, 58, 0.55));
+}
+#entities .sub-main-chev {
+  fill: none;
+  stroke: #d8a83a;
+  stroke-width: 1.2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  pointer-events: none;
+}
+#entities .tombstone {
+  opacity: 0.55;
+  animation: tombstoneFade 2s ease-out forwards;
+}
+#entities .tombstone-cross {
+  font-family: "Iowan Old Style", "Palatino Linotype", Georgia, serif;
+  font-size: 11px;
+  fill: #d8cfb4;
+  opacity: 0.85;
+  pointer-events: none;
+  animation: tombstoneFade 2s ease-out forwards;
+}
+@keyframes tombstoneFade {
+  0%   { opacity: 0.9; }
+  100% { opacity: 0.0; }
+}
+
 /* ----- Township Index panel ----- */
 #township-index .index-list {
   font-family: "JetBrains Mono", "SF Mono", Menlo, monospace;

--- a/from-simulation/app/static/css/style.css
+++ b/from-simulation/app/static/css/style.css
@@ -696,3 +696,175 @@ svg#world.dream-mode {
   color: var(--muted);
   font-style: italic;
 }
+
+/* ============================================================
+ * v3 additions — hand-drawn map, character tokens, day/night
+ * lighting overlay (radial-gradient + windows + beam sweep),
+ * Township Index panel.
+ * ============================================================ */
+
+/* The hand-drawn map sits inside .map-wrap, which contains the inline
+ * SVG and the radial lighting overlay <div>. */
+.map-wrap {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  aspect-ratio: 1000 / 700;
+  background: #c9c2a8;
+  overflow: hidden;
+}
+.map-wrap > svg#map {
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
+/* Lighting overlay: empty/dark on DAY, radial gradient on DUSK / NIGHT */
+.lighting {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  mix-blend-mode: multiply;
+  transition: background 800ms ease, opacity 800ms ease;
+  opacity: 0;
+}
+.lighting.dusk {
+  opacity: 1;
+  background:
+    radial-gradient(60% 70% at 47% 65%,
+      rgba(70, 40, 60, 0.0) 0%,
+      rgba(40, 25, 55, 0.55) 60%,
+      rgba(15, 10, 30, 0.78) 100%);
+}
+.lighting.night {
+  opacity: 1;
+  background:
+    radial-gradient(45% 55% at 47% 65%,
+      rgba(10, 12, 30, 0.55) 0%,
+      rgba(8, 10, 26, 0.85) 50%,
+      rgba(4, 6, 18, 0.96) 100%);
+}
+
+/* Building windows light up at DUSK / NIGHT — controlled by mapWrap[data-time]. */
+.map-wrap .windows { opacity: 0; transition: opacity 800ms ease; }
+.map-wrap[data-time="dusk"]  .windows { opacity: 0.55; }
+.map-wrap[data-time="night"] .windows { opacity: 1; }
+
+/* Lighthouse rotating beam — sweeps continuously, fades in at DUSK/NIGHT. */
+.lighthouse-beam {
+  opacity: 0;
+  transition: opacity 800ms ease;
+  transform-origin: 140px 585px;
+  animation: sweep 9s linear infinite;
+}
+.map-wrap[data-time="dusk"]  .lighthouse-beam { opacity: 0.4; }
+.map-wrap[data-time="night"] .lighthouse-beam { opacity: 0.85; }
+@keyframes sweep {
+  from { transform: rotate(0deg); }
+  to   { transform: rotate(360deg); }
+}
+
+/* Talisman sigils on talisman buildings — re-uses v1 rune-glow keyframes. */
+.map-wrap use[href="#talisman"] {
+  animation: rune-glow 6s ease-in-out infinite;
+  transform-origin: center;
+}
+
+/* ----- character token sprites ----- */
+.token {
+  cursor: pointer;
+  filter: drop-shadow(0 2px 3px rgba(0, 0, 0, 0.45));
+  transition: transform 500ms linear;
+}
+.token.char:hover {
+  filter: drop-shadow(0 0 6px #d8a83a);
+}
+.token.yellow {
+  filter: drop-shadow(0 0 8px rgba(216, 200, 74, 0.85));
+}
+.token.white {
+  filter: drop-shadow(0 0 10px rgba(244, 246, 255, 0.9));
+  opacity: 0.95;
+}
+
+/* ----- simple shape entities (NPCs / creatures / anghkooey) ----- */
+#entities .npc {
+  fill: #6d6856;
+  stroke: #1a1611;
+  stroke-width: 0.6;
+  cursor: pointer;
+  transition: cx 500ms linear, cy 500ms linear;
+}
+#entities .npc:hover { stroke: var(--talisman); stroke-width: 1.4; }
+
+#entities .creature {
+  fill: #a83a2a;
+  stroke: #1a1611;
+  stroke-width: 0.7;
+  opacity: 0.92;
+  cursor: pointer;
+  transition: transform 500ms linear;
+}
+#entities .creature:hover { stroke: #f4a884; stroke-width: 1.2; }
+
+#entities .anghkooey {
+  fill: #7d6dc0;
+  opacity: 0.7;
+  stroke: #1a1611;
+  stroke-width: 0.5;
+  cursor: pointer;
+  transition: cx 500ms linear, cy 500ms linear;
+}
+
+/* ----- hash marks: thin charcoal tallies above breach-prone buildings ----- */
+#overlays .hash-marks line {
+  stroke: #1a1611;
+  stroke-width: 1;
+  stroke-linecap: round;
+}
+#overlays .hash-marks text {
+  font-family: "JetBrains Mono", "SF Mono", Menlo, monospace;
+  font-size: 8px;
+  fill: #1a1611;
+}
+
+/* ----- Township Index panel ----- */
+#township-index .index-list {
+  font-family: "JetBrains Mono", "SF Mono", Menlo, monospace;
+  font-size: 11px;
+  display: grid;
+  grid-template-columns: 22px 24px 1fr;
+  gap: 5px 8px;
+  align-items: center;
+  color: var(--text);
+  line-height: 1.5;
+}
+#township-index .index-list .n {
+  color: var(--talisman);
+  text-align: right;
+}
+#township-index .index-list .ic {
+  width: 22px;
+  height: 16px;
+  display: block;
+}
+#township-index .index-list .ic svg {
+  width: 100%;
+  height: 100%;
+  display: block;
+  overflow: visible;
+}
+#township-index .index-list .t .tag {
+  color: #a83a2a;
+  margin-left: 6px;
+  font-size: 10px;
+}
+
+/* World host (now a div, not an SVG) hosts the dream-mode hue rotation. */
+#world {
+  transition: filter 1000ms ease;
+}
+#world.dream-mode,
+.map-wrap.dream-mode {
+  filter: hue-rotate(80deg) saturate(0.6) brightness(0.85);
+}

--- a/from-simulation/app/static/css/style.css
+++ b/from-simulation/app/static/css/style.css
@@ -462,3 +462,237 @@ body.theme-dread {
 }
 
 .hidden { display: none !important; }
+
+/* ============================================================
+ * v2 additions — legacy hash marks, bus, outsiders, tendrils,
+ * lighthouse-called, dream mode, journal / voice / bus panels.
+ * ============================================================ */
+
+/* HUD: cycles_witnessed badge + fragments indicator */
+.hud-fragments {
+  margin-left: 8px;
+  font-size: 10px;
+  letter-spacing: 0.5px;
+  color: #c0a070;
+  font-variant-numeric: tabular-nums;
+}
+.hud-witnessed {
+  font-family: "Georgia", serif;
+  font-style: italic;
+  font-size: 11px;
+  color: #c0a070;
+  letter-spacing: 0.5px;
+  max-width: 240px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* Hash-mark tallies above breached buildings */
+.hash-marks line {
+  stroke: #1c1610;
+  stroke-width: 1;
+  stroke-linecap: round;
+  opacity: 0.85;
+}
+.hash-marks .hash-overflow,
+text.hash-overflow {
+  fill: #2a1d12;
+  font-size: 8px;
+  font-family: "Georgia", serif;
+}
+
+/* Bus — yellow rect, black windows, soft drop shadow */
+.bus {
+  filter: drop-shadow(0 2px 4px rgba(0, 0, 0, 0.55));
+  transition: transform 800ms ease-out;
+}
+.bus .bus-body-rect {
+  fill: #e9c93d;
+  stroke: #1c1304;
+  stroke-width: 1.2;
+}
+.bus .bus-window {
+  fill: #0a0a10;
+  stroke: #1c1304;
+  stroke-width: 0.5;
+}
+.bus .bus-door {
+  fill: #6c5320;
+  stroke: #1c1304;
+  stroke-width: 0.5;
+}
+.bus .bus-wheel {
+  fill: #0a0805;
+  stroke: #1c1304;
+  stroke-width: 0.6;
+}
+
+/* Outsiders — pale-gold circle slightly larger than NPC, with "+" glyph above */
+#entities circle.outsider {
+  fill: #d9c486;
+  r: 5.5;
+  stroke: rgba(80, 60, 20, 0.7);
+  stroke-width: 0.8;
+}
+.outsider-glyph {
+  fill: #e8d9a4;
+  font-size: 9px;
+  font-family: "Georgia", serif;
+  font-weight: 700;
+  pointer-events: none;
+}
+
+/* Yellow Man tendrils — mustard pulsing ring */
+#overlays circle.tendril {
+  stroke: #c2a23f;
+  stroke-width: 1.4;
+  opacity: 0.7;
+  r: 9;
+  animation: tendril-pulse 2.2s ease-in-out infinite;
+}
+#overlays circle.tendril-leader {
+  stroke: #f4d77a;
+  stroke-width: 2;
+  opacity: 0.9;
+  r: 10;
+  animation: tendril-pulse 1.6s ease-in-out infinite;
+  filter: drop-shadow(0 0 5px rgba(244, 215, 122, 0.7));
+}
+@keyframes tendril-pulse {
+  0%, 100% { opacity: 0.45; }
+  50%      { opacity: 1; }
+}
+
+/* Lighthouse-called — slow aqua pulse */
+#overlays circle.called {
+  stroke: #6bd3d1;
+  stroke-width: 1.6;
+  opacity: 0.8;
+  r: 11;
+  fill: none;
+  animation: called-pulse 3.2s ease-in-out infinite;
+  filter: drop-shadow(0 0 6px rgba(107, 211, 209, 0.6));
+}
+@keyframes called-pulse {
+  0%, 100% { opacity: 0.35; r: 10; }
+  50%      { opacity: 0.9;  r: 13; }
+}
+
+/* Dream-mode — washes the whole SVG in a hue-rotated, desaturated tint */
+svg#world {
+  transition: filter 1000ms ease;
+}
+svg#world.dream-mode {
+  filter: hue-rotate(80deg) saturate(0.6) brightness(0.85);
+}
+
+/* Dream dialog text — green serif, faded edges */
+.dream-dialog text {
+  font-family: "Georgia", serif;
+  font-size: 9px;
+  fill: #8edc9c;
+  opacity: 0.85;
+  text-shadow: 0 0 4px rgba(60, 100, 60, 0.4);
+  paint-order: stroke;
+  stroke: rgba(8, 16, 8, 0.85);
+  stroke-width: 0.6;
+}
+
+/* Roster drift indicator */
+.roster-list li.drifted {
+  color: #e7c4ed;
+  font-style: italic;
+}
+
+/* ============================== Journal panel ============================== */
+#journal {
+  background: #2a2014;
+  border-color: #5a4528;
+}
+#journal > summary {
+  background: #3a2c18;
+  color: #e7c98a;
+  border-bottom-color: #5a4528;
+}
+.journal-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  font-family: "Georgia", "Times New Roman", serif;
+  font-style: italic;
+  font-size: 12px;
+  color: #efe2bf;
+}
+.journal-list li {
+  padding: 5px 0;
+  border-bottom: 1px dotted #5a4528;
+  line-height: 1.4;
+}
+
+/* ============================== Lighthouse voice panel ============================== */
+#lighthouse-voice {
+  background: #02100a;
+  border-color: #1f6240;
+}
+#lighthouse-voice > summary {
+  background: #051a10;
+  color: #6bd3a1;
+  border-bottom-color: #1f6240;
+}
+.lighthouse-voice-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  font-family: "Courier New", "Menlo", monospace;
+  font-size: 12px;
+  color: #6bd3a1;
+  letter-spacing: 1.2px;
+  text-shadow: 0 0 3px rgba(107, 211, 161, 0.4);
+}
+.lighthouse-voice-list li {
+  padding: 4px 0;
+  border-bottom: 1px dotted #1f6240;
+  animation: crt-twitch 4s steps(20, end) infinite;
+}
+@keyframes crt-twitch {
+  0%, 92%, 100% { letter-spacing: 1.2px; }
+  93%           { letter-spacing: 2.2px; opacity: 0.8; }
+  95%           { letter-spacing: 0.8px; opacity: 1; }
+}
+
+/* ============================== Bus panel ============================== */
+#bus-panel {
+  border-color: #c2a23f;
+}
+#bus-panel > summary {
+  background: #1f1a08;
+  color: #f4d77a;
+  border-bottom-color: #c2a23f;
+}
+.bus-countdown {
+  font-family: "Georgia", serif;
+  font-size: 12px;
+  color: #f4d77a;
+  margin-bottom: 6px;
+  letter-spacing: 0.5px;
+}
+.bus-passengers {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  font-size: 12px;
+}
+.bus-passengers li {
+  padding: 4px 0;
+  border-bottom: 1px dotted var(--line);
+}
+.bus-passengers li strong { color: var(--char); }
+.bus-passengers li .bus-back {
+  color: var(--muted);
+  font-style: italic;
+}
+.bus-passengers li.bus-empty {
+  color: var(--muted);
+  font-style: italic;
+}

--- a/from-simulation/app/static/img/fromville.svg
+++ b/from-simulation/app/static/img/fromville.svg
@@ -51,6 +51,22 @@
       <feDisplacementMap in="SourceGraphic" scale="1.5" />
     </filter>
 
+    <!-- CRT-scanline filter for the lighthouse-voice radio panel (referenced from CSS) -->
+    <filter id="crt" x="0%" y="0%" width="100%" height="100%">
+      <feFlood flood-color="#0a1e10" flood-opacity="0" result="bg" />
+      <feTurbulence type="fractalNoise" baseFrequency="0.0 1.6" numOctaves="1" seed="7" result="noise" />
+      <feColorMatrix in="noise" type="matrix"
+        values="0 0 0 0 0
+                0 0 0 0 0.65
+                0 0 0 0 0.4
+                0 0 0 0.18 0" result="scanlines" />
+      <feComposite in="scanlines" in2="SourceGraphic" operator="in" result="lines" />
+      <feMerge>
+        <feMergeNode in="SourceGraphic" />
+        <feMergeNode in="lines" />
+      </feMerge>
+    </filter>
+
     <!-- A reusable tree silhouette for the forest ring -->
     <symbol id="tree-tiny" viewBox="0 0 20 24">
       <path d="M10 1 L3 14 L7 14 L1 22 L19 22 L13 14 L17 14 Z" fill="#0d2b13" />
@@ -186,6 +202,44 @@
       stroke-linecap="round"
       opacity="0.75"
     />
+
+    <!-- v2: bus-road continuations.
+         West: dirt road slips through the forest edge and joins the dirt loop near (188, 340).
+         East: an exit road leaves the loop near (812, 340) and curls out into the eastern forest. -->
+    <g id="bus-road">
+      <path
+        d="M 70 320 Q 130 325 188 340"
+        fill="none"
+        stroke="#46381f"
+        stroke-width="18"
+        stroke-linecap="round"
+        opacity="0.82"
+      />
+      <path
+        d="M 70 320 Q 130 325 188 340"
+        fill="none"
+        stroke="#5a4729"
+        stroke-width="12"
+        stroke-dasharray="2 14"
+        opacity="0.6"
+      />
+      <path
+        d="M 812 340 Q 870 300 940 250"
+        fill="none"
+        stroke="#46381f"
+        stroke-width="18"
+        stroke-linecap="round"
+        opacity="0.82"
+      />
+      <path
+        d="M 812 340 Q 870 300 940 250"
+        fill="none"
+        stroke="#5a4729"
+        stroke-width="12"
+        stroke-dasharray="2 14"
+        opacity="0.6"
+      />
+    </g>
   </g>
 
   <!-- ============================== Colony House hilltop ============================== -->

--- a/from-simulation/app/static/img/fromville.svg
+++ b/from-simulation/app/static/img/fromville.svg
@@ -1,0 +1,356 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  viewBox="0 0 1000 700"
+  width="1000"
+  height="700"
+  font-family="Georgia, 'Times New Roman', serif"
+>
+  <title>Fromville</title>
+  <desc>
+    Hand-drawn-feel map of Fromville. Outer forest ring, dirt road oval,
+    town center buildings per BUILDING_LAYOUT, Colony House on a hilltop, the
+    lighthouse in a southern clearing, and five Faraway Trees with dangling
+    bottles along the forest perimeter.
+  </desc>
+
+  <!-- ============================== defs ============================== -->
+  <defs>
+    <radialGradient id="ground" cx="50%" cy="55%" r="65%">
+      <stop offset="0%" stop-color="#3a3320" />
+      <stop offset="55%" stop-color="#28241a" />
+      <stop offset="100%" stop-color="#16140e" />
+    </radialGradient>
+
+    <pattern id="forestNoise" patternUnits="userSpaceOnUse" width="40" height="40">
+      <rect width="40" height="40" fill="#0c1a0c" />
+      <circle cx="6" cy="10" r="3" fill="#143918" opacity="0.6" />
+      <circle cx="20" cy="22" r="4" fill="#0e2a12" opacity="0.7" />
+      <circle cx="32" cy="8" r="2" fill="#1a4422" opacity="0.5" />
+      <circle cx="28" cy="32" r="3" fill="#0a200d" opacity="0.8" />
+      <circle cx="10" cy="30" r="2" fill="#173a1c" opacity="0.6" />
+    </pattern>
+
+    <radialGradient id="hilltop" cx="50%" cy="60%" r="60%">
+      <stop offset="0%" stop-color="#3d3a2b" />
+      <stop offset="100%" stop-color="#1c1a14" stop-opacity="0" />
+    </radialGradient>
+
+    <radialGradient id="lightclearing" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#4a4232" />
+      <stop offset="100%" stop-color="#1c1a14" stop-opacity="0" />
+    </radialGradient>
+
+    <radialGradient id="bottleGlow" cx="50%" cy="50%" r="50%">
+      <stop offset="0%" stop-color="#cda74d" stop-opacity="0.55" />
+      <stop offset="100%" stop-color="#cda74d" stop-opacity="0" />
+    </radialGradient>
+
+    <filter id="rough" x="-5%" y="-5%" width="110%" height="110%">
+      <feTurbulence type="fractalNoise" baseFrequency="0.9" numOctaves="2" seed="3" />
+      <feDisplacementMap in="SourceGraphic" scale="1.5" />
+    </filter>
+
+    <!-- A reusable tree silhouette for the forest ring -->
+    <symbol id="tree-tiny" viewBox="0 0 20 24">
+      <path d="M10 1 L3 14 L7 14 L1 22 L19 22 L13 14 L17 14 Z" fill="#0d2b13" />
+      <rect x="9" y="22" width="2" height="2" fill="#241608" />
+    </symbol>
+
+    <!-- A Faraway Tree: taller, gnarled, with dangling bottles -->
+    <symbol id="faraway-tree" viewBox="0 0 80 120">
+      <!-- glow -->
+      <circle cx="40" cy="60" r="55" fill="url(#bottleGlow)" />
+      <!-- trunk -->
+      <path
+        d="M38 118 Q34 92 36 70 Q30 50 40 30 Q50 50 44 70 Q46 92 42 118 Z"
+        fill="#1d1206"
+        stroke="#0a0603"
+        stroke-width="1"
+      />
+      <!-- canopy -->
+      <path
+        d="M10 50 Q20 10 40 5 Q60 10 70 50 Q60 60 50 50 Q45 70 40 50 Q35 70 30 50 Q20 60 10 50 Z"
+        fill="#0a1f0c"
+        stroke="#1b3a1f"
+        stroke-width="0.8"
+      />
+      <!-- bottles -->
+      <g stroke="#7b6a3a" stroke-width="0.6">
+        <line x1="22" y1="46" x2="22" y2="62" />
+        <line x1="32" y1="40" x2="32" y2="58" />
+        <line x1="44" y1="42" x2="44" y2="64" />
+        <line x1="56" y1="44" x2="56" y2="60" />
+        <line x1="64" y1="48" x2="64" y2="66" />
+      </g>
+      <g fill="#3a5c47" stroke="#cda74d" stroke-width="0.4">
+        <ellipse cx="22" cy="66" rx="2.4" ry="3.6" />
+        <ellipse cx="32" cy="62" rx="2.4" ry="3.6" />
+        <ellipse cx="44" cy="68" rx="2.4" ry="3.6" />
+        <ellipse cx="56" cy="64" rx="2.4" ry="3.6" />
+        <ellipse cx="64" cy="70" rx="2.4" ry="3.6" />
+      </g>
+    </symbol>
+  </defs>
+
+  <!-- ============================== ground ============================== -->
+  <rect x="0" y="0" width="1000" height="700" fill="url(#ground)" />
+
+  <!-- Outer forest ring: dense pattern band around the perimeter -->
+  <g id="forest-ring">
+    <!-- top band -->
+    <rect x="0" y="0" width="1000" height="85" fill="url(#forestNoise)" />
+    <!-- bottom band -->
+    <rect x="0" y="600" width="1000" height="100" fill="url(#forestNoise)" />
+    <!-- left band -->
+    <rect x="0" y="0" width="120" height="700" fill="url(#forestNoise)" />
+    <!-- right band -->
+    <rect x="880" y="0" width="120" height="700" fill="url(#forestNoise)" />
+
+    <!-- Irregular tree clusters bleeding inward -->
+    <g opacity="0.95">
+      <use href="#tree-tiny" x="130" y="60" width="20" height="24" />
+      <use href="#tree-tiny" x="180" y="40" width="22" height="26" />
+      <use href="#tree-tiny" x="240" y="65" width="20" height="24" />
+      <use href="#tree-tiny" x="320" y="50" width="22" height="26" />
+      <use href="#tree-tiny" x="400" y="60" width="20" height="24" />
+      <use href="#tree-tiny" x="470" y="48" width="24" height="28" />
+      <use href="#tree-tiny" x="560" y="55" width="20" height="24" />
+      <use href="#tree-tiny" x="630" y="62" width="22" height="26" />
+      <use href="#tree-tiny" x="710" y="50" width="20" height="24" />
+      <use href="#tree-tiny" x="780" y="68" width="22" height="26" />
+      <use href="#tree-tiny" x="840" y="48" width="20" height="24" />
+
+      <use href="#tree-tiny" x="100" y="160" width="20" height="24" />
+      <use href="#tree-tiny" x="80" y="240" width="22" height="26" />
+      <use href="#tree-tiny" x="105" y="330" width="20" height="24" />
+      <use href="#tree-tiny" x="85" y="420" width="22" height="26" />
+      <use href="#tree-tiny" x="110" y="500" width="20" height="24" />
+
+      <use href="#tree-tiny" x="880" y="170" width="22" height="26" />
+      <use href="#tree-tiny" x="900" y="260" width="20" height="24" />
+      <use href="#tree-tiny" x="880" y="350" width="22" height="26" />
+      <use href="#tree-tiny" x="900" y="440" width="20" height="24" />
+      <use href="#tree-tiny" x="880" y="520" width="22" height="26" />
+
+      <use href="#tree-tiny" x="160" y="610" width="22" height="26" />
+      <use href="#tree-tiny" x="250" y="630" width="20" height="24" />
+      <use href="#tree-tiny" x="340" y="615" width="22" height="26" />
+      <use href="#tree-tiny" x="430" y="625" width="20" height="24" />
+      <use href="#tree-tiny" x="520" y="615" width="22" height="26" />
+      <use href="#tree-tiny" x="610" y="630" width="20" height="24" />
+      <use href="#tree-tiny" x="700" y="612" width="22" height="26" />
+      <use href="#tree-tiny" x="780" y="630" width="20" height="24" />
+    </g>
+  </g>
+
+  <!-- ============================== road loop ============================== -->
+  <g id="road">
+    <ellipse
+      cx="500"
+      cy="380"
+      rx="320"
+      ry="180"
+      fill="none"
+      stroke="#46381f"
+      stroke-width="22"
+      stroke-linecap="round"
+      opacity="0.85"
+    />
+    <ellipse
+      cx="500"
+      cy="380"
+      rx="320"
+      ry="180"
+      fill="none"
+      stroke="#5a4729"
+      stroke-width="14"
+      stroke-dasharray="2 14"
+      opacity="0.65"
+    />
+    <!-- Side path up to the Colony House hilltop -->
+    <path
+      d="M760 320 Q790 250 780 200"
+      fill="none"
+      stroke="#46381f"
+      stroke-width="14"
+      stroke-linecap="round"
+      opacity="0.8"
+    />
+    <!-- Side path down to the lighthouse clearing -->
+    <path
+      d="M500 540 Q500 555 500 560"
+      fill="none"
+      stroke="#46381f"
+      stroke-width="12"
+      stroke-linecap="round"
+      opacity="0.75"
+    />
+  </g>
+
+  <!-- ============================== Colony House hilltop ============================== -->
+  <g id="colony-hilltop">
+    <ellipse cx="780" cy="200" rx="110" ry="60" fill="url(#hilltop)" />
+    <!-- Victorian Colony House @ (780, 180) -->
+    <g transform="translate(780,180)">
+      <!-- glow rune (talisman) -->
+      <g class="talisman">
+        <circle r="46" fill="none" stroke="#cda74d" stroke-width="0.6" opacity="0.45" />
+        <path
+          d="M -38 0 L -32 -6 L -28 0 L -32 6 Z M 38 0 L 32 -6 L 28 0 L 32 6 Z M 0 -38 L -6 -32 L 0 -28 L 6 -32 Z M 0 38 L -6 32 L 0 28 L 6 32 Z"
+          fill="#cda74d"
+          opacity="0.55"
+        />
+      </g>
+      <!-- main body -->
+      <rect x="-44" y="-6" width="88" height="38" fill="#2c241a" stroke="#0a0805" stroke-width="1.2" />
+      <!-- roof -->
+      <path d="M -52 -6 L 0 -36 L 52 -6 Z" fill="#3a2f1f" stroke="#0a0805" stroke-width="1.2" />
+      <!-- tower -->
+      <rect x="-10" y="-30" width="20" height="20" fill="#2c241a" stroke="#0a0805" stroke-width="1" />
+      <path d="M -12 -30 L 0 -46 L 12 -30 Z" fill="#3a2f1f" stroke="#0a0805" stroke-width="1" />
+      <!-- windows -->
+      <rect x="-34" y="2" width="10" height="12" fill="#c8a14a" opacity="0.7" />
+      <rect x="-8" y="2" width="10" height="12" fill="#c8a14a" opacity="0.7" />
+      <rect x="18" y="2" width="10" height="12" fill="#c8a14a" opacity="0.7" />
+      <rect x="-4" y="18" width="8" height="14" fill="#241406" />
+      <!-- label -->
+      <text x="0" y="58" text-anchor="middle" fill="#cda74d" font-size="11" letter-spacing="1">
+        COLONY HOUSE
+      </text>
+    </g>
+  </g>
+
+  <!-- ============================== Lighthouse clearing ============================== -->
+  <g id="lighthouse-area">
+    <ellipse cx="500" cy="560" rx="70" ry="36" fill="url(#lightclearing)" />
+    <g transform="translate(500,560)">
+      <!-- base -->
+      <rect x="-7" y="-4" width="14" height="22" fill="#1f1c14" stroke="#0a0805" stroke-width="1" />
+      <!-- tower -->
+      <path d="M -9 -4 L -5 -32 L 5 -32 L 9 -4 Z" fill="#d3d0c4" stroke="#0a0805" stroke-width="1" />
+      <!-- stripes -->
+      <rect x="-7" y="-26" width="14" height="4" fill="#8a1c1c" />
+      <rect x="-7" y="-14" width="14" height="4" fill="#8a1c1c" />
+      <!-- lamp room -->
+      <rect x="-7" y="-40" width="14" height="8" fill="#1f1c14" stroke="#0a0805" stroke-width="1" />
+      <circle cx="0" cy="-36" r="3" fill="#f4d77a" />
+      <!-- cap -->
+      <path d="M -8 -40 L 0 -48 L 8 -40 Z" fill="#3a2f1f" stroke="#0a0805" stroke-width="1" />
+      <text x="0" y="30" text-anchor="middle" fill="#9a8c64" font-size="9" letter-spacing="1">
+        LIGHTHOUSE
+      </text>
+    </g>
+  </g>
+
+  <!-- ============================== Town center buildings ============================== -->
+  <!-- Coordinates match BUILDING_LAYOUT in contracts.py -->
+
+  <!-- Sheriff's House (350, 360) talisman -->
+  <g class="building" transform="translate(350,360)">
+    <g class="talisman">
+      <circle r="30" fill="none" stroke="#cda74d" stroke-width="0.5" opacity="0.35" />
+      <path d="M -22 0 L 0 -22 L 22 0 L 0 22 Z" fill="none" stroke="#cda74d" stroke-width="0.8" opacity="0.55" />
+    </g>
+    <rect x="-22" y="-14" width="44" height="22" fill="#3a2f20" stroke="#0a0805" stroke-width="1" />
+    <path d="M -26 -14 L 0 -28 L 26 -14 Z" fill="#4a3a26" stroke="#0a0805" stroke-width="1" />
+    <rect x="-4" y="-4" width="8" height="12" fill="#241406" />
+    <rect x="-16" y="-8" width="6" height="6" fill="#c8a14a" opacity="0.6" />
+    <rect x="10" y="-8" width="6" height="6" fill="#c8a14a" opacity="0.6" />
+    <text x="0" y="22" text-anchor="middle" fill="#cda74d" font-size="9">SHERIFF</text>
+  </g>
+
+  <!-- Matthews House (520, 380) talisman -->
+  <g class="building" transform="translate(520,380)">
+    <g class="talisman">
+      <circle r="32" fill="none" stroke="#cda74d" stroke-width="0.5" opacity="0.35" />
+      <path d="M -22 0 L 0 -22 L 22 0 L 0 22 Z" fill="none" stroke="#cda74d" stroke-width="0.8" opacity="0.55" />
+    </g>
+    <rect x="-24" y="-14" width="48" height="22" fill="#3a2f20" stroke="#0a0805" stroke-width="1" />
+    <path d="M -28 -14 L 0 -30 L 28 -14 Z" fill="#4a3a26" stroke="#0a0805" stroke-width="1" />
+    <rect x="-4" y="-4" width="8" height="12" fill="#241406" />
+    <rect x="-18" y="-8" width="6" height="6" fill="#c8a14a" opacity="0.6" />
+    <rect x="12" y="-8" width="6" height="6" fill="#c8a14a" opacity="0.6" />
+    <text x="0" y="22" text-anchor="middle" fill="#cda74d" font-size="9">MATTHEWS</text>
+  </g>
+
+  <!-- Church (430, 310) talisman -->
+  <g class="building" transform="translate(430,310)">
+    <g class="talisman">
+      <circle r="34" fill="none" stroke="#cda74d" stroke-width="0.5" opacity="0.45" />
+      <path d="M 0 -28 L 0 14 M -10 -10 L 10 -10" stroke="#cda74d" stroke-width="0.8" opacity="0.7" />
+    </g>
+    <rect x="-22" y="-12" width="44" height="22" fill="#2c2418" stroke="#0a0805" stroke-width="1" />
+    <path d="M -26 -12 L 0 -28 L 26 -12 Z" fill="#3a2f1f" stroke="#0a0805" stroke-width="1" />
+    <!-- steeple -->
+    <rect x="-4" y="-30" width="8" height="10" fill="#2c2418" stroke="#0a0805" stroke-width="0.6" />
+    <path d="M -5 -30 L 0 -40 L 5 -30 Z" fill="#3a2f1f" stroke="#0a0805" stroke-width="0.6" />
+    <line x1="0" y1="-44" x2="0" y2="-40" stroke="#cda74d" stroke-width="1" />
+    <line x1="-2" y1="-42" x2="2" y2="-42" stroke="#cda74d" stroke-width="1" />
+    <rect x="-3" y="-4" width="6" height="14" fill="#241406" />
+    <text x="0" y="24" text-anchor="middle" fill="#cda74d" font-size="9">CHURCH</text>
+  </g>
+
+  <!-- Diner (580, 330) — no talisman -->
+  <g class="building" transform="translate(580,330)">
+    <rect x="-22" y="-12" width="44" height="20" fill="#3a2f20" stroke="#0a0805" stroke-width="1" />
+    <path d="M -24 -12 L -24 -16 L 24 -16 L 24 -12 Z" fill="#7d5024" stroke="#0a0805" stroke-width="0.6" />
+    <rect x="-3" y="-2" width="6" height="10" fill="#241406" />
+    <rect x="-18" y="-8" width="10" height="6" fill="#f4d77a" opacity="0.75" />
+    <rect x="8" y="-8" width="10" height="6" fill="#f4d77a" opacity="0.75" />
+    <text x="0" y="22" text-anchor="middle" fill="#a89870" font-size="9">DINER</text>
+  </g>
+
+  <!-- Clinic (470, 420) talisman -->
+  <g class="building" transform="translate(470,420)">
+    <g class="talisman">
+      <circle r="28" fill="none" stroke="#cda74d" stroke-width="0.5" opacity="0.35" />
+      <path d="M -8 0 L 8 0 M 0 -8 L 0 8" stroke="#cda74d" stroke-width="0.8" opacity="0.6" />
+    </g>
+    <rect x="-20" y="-12" width="40" height="22" fill="#2e2a24" stroke="#0a0805" stroke-width="1" />
+    <path d="M -22 -12 L 0 -22 L 22 -12 Z" fill="#3a342a" stroke="#0a0805" stroke-width="1" />
+    <rect x="-3" y="-4" width="6" height="14" fill="#241406" />
+    <path d="M -3 -14 L 3 -14 M 0 -17 L 0 -11" stroke="#cda74d" stroke-width="1.4" />
+    <text x="0" y="24" text-anchor="middle" fill="#cda74d" font-size="9">CLINIC</text>
+  </g>
+
+  <!-- Boyd's Camper (300, 420) — no talisman -->
+  <g class="building" transform="translate(300,420)">
+    <rect x="-22" y="-8" width="44" height="16" rx="6" ry="6" fill="#3a3128" stroke="#0a0805" stroke-width="1" />
+    <rect x="-10" y="-4" width="8" height="6" fill="#c8a14a" opacity="0.6" />
+    <rect x="2" y="-4" width="8" height="6" fill="#c8a14a" opacity="0.6" />
+    <circle cx="-14" cy="9" r="3" fill="#16100a" />
+    <circle cx="14" cy="9" r="3" fill="#16100a" />
+    <text x="0" y="22" text-anchor="middle" fill="#a89870" font-size="9">CAMPER</text>
+  </g>
+
+  <!-- ============================== Faraway Trees ============================== -->
+  <g id="faraway-trees">
+    <use href="#faraway-tree" x="40" y="60" width="80" height="120" />
+    <use href="#faraway-tree" x="880" y="90" width="80" height="120" />
+    <use href="#faraway-tree" x="20" y="500" width="80" height="120" />
+    <use href="#faraway-tree" x="900" y="520" width="80" height="120" />
+    <use href="#faraway-tree" x="460" y="-20" width="80" height="120" />
+    <g font-size="8" fill="#3f7355" letter-spacing="1">
+      <text x="80" y="190" text-anchor="middle">faraway</text>
+      <text x="920" y="220" text-anchor="middle">faraway</text>
+      <text x="60" y="630" text-anchor="middle">faraway</text>
+      <text x="940" y="650" text-anchor="middle">faraway</text>
+      <text x="500" y="110" text-anchor="middle">faraway</text>
+    </g>
+  </g>
+
+  <!-- ============================== Town label ============================== -->
+  <g id="town-label">
+    <text
+      x="500"
+      y="685"
+      text-anchor="middle"
+      font-size="11"
+      letter-spacing="6"
+      fill="#5a4f36"
+    >
+      FROMVILLE
+    </text>
+  </g>
+</svg>

--- a/from-simulation/app/static/js/inspector.js
+++ b/from-simulation/app/static/js/inspector.js
@@ -1,0 +1,503 @@
+/*
+ * inspector.js — v6 dossier overlay + SVG viewBox zoom.
+ *
+ * Lifecycle:
+ *   1. User clicks a token on the map. map.js emits an `inspect` socket
+ *      event with the clicked agent's id.
+ *   2. The Flask server resolves the agent and emits `inspect_reply` back,
+ *      which socket.js fans out as a `from:inspect` window event with the
+ *      full agent record (now including v6 fields: intent, inventory,
+ *      relationships, memory_recent).
+ *   3. This module catches `from:inspect`, animates the SVG viewBox to
+ *      zoom on the agent's (x, y), and renders the dossier panel.
+ *   4. Close (button, Escape, or click outside the dossier) → restore the
+ *      original viewBox and hide the panel.
+ *
+ * Self-contained IIFE: no globals beyond the existing window event bus.
+ */
+(function () {
+  "use strict";
+
+  // viewport for the world map; matches the inline SVG declaration in
+  // _map_svg.html. Used as the "rest" frame to restore on close.
+  const DEFAULT_VIEWBOX = [0, 0, 1000, 700];
+  const ZOOM_W = 200;
+  const ZOOM_H = 150;
+  const ANIM_MS = 400;
+
+  let currentRecord = null;          // last full record received
+  let animRaf = 0;                   // RAF handle for the in-flight tween
+  let restoreViewBox = DEFAULT_VIEWBOX.slice();
+
+  function $(id) { return document.getElementById(id); }
+
+  // ---------------------------------------------------------------- helpers
+  function escapeHtml(s) {
+    return String(s == null ? "" : s).replace(/[&<>"']/g, (c) => ({
+      "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;",
+    })[c]);
+  }
+
+  function slugFor(record) {
+    if (!record) return null;
+    const name = String(record.name || "").toLowerCase().trim();
+    if (name.includes("yellow")) return "yellow";
+    if (name.includes("white"))  return "white";
+    const known = new Set([
+      "boyd", "donna", "jim", "tabitha", "ethan", "julie",
+      "jade", "kenny", "khatri", "sara",
+    ]);
+    if (known.has(name)) return name;
+    const mc = record.marker_class || "";
+    if (mc === "man-in-yellow") return "yellow";
+    if (mc === "boy-in-white")  return "white";
+    return null;
+  }
+
+  function parseViewBox(svg) {
+    const raw = svg && svg.getAttribute("viewBox");
+    if (!raw) return DEFAULT_VIEWBOX.slice();
+    const parts = raw.split(/[\s,]+/).map(Number).filter((n) => !isNaN(n));
+    if (parts.length !== 4) return DEFAULT_VIEWBOX.slice();
+    return parts;
+  }
+
+  // ---------------------------------------------------------------- zoom
+  function easeOutCubic(t) { return 1 - Math.pow(1 - t, 3); }
+
+  function tweenViewBox(svg, from, to, durationMs) {
+    if (animRaf) {
+      cancelAnimationFrame(animRaf);
+      animRaf = 0;
+    }
+    const start = performance.now();
+    function step(now) {
+      const t = Math.min(1, (now - start) / durationMs);
+      const e = easeOutCubic(t);
+      const x = from[0] + (to[0] - from[0]) * e;
+      const y = from[1] + (to[1] - from[1]) * e;
+      const w = from[2] + (to[2] - from[2]) * e;
+      const h = from[3] + (to[3] - from[3]) * e;
+      svg.setAttribute(
+        "viewBox",
+        `${x.toFixed(2)} ${y.toFixed(2)} ${w.toFixed(2)} ${h.toFixed(2)}`
+      );
+      if (t < 1) {
+        animRaf = requestAnimationFrame(step);
+      } else {
+        animRaf = 0;
+      }
+    }
+    animRaf = requestAnimationFrame(step);
+  }
+
+  function zoomToAgent(x, y) {
+    const svg = document.getElementById("map");
+    if (!svg) return;
+    // Save the viewBox the FIRST time we zoom — subsequent zooms (clicking
+    // a second token without closing) should still restore to the original
+    // pre-zoom frame, not the zoomed one we just left.
+    if (!isOpen()) restoreViewBox = parseViewBox(svg);
+    const from = parseViewBox(svg);
+    // Clamp the zoom rect inside the world bounds so we don't pan into the
+    // void when a token is right at the edge.
+    const minX = Math.max(0, Math.min(1000 - ZOOM_W, x - ZOOM_W / 2));
+    const minY = Math.max(0, Math.min(700 - ZOOM_H, y - ZOOM_H / 2));
+    tweenViewBox(svg, from, [minX, minY, ZOOM_W, ZOOM_H], ANIM_MS);
+  }
+
+  function restoreZoom() {
+    const svg = document.getElementById("map");
+    if (!svg) return;
+    const from = parseViewBox(svg);
+    tweenViewBox(svg, from, restoreViewBox, ANIM_MS);
+  }
+
+  // ---------------------------------------------------------------- dossier
+  function isOpen() {
+    const el = $("dossier");
+    return !!(el && !el.classList.contains("hidden"));
+  }
+
+  function close() {
+    const el = $("dossier");
+    if (!el) return;
+    if (!el.classList.contains("hidden")) {
+      el.classList.add("hidden");
+      restoreZoom();
+    }
+    currentRecord = null;
+  }
+
+  function renderTokenSvg(slug) {
+    if (!slug) {
+      // Generic silhouette for NPCs / creatures / unknowns. Uses a stylised
+      // pin shape so the dossier header isn't visually empty.
+      return [
+        '<svg viewBox="0 0 60 80" width="60" height="80" aria-hidden="true">',
+        '<ellipse cx="30" cy="76" rx="12" ry="1.5" fill="#1a1611" opacity="0.4"/>',
+        '<circle cx="30" cy="28" r="14" fill="#7d6a4a" stroke="#1a1611" stroke-width="1"/>',
+        '<path d="M 14 70 Q 30 50 46 70 L 48 76 L 12 76 Z" fill="#7d6a4a" stroke="#1a1611" stroke-width="1"/>',
+        "</svg>",
+      ].join("");
+    }
+    return [
+      '<svg viewBox="0 0 60 80" width="60" height="80" aria-hidden="true">',
+      `<use href="#token-${escapeHtml(slug)}" />`,
+      "</svg>",
+    ].join("");
+  }
+
+  function vitalBar(klass, label, value) {
+    // Values may be 0..1 (fear/sanity, floats) or 0..100 (hunger).
+    let pct;
+    if (value == null || isNaN(value)) {
+      pct = 0;
+    } else if (value <= 1.0001) {
+      pct = Math.max(0, Math.min(100, value * 100));
+    } else {
+      pct = Math.max(0, Math.min(100, value));
+    }
+    const display = value == null
+      ? "—"
+      : (value <= 1.0001 ? value.toFixed(2) : Math.round(value));
+    return [
+      '<div class="vital">',
+      `<span class="vital-label">${escapeHtml(label)}</span>`,
+      `<div class="bar ${escapeHtml(klass)}"><div class="bar-fill" style="width:${pct.toFixed(1)}%"></div></div>`,
+      `<span class="vital-val">${escapeHtml(display)}</span>`,
+      "</div>",
+    ].join("");
+  }
+
+  function renderInventory(inventory) {
+    const items = inventory && typeof inventory === "object" ? inventory : {};
+    const keys = Object.keys(items).filter((k) => Number(items[k]) > 0);
+    if (keys.length === 0) {
+      return '<ul class="inventory"><li class="muted">Empty pockets</li></ul>';
+    }
+    const rows = keys.map((k) => {
+      const qty = Number(items[k]) || 0;
+      const pretty = k.replace(/_/g, " ");
+      return `<li><span class="item-name">${escapeHtml(pretty)}</span><span class="item-qty">×${qty}</span></li>`;
+    });
+    return `<ul class="inventory">${rows.join("")}</ul>`;
+  }
+
+  function renderRelationships(rel) {
+    const trusted = (rel && Array.isArray(rel.trusted)) ? rel.trusted : [];
+    const mistrusted = (rel && Array.isArray(rel.mistrusted)) ? rel.mistrusted : [];
+    function rows(list, klass, empty) {
+      if (list.length === 0) {
+        return `<li class="muted">${escapeHtml(empty)}</li>`;
+      }
+      return list.map((r) => {
+        const score = (r && typeof r.score === "number") ? r.score.toFixed(2) : "—";
+        return `<li><span class="rel-name">${escapeHtml(r.partner_name || r.partner_id || "?")}</span><span class="rel-score ${klass}">${escapeHtml(score)}</span></li>`;
+      }).join("");
+    }
+    return [
+      '<div class="relationships">',
+      '<h3>Trusted</h3>',
+      `<ul class="rel-list pos">${rows(trusted, "pos", "no strong allies")}</ul>`,
+      '<h3>Mistrusted</h3>',
+      `<ul class="rel-list neg">${rows(mistrusted, "neg", "no enemies recorded")}</ul>`,
+      "</div>",
+    ].join("");
+  }
+
+  function renderMemory(memory) {
+    const rows = Array.isArray(memory) ? memory : [];
+    if (rows.length === 0) {
+      return '<ol class="memory"><li class="muted">No recent memories on file.</li></ol>';
+    }
+    const items = rows.map((m) => {
+      const tick = m && m.tick != null ? "t" + m.tick : "";
+      const kind = m && m.kind ? `[${String(m.kind).toUpperCase()}]` : "";
+      const detail = m && m.detail ? m.detail : "(silent)";
+      return [
+        "<li>",
+        `<span class="mem-tick">${escapeHtml(tick)}</span>`,
+        `<span class="kind">${escapeHtml(kind)}</span>`,
+        `<span class="detail">${escapeHtml(detail)}</span>`,
+        "</li>",
+      ].join("");
+    });
+    return `<ol class="memory">${items.join("")}</ol>`;
+  }
+
+  function isCreature(record) {
+    const k = String(record.kind || "").toLowerCase();
+    const mc = String(record.marker_class || "").toLowerCase();
+    return k === "creature" || mc.startsWith("creature");
+  }
+
+  function isBuilding(record) {
+    return String(record.kind || "").toLowerCase() === "building";
+  }
+
+  function isCar(record) {
+    return String(record.kind || "").toLowerCase() === "car";
+  }
+
+  // v9 — Mind section in the dossier: active goal + top 3 beliefs.
+  function renderMind(mind) {
+    if (!mind || typeof mind !== "object") {
+      return [
+        '<div class="mind-section">',
+          '<h4>Mind</h4>',
+          '<div class="mind-empty">No active thoughts.</div>',
+        '</div>',
+      ].join("");
+    }
+    const goal = mind.active_goal;
+    const beliefs = Array.isArray(mind.beliefs) ? mind.beliefs : [];
+    const parts = ['<div class="mind-section"><h4>Mind</h4>'];
+    if (goal) {
+      const prio = Math.round((goal.priority || 0) * 100);
+      parts.push(
+        '<div class="mind-goal">',
+          `<span class="goal-kind">${escapeHtml(goal.kind || "")}</span>`,
+          `<span class="goal-target">${escapeHtml(goal.target || "")}</span>`,
+          `<span class="goal-priority">P=${prio}</span>`,
+        '</div>'
+      );
+    } else {
+      parts.push('<div class="mind-empty">No active goal.</div>');
+    }
+    if (beliefs.length === 0) {
+      parts.push('<div class="mind-empty">No formed beliefs yet.</div>');
+    } else {
+      parts.push('<ul class="mind-beliefs">');
+      beliefs.forEach(function (b) {
+        const conf = Math.max(0, Math.min(1, b.confidence || 0));
+        const polCls = (b.polarity || 0) >= 0 ? "belief-polarity-positive" : "belief-polarity-negative";
+        const glyph = (b.polarity || 0) >= 0 ? "▲" : "▼";
+        parts.push(
+          '<li>',
+            `<span class="${polCls}">${glyph}</span>`,
+            `<span class="belief-key">${escapeHtml(b.key || "")}</span>`,
+            `<span class="belief-note">${escapeHtml(b.note || "")}</span>`,
+            '<span class="belief-conf"><span class="belief-conf-fill" ',
+              `style="width:${(conf * 100).toFixed(0)}%"></span></span>`,
+          '</li>'
+        );
+      });
+      parts.push('</ul>');
+    }
+    parts.push(
+      `<div class="mind-empty">Reflections: ${mind.reflections_count || 0}</div>`,
+      '</div>'
+    );
+    return parts.join("");
+  }
+
+  function renderCar(record) {
+    const pass = record.passenger;
+    const passLine = pass && pass.name
+      ? `${escapeHtml(pass.name)}`
+      : "no passenger";
+    return [
+      '<dl class="creature-facts">',
+        '<dt>Mode</dt>',
+        `<dd>${escapeHtml(record.substate || "—")}</dd>`,
+        '<dt>Passenger</dt>',
+        `<dd>${passLine}</dd>`,
+        '<dt>Trip</dt>',
+        `<dd>${escapeHtml(record.outbound_done > 0 ? "leaving town" : "arriving")}</dd>`,
+      "</dl>",
+    ].join("");
+  }
+
+  function renderBuilding(record) {
+    const occupants = Array.isArray(record.occupants_inside) ? record.occupants_inside : [];
+    const residents = Array.isArray(record.residents_away) ? record.residents_away : [];
+    const status = record.destroyed
+      ? "Destroyed"
+      : (record.cooling_off_in_ticks > 0
+          ? `Cooling off (${record.cooling_off_in_ticks} ticks)`
+          : "Intact");
+    const cap = record.capacity || 0;
+    const occ = record.occupied || 0;
+    const capLine = cap > 0
+      ? `${occ} of ${cap}${record.full ? " (FULL)" : ""}`
+      : "—";
+    const facts = [
+      '<dl class="creature-facts">',
+        '<dt>Talisman</dt>',
+        `<dd>${record.has_talisman ? "Warded" : "None"}</dd>`,
+        '<dt>State</dt>',
+        `<dd>${escapeHtml(status)}</dd>`,
+        '<dt>Capacity</dt>',
+        `<dd>${escapeHtml(capLine)}</dd>`,
+        '<dt>Damage</dt>',
+        `<dd>${escapeHtml(String(record.damage || 0))}</dd>`,
+      record.destroyed
+        ? `<dt>Rebuild</dt><dd>${(record.rebuild_progress || 0).toFixed(1)} / 50</dd>`
+        : "",
+      "</dl>",
+    ].join("");
+
+    function listSection(label, list, empty) {
+      if (!list.length) {
+        return `<h3>${escapeHtml(label)}</h3>`
+          + `<div class="muted-line">${escapeHtml(empty)}</div>`;
+      }
+      const rows = list.map((p) => {
+        const role = p.role
+          ? `<span class="building-role"> · ${escapeHtml(String(p.role))}</span>`
+          : "";
+        return `<li><span class="rel-name">${escapeHtml(p.name)}</span>${role}</li>`;
+      }).join("");
+      return `<h3>${escapeHtml(label)}</h3>`
+        + `<ul class="building-list">${rows}</ul>`;
+    }
+    return [
+      facts,
+      listSection("Inside now", occupants, "No one is inside right now."),
+      listSection("Lives here", residents, "No one calls this home."),
+    ].join("");
+  }
+
+  function renderCreatureExtras(record) {
+    // Creatures don't have vitals/inventory/relationships/memory — surface
+    // the substate FSM fields instead so clicking a creature is useful.
+    const target = record.target || record.target_id || "";
+    const targetLabel = record.target_name || target || "—";
+    const substate = record.substate || record.status || "—";
+    const victim = record.victim_id || "—";
+    return [
+      '<dl class="creature-facts">',
+        '<dt>Mode</dt>',
+        `<dd>${escapeHtml(substate)}</dd>`,
+        '<dt>Target</dt>',
+        `<dd>${escapeHtml(targetLabel)}</dd>`,
+        '<dt>Quarry</dt>',
+        `<dd>${escapeHtml(victim)}</dd>`,
+      "</dl>",
+    ].join("");
+  }
+
+  function render(record) {
+    const dossier = $("dossier");
+    if (!dossier || !record) return;
+    currentRecord = record;
+
+    if (record.error) {
+      dossier.innerHTML = [
+        '<button class="close" type="button" aria-label="Close">×</button>',
+        `<div class="error">${escapeHtml(record.error)}</div>`,
+      ].join("");
+      dossier.classList.remove("hidden");
+      wireClose();
+      return;
+    }
+
+    const slug = slugFor(record);
+    const name = record.name || record.id || "Unknown";
+    const role = record.role || record.kind || "";
+    const status = record.status || record.state || "";
+    const intent = (record.intent && String(record.intent).trim()) ||
+      "Going about their business.";
+
+    const building = isBuilding(record);
+    const car = !building && isCar(record);
+    const creature = !building && !car && isCreature(record);
+    const body = building
+      ? renderBuilding(record)
+      : car
+      ? renderCar(record)
+      : creature
+      ? [
+          `<p class="intent">${escapeHtml(intent)}</p>`,
+          renderCreatureExtras(record),
+        ].join("")
+      : [
+          `<p class="intent">${escapeHtml(intent)}</p>`,
+          '<div class="vitals">',
+            vitalBar("fear",   "Fear",   record.fear),
+            vitalBar("sanity", "Sanity", record.sanity),
+            vitalBar("hunger", "Hunger", record.hunger),
+          "</div>",
+          renderMind(record.mind),
+          "<h3>Inventory</h3>",
+          renderInventory(record.inventory),
+          renderRelationships(record.relationships),
+          "<h3>Recent memory</h3>",
+          renderMemory(record.memory_recent),
+        ].join("");
+
+    const html = [
+      '<button class="close" type="button" aria-label="Close">×</button>',
+      '<div class="header">',
+        renderTokenSvg(slug),
+        '<div class="header-text">',
+          `<h2>${escapeHtml(name)}</h2>`,
+          `<span class="role">${escapeHtml(role)}${role && status ? " · " : ""}${escapeHtml(status)}</span>`,
+        "</div>",
+      "</div>",
+      body,
+    ].join("");
+
+    dossier.innerHTML = html;
+    dossier.classList.remove("hidden");
+    wireClose();
+  }
+
+  function wireClose() {
+    const dossier = $("dossier");
+    if (!dossier) return;
+    const btn = dossier.querySelector(".close");
+    if (btn) {
+      btn.addEventListener("click", (e) => {
+        e.stopPropagation();
+        close();
+      });
+    }
+  }
+
+  // ---------------------------------------------------------------- events
+  window.addEventListener("from:inspect", (e) => {
+    const record = e && e.detail;
+    if (!record || !record.id) return;
+
+    // Zoom: prefer the agent's coords from the reply, falling back to looking
+    // up the on-screen token transform if the server omitted x/y.
+    let x = Number(record.x);
+    let y = Number(record.y);
+    if (!isFinite(x) || !isFinite(y)) {
+      const el = document.querySelector(`#entities [data-id="${record.id}"]`);
+      if (el) {
+        const cx = Number(el.getAttribute("cx"));
+        const cy = Number(el.getAttribute("cy"));
+        if (isFinite(cx) && isFinite(cy)) { x = cx; y = cy; }
+      }
+    }
+    if (isFinite(x) && isFinite(y)) zoomToAgent(x, y);
+
+    render(record);
+  });
+
+  // Close via Escape.
+  window.addEventListener("keydown", (e) => {
+    if (e.key === "Escape" && isOpen()) {
+      close();
+    }
+  });
+
+  // Click outside the dossier closes it. We listen on the document so any
+  // click anywhere on the page that ISN'T inside #dossier dismisses the panel.
+  // Clicks on map tokens still re-open it via the inspect round-trip.
+  document.addEventListener("click", (e) => {
+    if (!isOpen()) return;
+    const dossier = $("dossier");
+    if (!dossier) return;
+    if (dossier.contains(e.target)) return;
+    // If the click was on a map token, the new inspect cycle will re-render
+    // before this close fires — but the close listener runs first. Defer the
+    // close one frame so the new render wins.
+    const onToken = e.target && (e.target.closest && e.target.closest("[data-id]"));
+    if (onToken) return;
+    close();
+  });
+})();

--- a/from-simulation/app/static/js/lighting.js
+++ b/from-simulation/app/static/js/lighting.js
@@ -1,90 +1,78 @@
 /*
- * lighting.js — day/night overlay.
+ * lighting.js — day/night overlay (v3).
  *
- * Reads `payload.lighting` from the tick (0 = dark, 1 = bright) and adjusts
- * the alpha of a full-map dim rectangle. CSS transitions the fill smoothly.
- * Also toggles a `.lit` class on the static lighthouse group so its lamp
- * glows when the phase is anything other than DAY.
+ * Reads payload.time.phase ("DAY" | "DUSK" | "DAWN" | "NIGHT") and applies
+ * matching CSS classes to:
+ *   - #lighting   : radial-gradient overlay div inside .map-wrap
+ *   - #mapWrap    : data-time attribute drives .windows + .lighthouse-beam
+ *
+ * Mapping:  DAY  -> ""     (no overlay)
+ *           DUSK -> "dusk"
+ *           DAWN -> "dusk"  (same warm radial)
+ *           NIGHT-> "night"
+ *
+ * Continuous-alpha fallback: the existing #lighting rect (if any) is still
+ * tinted by payload.lighting so non-CSS clients still degrade smoothly.
+ *
+ * Dream-mode class toggle on #world (or #mapWrap as fallback) when
+ * payload.dreams.length > 0 — unchanged from v2.
  */
 (function () {
   "use strict";
 
   const SVG_NS = "http://www.w3.org/2000/svg";
 
-  function ensureOverlay() {
-    const layer = document.getElementById("lighting");
-    if (!layer) return null;
-    let rect = layer.querySelector("rect.lighting-overlay");
-    if (!rect) {
-      rect = document.createElementNS(SVG_NS, "rect");
-      rect.setAttribute("class", "lighting-overlay");
-      rect.setAttribute("x", 0);
-      rect.setAttribute("y", 0);
-      rect.setAttribute("width", 1000);
-      rect.setAttribute("height", 700);
-      rect.setAttribute("pointer-events", "none");
-      rect.setAttribute("fill", "rgba(10, 12, 40, 0)");
-      layer.appendChild(rect);
+  function classForPhase(phase) {
+    const p = (phase || "DAY").toUpperCase();
+    if (p === "NIGHT") return "night";
+    if (p === "DUSK" || p === "DAWN") return "dusk";
+    return "";
+  }
+
+  function applyPhase(payload) {
+    const phase = (payload.time && payload.time.phase) || "DAY";
+    const cls = classForPhase(phase);
+    const wrap = document.getElementById("mapWrap");
+    const lighting = document.getElementById("lighting");
+    if (wrap) wrap.dataset.time = cls || "day";
+    if (lighting) lighting.className = "lighting " + cls;
+
+    // Continuous-alpha fallback. If #lighting is a <div>, we'll set an inline
+    // background-color tint as well so non-CSS clients still see the gradient.
+    if (lighting) {
+      const a = alphaFor(payload.lighting);
+      // Only paint the fallback tint when we're not relying on the .night/.dusk
+      // class (so the cleaner CSS overlay wins).
+      lighting.style.boxShadow = `inset 0 0 0 1000px rgba(10, 12, 40, ${a.toFixed(3)})`;
+      lighting.style.opacity = cls ? "" : (a > 0 ? "1" : "0");
     }
-    return rect;
   }
 
   function alphaFor(lighting) {
-    // Clamp + invert: lighting=1 -> alpha=0 ; lighting=0 -> alpha=0.85
     const clamped = Math.max(0, Math.min(1, Number(lighting) || 0));
-    return (1 - clamped) * 0.85;
-  }
-
-  function updateLighthouseGlow(phase) {
-    // The static SVG is rendered as an <image>, so we can't reach inside it from
-    // the host document. Instead we add an explicit overlay glow class to the
-    // outer <svg id="world"> element keyed on phase, and style it from CSS if
-    // a lighthouse halo overlay is added by future iterations. For now we just
-    // expose `data-phase` for any future SVG-as-DOM swap-in.
-    const world = document.getElementById("world");
-    if (!world) return;
-    world.dataset.phase = (phase || "DAY").toUpperCase();
-    const lit = world.dataset.phase !== "DAY";
-    // Inject (or refresh) a tiny lighthouse halo overlay on top of the map.
-    let halo = document.getElementById("lighthouse-halo");
-    if (lit) {
-      if (!halo) {
-        const overlays = document.getElementById("overlays");
-        if (overlays) {
-          halo = document.createElementNS(SVG_NS, "circle");
-          halo.setAttribute("id", "lighthouse-halo");
-          halo.setAttribute("cx", 500);
-          halo.setAttribute("cy", 522);
-          halo.setAttribute("r", 14);
-          halo.setAttribute("fill", "rgba(244, 215, 122, 0.35)");
-          halo.style.filter = "blur(6px)";
-          halo.style.pointerEvents = "none";
-          overlays.appendChild(halo);
-        }
-      }
-    } else if (halo) {
-      halo.remove();
-    }
+    return (1 - clamped) * 0.55;
   }
 
   // ---------------------------------------------------------- v2: dream overlay
-  // character_id -> <g class="dream-dialog">
   const dreamDialogs = new Map();
 
+  function dreamHost() {
+    return document.getElementById("world") || document.getElementById("mapWrap");
+  }
+
   function renderDreamOverlay(payload) {
-    const world = document.getElementById("world");
+    const host = dreamHost();
     const overlays = document.getElementById("overlays");
-    if (!world || !overlays) return;
+    if (!host || !overlays) return;
     const dreams = Array.isArray(payload.dreams) ? payload.dreams : [];
     if (dreams.length === 0) {
-      world.classList.remove("dream-mode");
+      host.classList.remove("dream-mode");
       for (const [, g] of dreamDialogs) g.remove();
       dreamDialogs.clear();
       return;
     }
-    world.classList.add("dream-mode");
+    host.classList.add("dream-mode");
 
-    // Build an id -> {x, y} lookup from the agents in this snapshot.
     const agentXY = new Map();
     for (const a of (payload.agents || [])) {
       if (a && a.id) agentXY.set(a.id, { x: a.x, y: a.y });
@@ -104,11 +92,9 @@
         overlays.appendChild(g);
         dreamDialogs.set(d.character_id, g);
       }
-      // Position dialog just above and to the right of the dreaming dot.
       const ox = (pos.x || 0) + 12;
       const oy = (pos.y || 0) - 18;
       g.setAttribute("transform", `translate(${ox}, ${oy})`);
-      // Show the latest 1-2 lines.
       while (g.firstChild) g.removeChild(g.firstChild);
       const lines = (Array.isArray(d.lines) ? d.lines : []).slice(-2);
       lines.forEach((line, i) => {
@@ -119,7 +105,6 @@
         g.appendChild(t);
       });
     }
-    // Cull dialogs for dreams that have ended this tick.
     for (const [id, g] of dreamDialogs) {
       if (!seen.has(id)) {
         g.remove();
@@ -130,13 +115,7 @@
 
   window.addEventListener("from:tick", (e) => {
     const payload = e.detail || {};
-    const rect = ensureOverlay();
-    if (rect) {
-      const a = alphaFor(payload.lighting);
-      rect.setAttribute("fill", `rgba(10, 12, 40, ${a.toFixed(3)})`);
-    }
-    const phase = (payload.time && payload.time.phase) || "DAY";
-    updateLighthouseGlow(phase);
+    applyPhase(payload);
     renderDreamOverlay(payload);
   });
 })();

--- a/from-simulation/app/static/js/lighting.js
+++ b/from-simulation/app/static/js/lighting.js
@@ -37,14 +37,19 @@
     if (wrap) wrap.dataset.time = cls || "day";
     if (lighting) lighting.className = "lighting " + cls;
 
-    // Continuous-alpha fallback. If #lighting is a <div>, we'll set an inline
-    // background-color tint as well so non-CSS clients still see the gradient.
+    // Continuous-alpha fallback. If #lighting is a <div>, paint an inline
+    // box-shadow tint ONLY when the CSS .night / .dusk class is inactive —
+    // otherwise the gradient and the inset shadow stack and the map turns
+    // pitch-black for the few seconds between DUSK and full NIGHT.
     if (lighting) {
-      const a = alphaFor(payload.lighting);
-      // Only paint the fallback tint when we're not relying on the .night/.dusk
-      // class (so the cleaner CSS overlay wins).
-      lighting.style.boxShadow = `inset 0 0 0 1000px rgba(10, 12, 40, ${a.toFixed(3)})`;
-      lighting.style.opacity = cls ? "" : (a > 0 ? "1" : "0");
+      if (cls) {
+        lighting.style.boxShadow = "";
+        lighting.style.opacity = "";
+      } else {
+        const a = alphaFor(payload.lighting);
+        lighting.style.boxShadow = `inset 0 0 0 1000px rgba(10, 12, 40, ${a.toFixed(3)})`;
+        lighting.style.opacity = a > 0 ? "1" : "0";
+      }
     }
   }
 

--- a/from-simulation/app/static/js/lighting.js
+++ b/from-simulation/app/static/js/lighting.js
@@ -67,6 +67,67 @@
     }
   }
 
+  // ---------------------------------------------------------- v2: dream overlay
+  // character_id -> <g class="dream-dialog">
+  const dreamDialogs = new Map();
+
+  function renderDreamOverlay(payload) {
+    const world = document.getElementById("world");
+    const overlays = document.getElementById("overlays");
+    if (!world || !overlays) return;
+    const dreams = Array.isArray(payload.dreams) ? payload.dreams : [];
+    if (dreams.length === 0) {
+      world.classList.remove("dream-mode");
+      for (const [, g] of dreamDialogs) g.remove();
+      dreamDialogs.clear();
+      return;
+    }
+    world.classList.add("dream-mode");
+
+    // Build an id -> {x, y} lookup from the agents in this snapshot.
+    const agentXY = new Map();
+    for (const a of (payload.agents || [])) {
+      if (a && a.id) agentXY.set(a.id, { x: a.x, y: a.y });
+    }
+
+    const seen = new Set();
+    for (const d of dreams) {
+      if (!d || !d.character_id) continue;
+      const pos = agentXY.get(d.character_id);
+      if (!pos) continue;
+      seen.add(d.character_id);
+      let g = dreamDialogs.get(d.character_id);
+      if (!g) {
+        g = document.createElementNS(SVG_NS, "g");
+        g.setAttribute("class", "dream-dialog");
+        g.setAttribute("pointer-events", "none");
+        overlays.appendChild(g);
+        dreamDialogs.set(d.character_id, g);
+      }
+      // Position dialog just above and to the right of the dreaming dot.
+      const ox = (pos.x || 0) + 12;
+      const oy = (pos.y || 0) - 18;
+      g.setAttribute("transform", `translate(${ox}, ${oy})`);
+      // Show the latest 1-2 lines.
+      while (g.firstChild) g.removeChild(g.firstChild);
+      const lines = (Array.isArray(d.lines) ? d.lines : []).slice(-2);
+      lines.forEach((line, i) => {
+        const t = document.createElementNS(SVG_NS, "text");
+        t.setAttribute("x", 0);
+        t.setAttribute("y", i * 10);
+        t.textContent = String(line || "").slice(0, 80);
+        g.appendChild(t);
+      });
+    }
+    // Cull dialogs for dreams that have ended this tick.
+    for (const [id, g] of dreamDialogs) {
+      if (!seen.has(id)) {
+        g.remove();
+        dreamDialogs.delete(id);
+      }
+    }
+  }
+
   window.addEventListener("from:tick", (e) => {
     const payload = e.detail || {};
     const rect = ensureOverlay();
@@ -76,5 +137,6 @@
     }
     const phase = (payload.time && payload.time.phase) || "DAY";
     updateLighthouseGlow(phase);
+    renderDreamOverlay(payload);
   });
 })();

--- a/from-simulation/app/static/js/lighting.js
+++ b/from-simulation/app/static/js/lighting.js
@@ -1,0 +1,80 @@
+/*
+ * lighting.js — day/night overlay.
+ *
+ * Reads `payload.lighting` from the tick (0 = dark, 1 = bright) and adjusts
+ * the alpha of a full-map dim rectangle. CSS transitions the fill smoothly.
+ * Also toggles a `.lit` class on the static lighthouse group so its lamp
+ * glows when the phase is anything other than DAY.
+ */
+(function () {
+  "use strict";
+
+  const SVG_NS = "http://www.w3.org/2000/svg";
+
+  function ensureOverlay() {
+    const layer = document.getElementById("lighting");
+    if (!layer) return null;
+    let rect = layer.querySelector("rect.lighting-overlay");
+    if (!rect) {
+      rect = document.createElementNS(SVG_NS, "rect");
+      rect.setAttribute("class", "lighting-overlay");
+      rect.setAttribute("x", 0);
+      rect.setAttribute("y", 0);
+      rect.setAttribute("width", 1000);
+      rect.setAttribute("height", 700);
+      rect.setAttribute("pointer-events", "none");
+      rect.setAttribute("fill", "rgba(10, 12, 40, 0)");
+      layer.appendChild(rect);
+    }
+    return rect;
+  }
+
+  function alphaFor(lighting) {
+    // Clamp + invert: lighting=1 -> alpha=0 ; lighting=0 -> alpha=0.85
+    const clamped = Math.max(0, Math.min(1, Number(lighting) || 0));
+    return (1 - clamped) * 0.85;
+  }
+
+  function updateLighthouseGlow(phase) {
+    // The static SVG is rendered as an <image>, so we can't reach inside it from
+    // the host document. Instead we add an explicit overlay glow class to the
+    // outer <svg id="world"> element keyed on phase, and style it from CSS if
+    // a lighthouse halo overlay is added by future iterations. For now we just
+    // expose `data-phase` for any future SVG-as-DOM swap-in.
+    const world = document.getElementById("world");
+    if (!world) return;
+    world.dataset.phase = (phase || "DAY").toUpperCase();
+    const lit = world.dataset.phase !== "DAY";
+    // Inject (or refresh) a tiny lighthouse halo overlay on top of the map.
+    let halo = document.getElementById("lighthouse-halo");
+    if (lit) {
+      if (!halo) {
+        const overlays = document.getElementById("overlays");
+        if (overlays) {
+          halo = document.createElementNS(SVG_NS, "circle");
+          halo.setAttribute("id", "lighthouse-halo");
+          halo.setAttribute("cx", 500);
+          halo.setAttribute("cy", 522);
+          halo.setAttribute("r", 14);
+          halo.setAttribute("fill", "rgba(244, 215, 122, 0.35)");
+          halo.style.filter = "blur(6px)";
+          halo.style.pointerEvents = "none";
+          overlays.appendChild(halo);
+        }
+      }
+    } else if (halo) {
+      halo.remove();
+    }
+  }
+
+  window.addEventListener("from:tick", (e) => {
+    const payload = e.detail || {};
+    const rect = ensureOverlay();
+    if (rect) {
+      const a = alphaFor(payload.lighting);
+      rect.setAttribute("fill", `rgba(10, 12, 40, ${a.toFixed(3)})`);
+    }
+    const phase = (payload.time && payload.time.phase) || "DAY";
+    updateLighthouseGlow(phase);
+  });
+})();

--- a/from-simulation/app/static/js/map.js
+++ b/from-simulation/app/static/js/map.js
@@ -53,6 +53,9 @@
   const hashGroups = new Map();
   // Single bus group (or null when bus inactive).
   let busGroup = null;
+  // v6: dedicated <g id="wrecks"> that we wipe-and-redraw each tick. Up to
+  // MAX_PERMANENT_WRECKS (5) elements, so the cost is negligible.
+  let wreckGroup = null;
   let lastJournalKey = "";
   let lastVoiceTick = -1;
   let selectedId = null;
@@ -184,16 +187,20 @@
   // ---------------------------------------------------------- Entity rendering
   // Decide which token symbol id (if any) to use for a given agent.
   function tokenIdFor(item) {
-    if (!item || !item.name) return null;
+    if (!item) return null;
+    // v8 — marker_class fallback runs FIRST so nameless supernaturals (like
+    // the Yellow Man forest lurker) still resolve to their token. The
+    // previous early-return on missing name silently dropped them and they
+    // never rendered.
+    const mc = item.marker_class || "";
+    if (mc === "man-in-yellow") return "token-yellow";
+    if (mc === "boy-in-white")  return "token-white";
+    if (!item.name) return null;
     const key = String(item.name).toLowerCase().trim();
     // Strip "the " prefixes for Man in Yellow / Boy in White if present.
     if (key.includes("yellow")) return "token-yellow";
     if (key.includes("white"))  return "token-white";
     if (TOKEN_NAMES.has(key)) return "token-" + key;
-    // Marker-class fallbacks for supernaturals carrying no name.
-    const mc = item.marker_class || "";
-    if (mc === "man-in-yellow") return "token-yellow";
-    if (mc === "boy-in-white")  return "token-white";
     return null;
   }
 
@@ -222,6 +229,11 @@
     use.setAttribute("href", "#" + symbolId);
     use.setAttribute("class", "token " + klass);
     use.setAttribute("data-id", id);
+    // Force the <use> to honour the symbol's intrinsic 60×80 viewBox.
+    // Without width/height a <use> referencing a <symbol> inherits the
+    // parent SVG viewport (1000×700) and renders enormous.
+    use.setAttribute("width", "60");
+    use.setAttribute("height", "80");
     layer.appendChild(use);
     attachClick(use, id);
     entry = { el: use, kind: "token", symbolId, klass };
@@ -258,16 +270,37 @@
   }
 
   function placeToken(entry, x, y) {
-    // 60x80 viewBox centered roughly on token's belt; scale 0.55 ⇒ visual ~33x44.
-    // Anchor so that (x,y) sits at the centre of the token's mass.
+    // 60x80 viewBox; scale 0.25 ⇒ visual ~15x20, so named tokens read at the
+    // same scale as buildings (most ~20-30 px wide) and NPC dots (~12 px).
+    // Anchor offsets put symbol centre (30, 40) at (x, y).
     entry.el.setAttribute(
       "transform",
-      `translate(${(x - 15).toFixed(2)} ${(y - 22).toFixed(2)}) scale(0.55)`,
+      `translate(${(x - 7.5).toFixed(2)} ${(y - 10).toFixed(2)}) scale(0.25)`,
     );
   }
 
   function applyAgent(item, seenIds) {
     if (!item || !item.id) return;
+    // v8 — indoor agents are hidden from the map so the user sees who is
+    // exposed outside. We DO mark them as "seen" so removeEntities()
+    // doesn't garbage-collect a token we're going to want back the next
+    // time they step outside. But we tear down the visible element here
+    // so the map empties at NIGHT inside houses.
+    if (item.indoors === true) {
+      seenIds.add(item.id);
+      const existing = entities.get(item.id);
+      if (existing) {
+        existing.el.remove();
+        entities.delete(item.id);
+        // Sub-mains carry a chevron sibling under "<id>::chev".
+        const chev = entities.get(item.id + "::chev");
+        if (chev) {
+          chev.el.remove();
+          entities.delete(item.id + "::chev");
+        }
+      }
+      return;
+    }
     seenIds.add(item.id);
 
     const tokenId = tokenIdFor(item);
@@ -285,10 +318,46 @@
 
     // Fallback shapes by marker_class.
     const mc = item.marker_class || "npc";
+    // v6: live arrival car — uses the same <symbol id="token-car"> as wrecks
+    // but is part of the live entity registry so it transitions smoothly
+    // along the road.
+    if (mc === "car") {
+      let entry = entities.get(item.id);
+      if (!entry || entry.kind !== "car") {
+        if (entry) { entry.el.remove(); entities.delete(item.id); }
+        const layer = $("entities");
+        if (!layer) return;
+        const use = document.createElementNS(SVG_NS, "use");
+        use.setAttribute("href", "#token-car");
+        use.setAttribute("class", "token-car");
+        use.setAttribute("data-id", item.id);
+        use.setAttribute("width", "40");
+        use.setAttribute("height", "20");
+        layer.appendChild(use);
+        attachClick(use, item.id);
+        entry = { el: use, kind: "car" };
+        entities.set(item.id, entry);
+      }
+      entry.el.setAttribute(
+        "transform",
+        `translate(${(x - 20).toFixed(2)} ${(y - 10).toFixed(2)})`,
+      );
+      return;
+    }
+    // v6: swarmer creature — smaller, brighter polygon. Distinct CSS class.
+    if (mc === "creature-swarm") {
+      const entry = ensureShape(item.id, "polygon", "creature-swarm", {
+        points: "0,-6 3,-2 6,3 1,2 -1,5 -4,2 -6,1 -3,-2",
+      });
+      if (entry) entry.el.setAttribute("transform", `translate(${x} ${y})`);
+      return;
+    }
     if (mc === "creature") {
-      // small jagged triangle, points roughly forming a creature glyph
+      // jagged polygon — larger, asymmetric so it reads as a thing-with-claws
+      // even at 1:1 pixel ratio on the map (creatures at NIGHT are the visual
+      // anchor of "something is wrong"; they need to stand out).
       const entry = ensureShape(item.id, "polygon", "creature", {
-        points: "0,-7 6,5 -2,2 -6,5",
+        points: "0,-10 5,-3 9,4 3,3 -1,9 -5,3 -9,2 -4,-3",
       });
       if (entry) entry.el.setAttribute("transform", `translate(${x} ${y})`);
       return;
@@ -317,6 +386,22 @@
       }
       return;
     }
+    if (mc === "faraway-tree") {
+      // Short-lived portal/glitch shimmer (FarawayTreePortal + glitch markers
+      // from fear.py share this marker_class). Render as a small open ring so
+      // a stack of them — common during paranormal_break cascades — reads as
+      // a layered shimmer rather than a clump of solid NPC dots.
+      const entry = ensureShape(item.id, "circle", "faraway-tree", {
+        r: 4.5,
+        fill: "none",
+        "stroke-width": 1.2,
+      });
+      if (entry) {
+        entry.el.setAttribute("cx", x);
+        entry.el.setAttribute("cy", y);
+      }
+      return;
+    }
     if (item.kind === "outsider" || mc === "outsider") {
       const entry = ensureShape(item.id, "circle", "outsider", { r: 7 });
       if (entry) {
@@ -328,10 +413,16 @@
     // Default: NPC dot.
     // v5: NPC default — promoted sub-mains get a larger circle + a chevron;
     // tombstoned ones render with a fading "✝" glyph for ~30 ticks.
+    // v8: cultist NPCs get a red fill + gold ring (.cultist class).
     const isSubMain = item.is_sub_main === true;
     const isDead = (item.status === "DEAD");
+    const isCultist = item.cult_state === "CONVERTED";
     const r = isSubMain ? 7.5 : 6;
-    const klass = isSubMain ? (isDead ? "npc sub-main tombstone" : "npc sub-main") : "npc";
+    const parts = ["npc"];
+    if (isSubMain) parts.push("sub-main");
+    if (isCultist) parts.push("cultist");
+    if (isDead) parts.push("tombstone");
+    const klass = parts.join(" ");
     const entry = ensureShape(item.id, "circle", klass, { r });
     if (entry) {
       entry.el.setAttribute("cx", x);
@@ -417,6 +508,36 @@
         yel.textContent = "Yellow Man: " + yellow.mode + deadline;
       }
     }
+
+    // v9 — Minds heatmap. Director pressure 0..1, goal counts by kind, total beliefs.
+    const mind = payload.mind || {};
+    const pressure = typeof mind.director_pressure === "number" ? mind.director_pressure : 0;
+    const pFill = $("hud-pressure-fill");
+    if (pFill) {
+      pFill.style.width = (Math.max(0, Math.min(1, pressure)) * 100).toFixed(1) + "%";
+      // green-yellow-red gradient via inline color so we don't need a class table.
+      const r = Math.round(120 + 135 * Math.min(1, pressure * 1.2));
+      const g = Math.round(180 - 130 * Math.min(1, pressure * 1.2));
+      pFill.style.backgroundColor = `rgb(${r},${g},80)`;
+    }
+    const pText = $("hud-pressure-text");
+    if (pText) pText.textContent = pressure.toFixed(2);
+    const goals = (mind && mind.goals_by_kind) || {};
+    const pips = document.querySelectorAll("#hud-goals .goal-pip span[data-kind]");
+    pips.forEach(function (el) {
+      const k = el.getAttribute("data-kind");
+      el.textContent = String(goals[k] || 0);
+    });
+    const bel = $("hud-beliefs-count");
+    if (bel) bel.textContent = String(mind.beliefs_active || 0);
+    // v9.1 — population-stress signal (0..0.4). Tints when above zero so
+    // the user can see the "town's success → more monsters" link directly.
+    const ps = typeof mind.pop_stress === "number" ? mind.pop_stress : 0;
+    const psEle = $("hud-pop-stress");
+    if (psEle) {
+      psEle.textContent = ps.toFixed(2);
+      psEle.style.color = ps > 0 ? "#d88a8a" : "#c0a070";
+    }
   }
   function pad(n) { return String(n == null ? 0 : n).padStart(2, "0"); }
 
@@ -433,6 +554,19 @@
     setText("stat-creatures", counts.creature);
     const y = payload.yellow || { mode: "DORMANT" };
     setText("stat-yellow", y.mode || "DORMANT");
+    // v6: cave clues counter persists across cycles via Legacy.
+    const legacy = payload.legacy || {};
+    setText("stat-cave-clues", legacy.cave_clues_found != null ? legacy.cave_clues_found : 0);
+    // v7: barn destroyed indicator. Empty when barn is fine; shows the
+    // remaining ticks when down so the viewer knows the foragers are out.
+    const barnLeft = payload.barn_destroyed_in_ticks || 0;
+    setText("stat-barn", barnLeft > 0
+      ? ("DOWN — " + barnLeft + " ticks left")
+      : "intact");
+    const statBarnEl = document.getElementById("stat-barn");
+    if (statBarnEl) {
+      statBarnEl.style.color = barnLeft > 0 ? "#ff8060" : "";
+    }
 
     const roster = $("roster-summary");
     if (roster) {
@@ -447,6 +581,16 @@
   }
 
   // ---------------------------------------------------------- Event log
+  // v8 — agent-id → display-name map, rebuilt every tick from the latest
+  // agents payload. Event subjects (which carry raw ids like "npc_1_24")
+  // are resolved through this so the log reads "Beatrice — bolted outside"
+  // instead of "npc_1_24 — bolted outside".
+  let idToName = new Map();
+  function resolveName(id) {
+    if (!id) return id;
+    const n = idToName.get(id);
+    return n ? n : id;
+  }
   function renderEvents(events) {
     if (!Array.isArray(events) || events.length === 0) return;
     const ol = $("event-log");
@@ -467,7 +611,10 @@
       typeSpan.textContent = ev.type || "?";
       const detail = document.createElement("span");
       detail.className = "ev-detail";
-      detail.textContent = ev.subject ? (ev.subject + " — " + (ev.detail || "")) : (ev.detail || "");
+      const subjectName = ev.subject ? resolveName(ev.subject) : "";
+      detail.textContent = subjectName
+        ? (subjectName + " — " + (ev.detail || ""))
+        : (ev.detail || "");
       li.appendChild(tickSpan);
       li.appendChild(typeSpan);
       li.appendChild(detail);
@@ -476,16 +623,36 @@
   }
 
   // ---------------------------------------------------------- Roster list
+  // v6: also surfaces each agent's `intent` string on a muted second line so
+  // viewers can see "Boyd is patrolling toward the church." next to his name.
+  // We rebuild the list whenever the agent count OR any intent string has
+  // changed since the last render — keeps the DOM stable while keeping the
+  // "Right now" text in sync.
+  let lastRosterSig = "";
   function renderRosterList(agents) {
     const list = $("roster-list");
     if (!list) return;
-    if (list.childElementCount === agents.length) return;
+    const sig = agents.map((a) =>
+      (a.id || "") + "|" + (a.intent || "") + "|" + (a.role || "")
+    ).join("\n");
+    if (sig === lastRosterSig) return;
+    lastRosterSig = sig;
     list.innerHTML = "";
     for (const a of agents) {
       const li = document.createElement("li");
       const base = (a.name || a.id) + (a.role ? "  ·  " + a.role : "");
       const drifted = !!(a.drift || a.personality_drifted);
-      li.textContent = base + (drifted ? "  ↕" : "");
+      const title = document.createElement("div");
+      title.className = "roster-title";
+      title.textContent = base + (drifted ? "  ↕" : "");
+      li.appendChild(title);
+      const intent = (a.intent || "").trim();
+      if (intent) {
+        const sub = document.createElement("div");
+        sub.className = "intent muted";
+        sub.textContent = intent;
+        li.appendChild(sub);
+      }
       if (drifted) li.classList.add("drifted");
       li.dataset.id = a.id;
       if (a.id === selectedId) li.classList.add("selected");
@@ -557,6 +724,112 @@
       li.textContent = typeof line === "string" ? line : (line && line.text) || "";
       list.appendChild(li);
     });
+  }
+
+  // ---------------------------------------------------------- v8: new houses
+  // Buildings that didn't exist in the original SVG layout (id starts with
+  // "built_house_") get painted dynamically as simple wooden shacks. Same
+  // hitbox + dossier pipeline as the original buildings, so the user can
+  // click them and see who lives inside.
+  const builtHouseShapes = new Map();
+  const ORIGINAL_BUILDING_IDS = new Set([
+    "colony_house","green_house","shed","clinic","root_cellar",
+    "choosing_stone","church","grey_house","blue_house","pool",
+    "lius_home","bar","barn","sheriff_office","abandoned_bus",
+    "matthews_home","diner","myers_home","lighthouse",
+  ]);
+  function renderBuiltHouses(buildings) {
+    const overlays = $("overlays");
+    if (!overlays) return;
+    const live = new Set();
+    for (const b of buildings) {
+      if (!b || !b.id) continue;
+      if (ORIGINAL_BUILDING_IDS.has(b.id)) continue;
+      live.add(b.id);
+      let entry = builtHouseShapes.get(b.id);
+      if (!entry) {
+        const g = document.createElementNS(SVG_NS, "g");
+        g.setAttribute("class", "built-house");
+        g.style.pointerEvents = "none";
+        // Simple cabin: brown rect + darker roof + door.
+        const wall = document.createElementNS(SVG_NS, "rect");
+        wall.setAttribute("x", -12);
+        wall.setAttribute("y", -7);
+        wall.setAttribute("width", 24);
+        wall.setAttribute("height", 14);
+        wall.setAttribute("fill", "#8a6a48");
+        wall.setAttribute("stroke", "#1a1611");
+        wall.setAttribute("stroke-width", "0.8");
+        const roof = document.createElementNS(SVG_NS, "polygon");
+        roof.setAttribute("points", "-14,-7 14,-7 11,-13 -11,-13");
+        roof.setAttribute("fill", "#3a2820");
+        roof.setAttribute("stroke", "#1a1611");
+        roof.setAttribute("stroke-width", "0.8");
+        const door = document.createElementNS(SVG_NS, "rect");
+        door.setAttribute("x", -2);
+        door.setAttribute("y", -1);
+        door.setAttribute("width", 4);
+        door.setAttribute("height", 8);
+        door.setAttribute("fill", "#1a1611");
+        g.appendChild(roof);
+        g.appendChild(wall);
+        g.appendChild(door);
+        overlays.appendChild(g);
+        entry = { g };
+        builtHouseShapes.set(b.id, entry);
+      }
+      entry.g.setAttribute("transform", `translate(${b.x} ${b.y})`);
+    }
+    for (const [id, entry] of builtHouseShapes) {
+      if (!live.has(id)) {
+        entry.g.remove();
+        builtHouseShapes.delete(id);
+      }
+    }
+  }
+
+  // ---------------------------------------------------------- v8: building hitboxes
+  // Invisible click targets layered over the painted building art so clicking
+  // a house opens its dossier (residents inside / away, talisman state).
+  const buildingHitboxes = new Map();
+  function renderBuildingHitboxes(buildings) {
+    const overlays = $("overlays");
+    if (!overlays) return;
+    const live = new Set();
+    for (const b of buildings) {
+      if (!b || !b.id) continue;
+      // Lighthouse, abandoned bus, pool etc. are part of the map atmosphere
+      // and don't house residents — skip them so clicks pass through.
+      if (b.footprint === 0) continue;
+      live.add(b.id);
+      let entry = buildingHitboxes.get(b.id);
+      // Hitbox size scales with footprint so colony_house (10) gets a bigger
+      // click area than a small home (3). 26 px works for the big buildings,
+      // 18 px for medium, 14 px floor.
+      const half = Math.max(14, Math.min(28, 12 + (b.footprint || 1) * 1.4));
+      if (!entry) {
+        const rect = document.createElementNS(SVG_NS, "rect");
+        rect.setAttribute("class", "building-hit");
+        rect.setAttribute("data-id", b.id);
+        rect.setAttribute("fill", "transparent");
+        rect.setAttribute("pointer-events", "all");
+        rect.style.cursor = "pointer";
+        attachClick(rect, b.id);
+        overlays.appendChild(rect);
+        entry = { rect };
+        buildingHitboxes.set(b.id, entry);
+      }
+      entry.rect.setAttribute("x", (b.x || 0) - half);
+      entry.rect.setAttribute("y", (b.y || 0) - half);
+      entry.rect.setAttribute("width", half * 2);
+      entry.rect.setAttribute("height", half * 2);
+    }
+    for (const [id, entry] of buildingHitboxes) {
+      if (!live.has(id)) {
+        entry.rect.remove();
+        buildingHitboxes.delete(id);
+      }
+    }
   }
 
   // ---------------------------------------------------------- v4: cooling-off haze
@@ -701,6 +974,42 @@
       busGroup = g;
     }
     busGroup.setAttribute("transform", `translate(${bus.x || 0}, ${bus.y || 0})`);
+  }
+
+  // ---------------------------------------------------------- v6: wrecks
+  // Static, indelible parked-and-broken cars from `payload.legacy.permanent_wrecks`.
+  // These persist across cycle wipes via Legacy. We wipe-and-redraw the whole
+  // <g id="wrecks"> each tick; the cap is 5 wrecks so the cost is trivial.
+  function renderWrecks(wrecks) {
+    const overlays = $("overlays");
+    if (!overlays) return;
+    if (!wreckGroup) {
+      wreckGroup = document.createElementNS(SVG_NS, "g");
+      wreckGroup.setAttribute("id", "wrecks");
+      overlays.appendChild(wreckGroup);
+    }
+    while (wreckGroup.firstChild) wreckGroup.removeChild(wreckGroup.firstChild);
+    if (!Array.isArray(wrecks) || wrecks.length === 0) return;
+    for (const w of wrecks) {
+      if (!w) continue;
+      const x = Number(w.x);
+      const y = Number(w.y);
+      if (!isFinite(x) || !isFinite(y)) continue;
+      const use = document.createElementNS(SVG_NS, "use");
+      use.setAttribute("href", "#token-car");
+      use.setAttribute("class", "wreck");
+      use.setAttribute("width", "40");
+      use.setAttribute("height", "20");
+      // Translate-then-rotate; SVG transforms compose right-to-left so the
+      // rotation happens around the wreck's own centre.
+      const cx = x;
+      const cy = y;
+      use.setAttribute(
+        "transform",
+        `translate(${(x - 20).toFixed(2)} ${(y - 10).toFixed(2)}) rotate(-12 ${(cx - (x - 20)).toFixed(2)} ${(cy - (y - 10)).toFixed(2)})`,
+      );
+      wreckGroup.appendChild(use);
+    }
   }
 
   // ---------------------------------------------------------- v2: outsider '+'
@@ -859,6 +1168,12 @@
     const creatures = Array.isArray(payload.creatures) ? payload.creatures : [];
     const supes = Array.isArray(payload.supernaturals) ? payload.supernaturals : [];
 
+    // v8 — rebuild id → name map so the event log can resolve raw ids.
+    idToName = new Map();
+    for (const a of agents) if (a.id && a.name) idToName.set(a.id, a.name);
+    for (const c of creatures) if (c.id && c.name) idToName.set(c.id, c.name);
+    for (const s of supes) if (s.id && s.name) idToName.set(s.id, s.name);
+
     const seenGlyphs = new Set();
     for (const a of agents) {
       applyAgent(a, seen);
@@ -909,9 +1224,13 @@
 
     const buildings = Array.isArray(payload.buildings) ? payload.buildings : [];
     const legacy = payload.legacy || {};
+    renderBuiltHouses(buildings);
+    renderBuildingHitboxes(buildings);
     renderHashMarks(buildings, legacy.building_breach_marks);
     renderCoolingOff(buildings);
     renderBus(payload.bus);
+    // v6: paint permanent wrecks every tick (idempotent, capped at 5).
+    renderWrecks(legacy.permanent_wrecks);
 
     updateHud(payload);
     updateStats(payload, counts);

--- a/from-simulation/app/static/js/map.js
+++ b/from-simulation/app/static/js/map.js
@@ -1,0 +1,313 @@
+/*
+ * map.js — render the per-tick snapshot onto the SVG, drive the UI panels.
+ *
+ * Tick payload keys we read (see contracts.snapshot_dict):
+ *   tick, time, lighting, cycle_number, village_wipes,
+ *   food_supply, food_capacity, farm_health,
+ *   yellow:{mode, deadline_in},
+ *   buildings[], agents[], creatures[], supernaturals[], events[],
+ *   narration[]?  (optional — only present when the LLM driver is wired)
+ *
+ * We maintain a Map id -> {circle, label} so updates are O(deltas), not O(N²).
+ */
+(function () {
+  "use strict";
+
+  const SVG_NS = "http://www.w3.org/2000/svg";
+  const RADIUS_BY_CLASS = {
+    "char": 6,
+    "npc": 4.5,
+    "creature": 5,
+    "boy-in-white": 5,
+    "man-in-yellow": 6,
+    "anghkooey": 5,
+    "faraway-tree": 0, // already drawn in static SVG; skip rendering
+  };
+
+  // Per-pool live registries. id -> {el, lastClass}
+  const dots = new Map();
+
+  let selectedId = null;
+  let lastEventTick = -1;
+
+  function $(id) { return document.getElementById(id); }
+
+  function ensureCircle(id, markerClass) {
+    let entry = dots.get(id);
+    const r = RADIUS_BY_CLASS[markerClass] != null ? RADIUS_BY_CLASS[markerClass] : 4;
+    if (r === 0) return null; // faraway-trees live in the static map
+    if (entry) {
+      if (entry.lastClass !== markerClass) {
+        entry.el.setAttribute("class", markerClass);
+        entry.el.setAttribute("r", r);
+        entry.lastClass = markerClass;
+      }
+      return entry;
+    }
+    const layer = $("entities");
+    if (!layer) return null;
+    const circle = document.createElementNS(SVG_NS, "circle");
+    circle.setAttribute("class", markerClass);
+    circle.setAttribute("r", r);
+    circle.setAttribute("data-id", id);
+    circle.addEventListener("click", (e) => {
+      e.stopPropagation();
+      selectedId = id;
+      if (window.FROM_SOCKET) {
+        window.FROM_SOCKET.emit("inspect", { id });
+      }
+      highlightRoster(id);
+    });
+    layer.appendChild(circle);
+    entry = { el: circle, lastClass: markerClass };
+    dots.set(id, entry);
+    return entry;
+  }
+
+  function removeDots(seenIds) {
+    for (const [id, entry] of dots) {
+      if (!seenIds.has(id)) {
+        entry.el.remove();
+        dots.delete(id);
+      }
+    }
+  }
+
+  function applyAgent(item, seenIds) {
+    if (!item || !item.id) return;
+    seenIds.add(item.id);
+    const entry = ensureCircle(item.id, item.marker_class || "npc");
+    if (!entry) return;
+    entry.el.setAttribute("cx", item.x);
+    entry.el.setAttribute("cy", item.y);
+  }
+
+  // ---------------------------------------------------------- HUD updates
+  function pct(num, denom) {
+    if (!denom) return 0;
+    return Math.max(0, Math.min(100, (num / denom) * 100));
+  }
+  function updateHud(payload) {
+    const time = payload.time || {};
+    const clock = $("hud-clock");
+    if (clock) clock.textContent = time.label || `D${time.day || 0} ${pad(time.hour)}:${pad(time.minute)} ${time.phase || ""}`;
+    const phase = $("hud-phase");
+    if (phase) {
+      const p = (time.phase || "DAY").toUpperCase();
+      phase.textContent = p;
+      phase.className = "hud-chip phase-" + p.toLowerCase();
+    }
+    const cycle = $("hud-cycle");
+    if (cycle) cycle.textContent = payload.cycle_number || 1;
+
+    const foodFill = $("hud-food-fill");
+    const foodText = $("hud-food-text");
+    if (foodFill && foodText) {
+      const p = pct(payload.food_supply, payload.food_capacity || 200);
+      foodFill.style.width = p.toFixed(1) + "%";
+      foodText.textContent = Math.round(payload.food_supply || 0) + " / " + (payload.food_capacity || 200);
+    }
+    const farmFill = $("hud-farm-fill");
+    const farmText = $("hud-farm-text");
+    if (farmFill && farmText) {
+      const p = (payload.farm_health || 0) * 100;
+      farmFill.style.width = p.toFixed(1) + "%";
+      farmText.textContent = Math.round(p) + "%";
+    }
+
+    const yellow = payload.yellow || { mode: "DORMANT", deadline_in: 0 };
+    const yel = $("hud-yellow");
+    if (yel) {
+      if (!yellow.mode || yellow.mode === "DORMANT") {
+        yel.classList.add("hidden");
+      } else {
+        yel.classList.remove("hidden");
+        const mode = yellow.mode.toLowerCase();
+        yel.className = "hud-chip yellow-" + mode;
+        const deadline = yellow.deadline_in ? `  T-${yellow.deadline_in}` : "";
+        yel.textContent = "Yellow Man: " + yellow.mode + deadline;
+      }
+    }
+  }
+  function pad(n) { return String(n == null ? 0 : n).padStart(2, "0"); }
+
+  // ---------------------------------------------------------- Stats panel
+  function updateStats(payload, counts) {
+    setText("stat-tick", payload.tick);
+    setText("stat-cycle", payload.cycle_number);
+    setText("stat-wipes", payload.village_wipes || 0);
+    setText("stat-lighting", (payload.lighting != null ? payload.lighting : 0).toFixed(3));
+    setText("stat-food", Math.round(payload.food_supply || 0) + " / " + (payload.food_capacity || 200));
+    setText("stat-farm", Math.round((payload.farm_health || 0) * 100) + "%");
+    setText("stat-chars", counts.char);
+    setText("stat-npcs", counts.npc);
+    setText("stat-creatures", counts.creature);
+    const y = payload.yellow || { mode: "DORMANT" };
+    setText("stat-yellow", y.mode || "DORMANT");
+
+    // Roster summary chips
+    const roster = $("roster-summary");
+    if (roster) {
+      roster.querySelector('[data-pool="char"]').textContent = counts.char + " chars";
+      roster.querySelector('[data-pool="npc"]').textContent = counts.npc + " NPCs";
+      roster.querySelector('[data-pool="creature"]').textContent = counts.creature + " creatures";
+    }
+  }
+  function setText(id, v) {
+    const el = $(id);
+    if (el) el.textContent = v == null ? "—" : String(v);
+  }
+
+  // ---------------------------------------------------------- Event log
+  function renderEvents(events) {
+    if (!Array.isArray(events) || events.length === 0) return;
+    const ol = $("event-log");
+    if (!ol) return;
+
+    // Append only new events since last tick (deduped by tick + type + subject).
+    const latestTick = events[events.length - 1].tick;
+    if (latestTick === lastEventTick) return;
+    lastEventTick = latestTick;
+
+    // Replace contents — payload already last-50 from server.
+    ol.innerHTML = "";
+    for (let i = events.length - 1; i >= 0; i--) {
+      const ev = events[i];
+      const li = document.createElement("li");
+      li.className = "sev-" + (ev.severity || "info");
+      const tickSpan = document.createElement("span");
+      tickSpan.className = "ev-tick";
+      tickSpan.textContent = "t" + ev.tick;
+      const typeSpan = document.createElement("span");
+      typeSpan.className = "ev-type t-" + (ev.type || "info");
+      typeSpan.textContent = ev.type || "?";
+      const detail = document.createElement("span");
+      detail.className = "ev-detail";
+      detail.textContent = ev.subject ? (ev.subject + " — " + (ev.detail || "")) : (ev.detail || "");
+      li.appendChild(tickSpan);
+      li.appendChild(typeSpan);
+      li.appendChild(detail);
+      ol.appendChild(li);
+    }
+  }
+
+  // ---------------------------------------------------------- Roster list
+  function renderRosterList(agents) {
+    const list = $("roster-list");
+    if (!list) return;
+    // Re-render only when count changes — names rarely shift mid-tick.
+    if (list.childElementCount === agents.length) return;
+    list.innerHTML = "";
+    for (const a of agents) {
+      const li = document.createElement("li");
+      li.textContent = (a.name || a.id) + (a.role ? "  ·  " + a.role : "");
+      li.dataset.id = a.id;
+      if (a.id === selectedId) li.classList.add("selected");
+      li.addEventListener("click", () => {
+        selectedId = a.id;
+        if (window.FROM_SOCKET) window.FROM_SOCKET.emit("inspect", { id: a.id });
+        highlightRoster(a.id);
+      });
+      list.appendChild(li);
+    }
+  }
+  function highlightRoster(id) {
+    const list = $("roster-list");
+    if (!list) return;
+    list.querySelectorAll("li").forEach((li) => {
+      li.classList.toggle("selected", li.dataset.id === id);
+    });
+  }
+
+  // ---------------------------------------------------------- Inspect detail
+  function renderInspect(record) {
+    const box = $("roster-detail");
+    if (!box) return;
+    if (!record || record.error) {
+      box.innerHTML = '<div class="roster-empty">' +
+        (record && record.error ? record.error : "No selection.") + "</div>";
+      return;
+    }
+    const fields = [
+      ["id", record.id],
+      ["name", record.name],
+      ["kind", record.kind],
+      ["role", record.role],
+      ["status", record.status],
+      ["state", record.state],
+      ["personality", record.personality],
+      ["fear", record.fear != null ? Number(record.fear).toFixed(2) : null],
+      ["sanity", record.sanity != null ? Number(record.sanity).toFixed(2) : null],
+      ["trust", record.trust],
+      ["hunger", record.hunger],
+      ["home", record.home_id],
+      ["faction", record.faction],
+    ];
+    const title = record.name || record.id;
+    let html = `<h4>${escapeHtml(title)}</h4><dl class="kv">`;
+    for (const [k, v] of fields) {
+      if (v == null || v === "") continue;
+      html += `<dt>${escapeHtml(k)}</dt><dd>${escapeHtml(String(v))}</dd>`;
+    }
+    html += "</dl>";
+    box.innerHTML = html;
+  }
+  function escapeHtml(s) {
+    return s.replace(/[&<>"']/g, (c) => ({
+      "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;",
+    })[c]);
+  }
+
+  // ---------------------------------------------------------- Narration
+  function renderNarration(items) {
+    const panel = $("narration-panel");
+    const list = $("narration");
+    if (!panel || !list) return;
+    if (!Array.isArray(items) || items.length === 0) {
+      // leave panel hidden if server has never sent any
+      return;
+    }
+    panel.style.display = "";
+    list.innerHTML = "";
+    items.slice(-10).reverse().forEach((line) => {
+      const li = document.createElement("li");
+      li.textContent = typeof line === "string" ? line : (line && line.text) || "";
+      list.appendChild(li);
+    });
+  }
+
+  // ---------------------------------------------------------- main tick
+  function handleTick(payload) {
+    const seen = new Set();
+    const counts = { char: 0, npc: 0, creature: 0, other: 0 };
+
+    const agents = Array.isArray(payload.agents) ? payload.agents : [];
+    const creatures = Array.isArray(payload.creatures) ? payload.creatures : [];
+    const supes = Array.isArray(payload.supernaturals) ? payload.supernaturals : [];
+
+    for (const a of agents) {
+      applyAgent(a, seen);
+      if (a.marker_class === "char") counts.char++;
+      else if (a.marker_class === "npc") counts.npc++;
+      else counts.other++;
+    }
+    for (const c of creatures) {
+      applyAgent(c, seen);
+      counts.creature++;
+    }
+    for (const s of supes) {
+      applyAgent(s, seen);
+      counts.other++;
+    }
+
+    removeDots(seen);
+    updateHud(payload);
+    updateStats(payload, counts);
+    renderEvents(payload.events || []);
+    renderRosterList(agents);
+    renderNarration(payload.narration);
+  }
+
+  window.addEventListener("from:tick", (e) => handleTick(e.detail));
+  window.addEventListener("from:inspect_reply", (e) => renderInspect(e.detail));
+})();

--- a/from-simulation/app/static/js/map.js
+++ b/from-simulation/app/static/js/map.js
@@ -326,10 +326,39 @@
       return;
     }
     // Default: NPC dot.
-    const entry = ensureShape(item.id, "circle", "npc", { r: 6 });
+    // v5: NPC default — promoted sub-mains get a larger circle + a chevron;
+    // tombstoned ones render with a fading "✝" glyph for ~30 ticks.
+    const isSubMain = item.is_sub_main === true;
+    const isDead = (item.status === "DEAD");
+    const r = isSubMain ? 7.5 : 6;
+    const klass = isSubMain ? (isDead ? "npc sub-main tombstone" : "npc sub-main") : "npc";
+    const entry = ensureShape(item.id, "circle", klass, { r });
     if (entry) {
       entry.el.setAttribute("cx", x);
       entry.el.setAttribute("cy", y);
+      // Keep the class fresh in case status flips between ticks (alive -> tombstone).
+      entry.el.setAttribute("class", klass);
+    }
+    if (isSubMain) {
+      // chevron marker: a tiny "^" rendered as a polyline 8 px above the dot.
+      const chevId = item.id + "::chev";
+      const chev = ensureShape(chevId, "polyline", isDead ? "sub-main-chev tombstone" : "sub-main-chev", {
+        points: "-3,-12 0,-16 3,-12",
+      });
+      if (chev) chev.el.setAttribute("transform", `translate(${x} ${y})`);
+      seenIds.add(chevId);
+      // Tombstone cross glyph for dead sub-mains.
+      if (isDead) {
+        const xId = item.id + "::cross";
+        const cross = ensureShape(xId, "text", "tombstone-cross", {});
+        if (cross) {
+          cross.el.setAttribute("x", x);
+          cross.el.setAttribute("y", y - 18);
+          cross.el.setAttribute("text-anchor", "middle");
+          cross.el.textContent = "✝";
+        }
+        seenIds.add(xId);
+      }
     }
   }
 

--- a/from-simulation/app/static/js/map.js
+++ b/from-simulation/app/static/js/map.js
@@ -301,6 +301,22 @@
       }
       return;
     }
+    if (mc === "music-box") {
+      // small ornate gold box with soft pulsing glow
+      const entry = ensureShape(item.id, "rect", "music-box", {
+        x: -6, y: -4, width: 12, height: 8, rx: 1,
+      });
+      if (entry) entry.el.setAttribute("transform", `translate(${x} ${y})`);
+      return;
+    }
+    if (mc === "cicada") {
+      const entry = ensureShape(item.id, "circle", "cicada", { r: 1.6 });
+      if (entry) {
+        entry.el.setAttribute("cx", x);
+        entry.el.setAttribute("cy", y);
+      }
+      return;
+    }
     if (item.kind === "outsider" || mc === "outsider") {
       const entry = ensureShape(item.id, "circle", "outsider", { r: 7 });
       if (entry) {
@@ -512,6 +528,42 @@
       li.textContent = typeof line === "string" ? line : (line && line.text) || "";
       list.appendChild(li);
     });
+  }
+
+  // ---------------------------------------------------------- v4: cooling-off haze
+  const coolingMarkers = new Map();
+  function renderCoolingOff(buildings) {
+    const overlays = $("overlays");
+    if (!overlays) return;
+    const live = new Set();
+    for (const b of buildings) {
+      if (!b || !b.id) continue;
+      const cooling = (b.cooling_off || 0) > 0 || b.protected === false && b.has_talisman;
+      if (!cooling) continue;
+      live.add(b.id);
+      let entry = coolingMarkers.get(b.id);
+      if (!entry) {
+        const g = document.createElementNS(SVG_NS, "g");
+        g.setAttribute("class", "cooling-off");
+        const haze = document.createElementNS(SVG_NS, "rect");
+        haze.setAttribute("x", -22);
+        haze.setAttribute("y", -22);
+        haze.setAttribute("width", 44);
+        haze.setAttribute("height", 44);
+        haze.setAttribute("rx", 4);
+        g.appendChild(haze);
+        overlays.appendChild(g);
+        entry = { group: g };
+        coolingMarkers.set(b.id, entry);
+      }
+      entry.group.setAttribute("transform", `translate(${b.x || 0} ${b.y || 0})`);
+    }
+    for (const [id, entry] of coolingMarkers) {
+      if (!live.has(id)) {
+        entry.group.remove();
+        coolingMarkers.delete(id);
+      }
+    }
   }
 
   // ---------------------------------------------------------- v2: hash marks
@@ -829,6 +881,7 @@
     const buildings = Array.isArray(payload.buildings) ? payload.buildings : [];
     const legacy = payload.legacy || {};
     renderHashMarks(buildings, legacy.building_breach_marks);
+    renderCoolingOff(buildings);
     renderBus(payload.bus);
 
     updateHud(payload);

--- a/from-simulation/app/static/js/map.js
+++ b/from-simulation/app/static/js/map.js
@@ -26,6 +26,16 @@
 
   // Per-pool live registries. id -> {el, lastClass}
   const dots = new Map();
+  // id -> {ring: <circle>, lastKind: "tendril"|"tendril-leader"|"called"} for pulsing rings around dots
+  const rings = new Map();
+  // id -> <text> "+" glyph for outsiders
+  const outsiderGlyphs = new Map();
+  // building_id -> {group: <g>, lastCount}
+  const hashGroups = new Map();
+  // Single bus group (or null when bus inactive)
+  let busGroup = null;
+  let lastJournalKey = "";
+  let lastVoiceTick = -1;
 
   let selectedId = null;
   let lastEventTick = -1;
@@ -200,7 +210,12 @@
     list.innerHTML = "";
     for (const a of agents) {
       const li = document.createElement("li");
-      li.textContent = (a.name || a.id) + (a.role ? "  ·  " + a.role : "");
+      const base = (a.name || a.id) + (a.role ? "  ·  " + a.role : "");
+      // Optional drift indicator: agent may carry a "drift" field per v2;
+      // when present (truthy), show a small "↕" glyph beside the name.
+      const drifted = !!(a.drift || a.personality_drifted);
+      li.textContent = base + (drifted ? "  ↕" : "");
+      if (drifted) li.classList.add("drifted");
       li.dataset.id = a.id;
       if (a.id === selectedId) li.classList.add("selected");
       li.addEventListener("click", () => {
@@ -276,6 +291,267 @@
     });
   }
 
+  // ---------------------------------------------------------- v2: hash marks on buildings
+  function renderHashMarks(buildings, marks) {
+    const overlays = $("overlays");
+    if (!overlays) return;
+    const seenBuildings = new Set();
+    const safeMarks = marks || {};
+
+    for (const b of buildings) {
+      if (!b || !b.id) continue;
+      const count = Math.max(0, Math.floor(safeMarks[b.id] || 0));
+      if (count === 0) {
+        // Tear down any group we previously created for this building.
+        const existing = hashGroups.get(b.id);
+        if (existing) {
+          existing.group.remove();
+          hashGroups.delete(b.id);
+        }
+        continue;
+      }
+      seenBuildings.add(b.id);
+      let entry = hashGroups.get(b.id);
+      if (!entry) {
+        const g = document.createElementNS(SVG_NS, "g");
+        g.setAttribute("class", "hash-marks");
+        overlays.appendChild(g);
+        entry = { group: g, lastCount: -1 };
+        hashGroups.set(b.id, entry);
+      }
+      // Anchor at (b.x + 30, b.y + 30).
+      const ox = (b.x || 0) + 30;
+      const oy = (b.y || 0) + 30;
+      entry.group.setAttribute("transform", `translate(${ox}, ${oy})`);
+
+      if (entry.lastCount === count) continue;
+      entry.lastCount = count;
+
+      // Clear and redraw — up to 12 tally lines + optional "+N" overflow label.
+      while (entry.group.firstChild) entry.group.removeChild(entry.group.firstChild);
+
+      const visible = Math.min(12, count);
+      // Render in groups of 5 — four uprights + diagonal slash.
+      for (let i = 0; i < visible; i++) {
+        const groupIdx = Math.floor(i / 5);
+        const posInGroup = i % 5;
+        const gx = groupIdx * 10;
+        if (posInGroup < 4) {
+          const line = document.createElementNS(SVG_NS, "line");
+          line.setAttribute("x1", gx + posInGroup * 2);
+          line.setAttribute("y1", 0);
+          line.setAttribute("x2", gx + posInGroup * 2);
+          line.setAttribute("y2", 8);
+          entry.group.appendChild(line);
+        } else {
+          const slash = document.createElementNS(SVG_NS, "line");
+          slash.setAttribute("x1", gx - 1);
+          slash.setAttribute("y1", 8);
+          slash.setAttribute("x2", gx + 7);
+          slash.setAttribute("y2", 0);
+          entry.group.appendChild(slash);
+        }
+      }
+      if (count > 12) {
+        const txt = document.createElementNS(SVG_NS, "text");
+        txt.setAttribute("x", Math.ceil(visible / 5) * 10 + 2);
+        txt.setAttribute("y", 7);
+        txt.setAttribute("class", "hash-overflow");
+        txt.textContent = "+" + (count - 12);
+        entry.group.appendChild(txt);
+      }
+    }
+
+    // Tear down groups for buildings that no longer have any marks.
+    for (const [bid, entry] of hashGroups) {
+      if (!seenBuildings.has(bid)) {
+        entry.group.remove();
+        hashGroups.delete(bid);
+      }
+    }
+  }
+
+  // ---------------------------------------------------------- v2: bus
+  function renderBus(bus) {
+    const overlays = $("overlays");
+    if (!overlays) return;
+    if (!bus || !bus.active) {
+      if (busGroup) {
+        busGroup.remove();
+        busGroup = null;
+      }
+      return;
+    }
+    if (!busGroup) {
+      const g = document.createElementNS(SVG_NS, "g");
+      g.setAttribute("class", "bus");
+      // Hand-drawn-feel yellow school bus, ~50 x 20 (centered on origin).
+      g.innerHTML = [
+        '<rect class="bus-body-rect" x="-25" y="-10" width="50" height="20" rx="3" ry="3"></rect>',
+        '<rect class="bus-window" x="-21" y="-7" width="8" height="6"></rect>',
+        '<rect class="bus-window" x="-11" y="-7" width="8" height="6"></rect>',
+        '<rect class="bus-window" x="-1" y="-7" width="8" height="6"></rect>',
+        '<rect class="bus-window" x="9" y="-7" width="8" height="6"></rect>',
+        '<rect class="bus-door" x="18" y="-3" width="5" height="9"></rect>',
+        '<circle class="bus-wheel" cx="-15" cy="11" r="3"></circle>',
+        '<circle class="bus-wheel" cx="15" cy="11" r="3"></circle>',
+      ].join("");
+      overlays.appendChild(g);
+      busGroup = g;
+    }
+    busGroup.setAttribute("transform", `translate(${bus.x || 0}, ${bus.y || 0})`);
+  }
+
+  // ---------------------------------------------------------- v2: outsider glyphs
+  function applyOutsiderGlyph(item, seenGlyphs) {
+    if (!item || item.kind !== "outsider") return;
+    seenGlyphs.add(item.id);
+    let glyph = outsiderGlyphs.get(item.id);
+    if (!glyph) {
+      const overlays = $("overlays");
+      if (!overlays) return;
+      glyph = document.createElementNS(SVG_NS, "text");
+      glyph.setAttribute("class", "outsider-glyph");
+      glyph.setAttribute("text-anchor", "middle");
+      glyph.textContent = "+";
+      overlays.appendChild(glyph);
+      outsiderGlyphs.set(item.id, glyph);
+    }
+    glyph.setAttribute("x", item.x);
+    glyph.setAttribute("y", (item.y || 0) - 8);
+  }
+
+  function pruneOutsiderGlyphs(seenGlyphs) {
+    for (const [id, el] of outsiderGlyphs) {
+      if (!seenGlyphs.has(id)) {
+        el.remove();
+        outsiderGlyphs.delete(id);
+      }
+    }
+  }
+
+  // ---------------------------------------------------------- v2: pulsing rings (tendrils + called)
+  function applyRing(id, x, y, kind) {
+    let entry = rings.get(id);
+    if (!entry) {
+      const overlays = $("overlays");
+      if (!overlays) return;
+      const c = document.createElementNS(SVG_NS, "circle");
+      c.setAttribute("r", 10);
+      c.setAttribute("fill", "none");
+      c.setAttribute("pointer-events", "none");
+      overlays.appendChild(c);
+      entry = { ring: c, lastKind: null };
+      rings.set(id, entry);
+    }
+    if (entry.lastKind !== kind) {
+      entry.ring.setAttribute("class", kind);
+      entry.lastKind = kind;
+    }
+    entry.ring.setAttribute("cx", x);
+    entry.ring.setAttribute("cy", y);
+  }
+
+  function pruneRings(seenRingIds) {
+    for (const [id, entry] of rings) {
+      if (!seenRingIds.has(id)) {
+        entry.ring.remove();
+        rings.delete(id);
+      }
+    }
+  }
+
+  // ---------------------------------------------------------- v2: journal panel
+  function renderJournal(legacy) {
+    const ol = $("journal-list");
+    const witnessed = $("hud-cycles-witnessed");
+    const frag = $("hud-fragments");
+    if (witnessed) {
+      const n = (legacy && legacy.cycles_witnessed) || 0;
+      witnessed.textContent = "Cycle " + n + " of all that has ever been";
+    }
+    if (!ol) return;
+    const fragments = (legacy && Array.isArray(legacy.journal_fragments))
+      ? legacy.journal_fragments : [];
+    if (frag) frag.textContent = "📜 " + fragments.length + " fragments";
+    // Cheap change-key — only re-render when content shifts.
+    const key = fragments.map((f) => `${f.cycle}|${f.burned}|${f.text}`).join("");
+    if (key === lastJournalKey) return;
+    lastJournalKey = key;
+    ol.innerHTML = "";
+    // Oldest first (server already trims to last 12).
+    for (const f of fragments) {
+      const li = document.createElement("li");
+      const burned = Math.max(0, Math.min(1, Number(f.burned) || 0));
+      li.style.opacity = (1 - burned * 0.85).toFixed(3);
+      li.textContent = "D" + (f.cycle != null ? f.cycle : "?") + ": " + (f.text || "");
+      ol.appendChild(li);
+    }
+  }
+
+  // ---------------------------------------------------------- v2: lighthouse-voice panel
+  function renderLighthouseVoice(payload) {
+    const panel = $("lighthouse-voice");
+    const list = $("lighthouse-voice-list");
+    if (!panel || !list) return;
+    const lh = payload.lighthouse || {};
+    if (!lh.voice_active) {
+      panel.style.display = "none";
+      return;
+    }
+    panel.style.display = "";
+    const events = Array.isArray(payload.events) ? payload.events : [];
+    const voiceEvents = events.filter((e) => e && e.type === "lighthouse_voice").slice(-10);
+    const newestTick = voiceEvents.length ? voiceEvents[voiceEvents.length - 1].tick : -1;
+    if (newestTick === lastVoiceTick && list.childElementCount === voiceEvents.length) return;
+    lastVoiceTick = newestTick;
+    list.innerHTML = "";
+    for (const ev of voiceEvents) {
+      const li = document.createElement("li");
+      li.textContent = ev.detail || "(silence)";
+      list.appendChild(li);
+    }
+  }
+
+  // ---------------------------------------------------------- v2: bus panel
+  function renderBusPanel(payload) {
+    const panel = $("bus-panel");
+    const list = $("bus-passengers");
+    const countdown = $("bus-countdown");
+    if (!panel || !list || !countdown) return;
+    const bus = payload.bus || {};
+    if (!bus.active) {
+      panel.style.display = "none";
+      list.innerHTML = "";
+      countdown.textContent = "—";
+      return;
+    }
+    panel.style.display = "";
+    // Lookup agents by id.
+    const agents = Array.isArray(payload.agents) ? payload.agents : [];
+    const byId = new Map(agents.map((a) => [a.id, a]));
+    const passengers = Array.isArray(bus.passengers) ? bus.passengers : [];
+    list.innerHTML = "";
+    for (const pid of passengers) {
+      const agent = byId.get(pid);
+      const li = document.createElement("li");
+      const name = (agent && (agent.name || agent.id)) || pid;
+      const back = agent && (agent.backstory || agent.goal || agent.role);
+      li.innerHTML = "<strong>" + escapeHtml(name) + "</strong>" +
+        (back ? '<span class="bus-back"> — ' + escapeHtml(String(back)) + "</span>" : "");
+      list.appendChild(li);
+    }
+    if (passengers.length === 0) {
+      const li = document.createElement("li");
+      li.className = "bus-empty";
+      li.textContent = "(no passengers boarded yet)";
+      list.appendChild(li);
+    }
+    // Departure countdown — next_arrival_cycle is a cycle counter, so display it raw.
+    const next = bus.next_arrival_cycle;
+    countdown.textContent = next != null ? ("Next bus: cycle " + next) : "—";
+  }
+
   // ---------------------------------------------------------- main tick
   function handleTick(payload) {
     const seen = new Set();
@@ -285,10 +561,13 @@
     const creatures = Array.isArray(payload.creatures) ? payload.creatures : [];
     const supes = Array.isArray(payload.supernaturals) ? payload.supernaturals : [];
 
+    const seenGlyphs = new Set();
     for (const a of agents) {
       applyAgent(a, seen);
+      applyOutsiderGlyph(a, seenGlyphs);
       if (a.marker_class === "char") counts.char++;
       else if (a.marker_class === "npc") counts.npc++;
+      else if (a.kind === "outsider" || a.marker_class === "outsider") counts.other++;
       else counts.other++;
     }
     for (const c of creatures) {
@@ -301,11 +580,52 @@
     }
 
     removeDots(seen);
+    pruneOutsiderGlyphs(seenGlyphs);
+
+    // ---- v2: rings (tendrils + called) ----
+    const yellow = payload.yellow || {};
+    const tendrils = new Set(Array.isArray(yellow.tendrils) ? yellow.tendrils : []);
+    const leader = yellow.disguised_as || null;
+    const lighthouse = payload.lighthouse || {};
+    const calledId = lighthouse.called || null;
+
+    const seenRingIds = new Set();
+    const dotById = new Map();
+    for (const a of agents) dotById.set(a.id, a);
+
+    for (const id of tendrils) {
+      const a = dotById.get(id);
+      if (!a) continue;
+      const kind = (id === leader) ? "tendril-leader" : "tendril";
+      applyRing(id, a.x, a.y, kind);
+      seenRingIds.add(id);
+    }
+    if (calledId) {
+      const a = dotById.get(calledId);
+      if (a) {
+        // If the called character is also a tendril, the called ring overrides (slow aqua pulse).
+        applyRing(calledId, a.x, a.y, "called");
+        seenRingIds.add(calledId);
+      }
+    }
+    pruneRings(seenRingIds);
+
+    // ---- v2: hash marks + bus ----
+    const buildings = Array.isArray(payload.buildings) ? payload.buildings : [];
+    const legacy = payload.legacy || {};
+    renderHashMarks(buildings, legacy.building_breach_marks);
+    renderBus(payload.bus);
+
     updateHud(payload);
     updateStats(payload, counts);
     renderEvents(payload.events || []);
     renderRosterList(agents);
     renderNarration(payload.narration);
+
+    // v2 right-column panels
+    renderJournal(legacy);
+    renderLighthouseVoice(payload);
+    renderBusPanel(payload);
   }
 
   window.addEventListener("from:tick", (e) => handleTick(e.detail));

--- a/from-simulation/app/static/js/map.js
+++ b/from-simulation/app/static/js/map.js
@@ -1,95 +1,329 @@
 /*
  * map.js — render the per-tick snapshot onto the SVG, drive the UI panels.
  *
- * Tick payload keys we read (see contracts.snapshot_dict):
- *   tick, time, lighting, cycle_number, village_wipes,
- *   food_supply, food_capacity, farm_health,
- *   yellow:{mode, deadline_in},
- *   buildings[], agents[], creatures[], supernaturals[], events[],
- *   narration[]?  (optional — only present when the LLM driver is wired)
+ * v3 changes:
+ *  - Named characters render as <use href="#token-{name}"> hand-drawn tokens
+ *    that live inside the inline map SVG's <defs> as 60x80 <symbol>s.
+ *  - Man in Yellow / Boy in White render the same way (token-yellow / token-white).
+ *  - NPCs / creatures / anghkooey keep simple shapes (circle / polygon).
+ *  - Outsiders keep v2 styling: circle with a '+' glyph above.
+ *  - Forest scatter is generated once per session into <g id="forest"> via a
+ *    seeded mulberry32 RNG (matches the design reference exactly).
+ *  - Hash marks use a per-building offset table for the 5 talisman set.
  *
- * We maintain a Map id -> {circle, label} so updates are O(deltas), not O(N²).
+ * Tick payload keys (see contracts.snapshot_dict): tick, time, lighting,
+ *   cycle_number, village_wipes, food_supply, food_capacity, farm_health,
+ *   yellow:{mode, deadline_in, tendrils, disguised_as},
+ *   buildings[], agents[], creatures[], supernaturals[], events[],
+ *   narration[]?, legacy:{building_breach_marks, journal_fragments,
+ *   cycles_witnessed}, lighthouse:{voice_active, called}, bus:{...},
+ *   dreams[].
  */
 (function () {
   "use strict";
 
   const SVG_NS = "http://www.w3.org/2000/svg";
-  const RADIUS_BY_CLASS = {
-    "char": 6,
-    "npc": 4.5,
-    "creature": 5,
-    "boy-in-white": 5,
-    "man-in-yellow": 6,
-    "anghkooey": 5,
-    "faraway-tree": 0, // already drawn in static SVG; skip rendering
-  };
 
-  // Per-pool live registries. id -> {el, lastClass}
-  const dots = new Map();
-  // id -> {ring: <circle>, lastKind: "tendril"|"tendril-leader"|"called"} for pulsing rings around dots
+  // Tokens we have hand-drawn SVG <symbol>s for.
+  const TOKEN_NAMES = new Set([
+    "boyd", "donna", "jim", "tabitha", "ethan", "julie",
+    "jade", "kenny", "khatri", "sara", "yellow", "white",
+  ]);
+
+  // Per-building hash-mark anchor offsets. Other buildings fall back to [18, 18].
+  const HASH_OFFSET = {
+    colony_house:   [ 28,  18],
+    clinic:         [ 16,  18],
+    church:         [ 22, -22],
+    sheriff_office: [ 18,  20],
+    matthews_home:  [ 16,  18],
+  };
+  const HASH_OFFSET_DEFAULT = [18, 18];
+
+  // Per-pool live registries. id -> {el, kind, lastClass}
+  // kind === "token" means el is a <use>, kind === "shape" means el is the primary
+  // SVG element (circle/polygon).
+  const entities = new Map();
+
+  // id -> {ring: <circle>, lastKind} for pulsing rings around dots.
   const rings = new Map();
-  // id -> <text> "+" glyph for outsiders
+  // id -> <text> "+" glyph for outsiders.
   const outsiderGlyphs = new Map();
   // building_id -> {group: <g>, lastCount}
   const hashGroups = new Map();
-  // Single bus group (or null when bus inactive)
+  // Single bus group (or null when bus inactive).
   let busGroup = null;
   let lastJournalKey = "";
   let lastVoiceTick = -1;
-
   let selectedId = null;
   let lastEventTick = -1;
 
+  // Forest scatter runs once per session.
+  let forestScattered = false;
+
   function $(id) { return document.getElementById(id); }
 
-  function ensureCircle(id, markerClass) {
-    let entry = dots.get(id);
-    const r = RADIUS_BY_CLASS[markerClass] != null ? RADIUS_BY_CLASS[markerClass] : 4;
-    if (r === 0) return null; // faraway-trees live in the static map
-    if (entry) {
-      if (entry.lastClass !== markerClass) {
-        entry.el.setAttribute("class", markerClass);
-        entry.el.setAttribute("r", r);
-        entry.lastClass = markerClass;
-      }
+  // ---------------------------------------------------------- Forest scatter
+  // Seeded RNG copied verbatim from Fromville_Map.html (mulberry32).
+  function mulberry32(seed) {
+    return function () {
+      let t = seed += 0x6D2B79F5;
+      t = Math.imul(t ^ t >>> 15, t | 1);
+      t ^= t + Math.imul(t ^ t >>> 7, t | 61);
+      return ((t ^ t >>> 14) >>> 0) / 4294967296;
+    };
+  }
+
+  // The big meadow polygon; trees go OUTSIDE this clearing for the dark forest
+  // ring at the edges. Also a handful are placed INSIDE the meadow but away
+  // from town/landmarks/road/water for texture.
+  const MEADOW = [
+    [60,220],[80,130],[220,70],[380,80],[520,60],[660,70],[800,110],
+    [880,140],[940,230],[920,340],[950,460],[870,580],[720,620],
+    [600,680],[440,690],[300,660],[180,640],[60,540],[50,420],[30,360],
+  ];
+  const TOWN_PTS = [
+    {x:385,y:420},{x:418,y:400},{x:442,y:388},{x:478,y:402},{x:495,y:432},
+    {x:390,y:470},{x:385,y:510},{x:420,y:490},{x:440,y:490},{x:462,y:478},
+    {x:478,y:462},{x:510,y:458},{x:555,y:454},{x:490,y:510},{x:460,y:538},
+    {x:430,y:545},{x:405,y:530},{x:382,y:552},
+  ];
+  const LANDMARK_PTS = [
+    {x:560,y:55},{x:465,y:195},{x:620,y:225},{x:760,y:218},{x:380,y:325},
+    {x:615,y:335},{x:260,y:510},{x:345,y:580},{x:275,y:610},{x:470,y:615},
+    {x:240,y:650},{x:735,y:485},{x:390,y:670},{x:575,y:660},{x:720,y:670},
+    {x:140,y:585},
+  ];
+
+  function pointInPoly(x, y, poly) {
+    let inside = false;
+    for (let i = 0, j = poly.length - 1; i < poly.length; j = i++) {
+      const xi = poly[i][0], yi = poly[i][1];
+      const xj = poly[j][0], yj = poly[j][1];
+      const intersect = ((yi > y) !== (yj > y)) &&
+        (x < (xj - xi) * (y - yi) / (yj - yi + 1e-9) + xi);
+      if (intersect) inside = !inside;
+    }
+    return inside;
+  }
+  function nearAny(x, y, pts, r) {
+    return pts.some((p) => (p.x - x) ** 2 + (p.y - y) ** 2 < r * r);
+  }
+  function nearRoad(x, y) {
+    const segs = [
+      [-20,200, 240,320], [240,320, 395,405], [395,405, 555,405],
+      [555,405, 575,425], [575,425, 565,555], [565,555, 720,690],
+    ];
+    for (const [ax, ay, bx, by] of segs) {
+      const dx = bx - ax, dy = by - ay;
+      const t = Math.max(0, Math.min(1,
+        ((x - ax) * dx + (y - ay) * dy) / (dx * dx + dy * dy + 1e-9)));
+      const px = ax + t * dx, py = ay + t * dy;
+      if ((px - x) ** 2 + (py - y) ** 2 < 22 * 22) return true;
+    }
+    return false;
+  }
+
+  function scatterForest() {
+    if (forestScattered) return;
+    const forestG = $("forest");
+    if (!forestG) return;
+    forestScattered = true;
+
+    const rng = mulberry32(42);
+    const symbols = ["#tree", "#tree-dark", "#tree-pine"];
+    const placed = [];
+
+    // ~300 trees outside the meadow polygon.
+    for (let i = 0; i < 300; i++) {
+      const x = rng() * 1000;
+      const y = rng() * 700;
+      if (pointInPoly(x, y, MEADOW)) continue;
+      if (nearAny(x, y, placed, 14)) continue;
+      placed.push({ x, y });
+      const sym = symbols[Math.floor(rng() * symbols.length)];
+      const scale = 0.7 + rng() * 0.9;
+      const use = document.createElementNS(SVG_NS, "use");
+      use.setAttribute("href", sym);
+      use.setAttribute("transform",
+        `translate(${x.toFixed(1)} ${y.toFixed(1)}) scale(${scale.toFixed(2)})`);
+      forestG.appendChild(use);
+    }
+
+    // ~60 extras inside the meadow, away from points of interest.
+    const avoid = [
+      ...TOWN_PTS.map((t) => ({ x: t.x, y: t.y, r: 30 })),
+      ...LANDMARK_PTS.map((L) => ({ x: L.x, y: L.y, r: 30 })),
+      { x: 745, y: 240, r: 65 }, // lake
+      { x: 375, y: 335, r: 30 }, // brundles
+      { x: 155, y: 220, r: 30 }, // small pond
+    ];
+    function nearAvoid(x, y) {
+      return avoid.some((a) => (a.x - x) ** 2 + (a.y - y) ** 2 < a.r * a.r);
+    }
+    const extras = [];
+    for (let i = 0; i < 60; i++) {
+      const x = 70 + rng() * 860;
+      const y = 90 + rng() * 540;
+      if (!pointInPoly(x, y, MEADOW)) continue;
+      if (nearAvoid(x, y)) continue;
+      if (nearRoad(x, y)) continue;
+      if (nearAny(x, y, extras, 32)) continue;
+      extras.push({ x, y });
+      const sym = symbols[Math.floor(rng() * symbols.length)];
+      const scale = 0.55 + rng() * 0.5;
+      const use = document.createElementNS(SVG_NS, "use");
+      use.setAttribute("href", sym);
+      use.setAttribute("transform",
+        `translate(${x.toFixed(1)} ${y.toFixed(1)}) scale(${scale.toFixed(2)})`);
+      use.setAttribute("opacity", "0.92");
+      forestG.appendChild(use);
+    }
+  }
+
+  // ---------------------------------------------------------- Entity rendering
+  // Decide which token symbol id (if any) to use for a given agent.
+  function tokenIdFor(item) {
+    if (!item || !item.name) return null;
+    const key = String(item.name).toLowerCase().trim();
+    // Strip "the " prefixes for Man in Yellow / Boy in White if present.
+    if (key.includes("yellow")) return "token-yellow";
+    if (key.includes("white"))  return "token-white";
+    if (TOKEN_NAMES.has(key)) return "token-" + key;
+    // Marker-class fallbacks for supernaturals carrying no name.
+    const mc = item.marker_class || "";
+    if (mc === "man-in-yellow") return "token-yellow";
+    if (mc === "boy-in-white")  return "token-white";
+    return null;
+  }
+
+  function attachClick(el, id) {
+    el.addEventListener("click", (e) => {
+      e.stopPropagation();
+      selectedId = id;
+      if (window.FROM_SOCKET) window.FROM_SOCKET.emit("inspect", { id });
+      highlightRoster(id);
+    });
+  }
+
+  function ensureToken(id, symbolId, klass) {
+    let entry = entities.get(id);
+    if (entry && entry.kind === "token" && entry.symbolId === symbolId) {
       return entry;
+    }
+    if (entry) {
+      // Kind/symbol changed — tear down and rebuild.
+      entry.el.remove();
+      entities.delete(id);
     }
     const layer = $("entities");
     if (!layer) return null;
-    const circle = document.createElementNS(SVG_NS, "circle");
-    circle.setAttribute("class", markerClass);
-    circle.setAttribute("r", r);
-    circle.setAttribute("data-id", id);
-    circle.addEventListener("click", (e) => {
-      e.stopPropagation();
-      selectedId = id;
-      if (window.FROM_SOCKET) {
-        window.FROM_SOCKET.emit("inspect", { id });
-      }
-      highlightRoster(id);
-    });
-    layer.appendChild(circle);
-    entry = { el: circle, lastClass: markerClass };
-    dots.set(id, entry);
+    const use = document.createElementNS(SVG_NS, "use");
+    use.setAttribute("href", "#" + symbolId);
+    use.setAttribute("class", "token " + klass);
+    use.setAttribute("data-id", id);
+    layer.appendChild(use);
+    attachClick(use, id);
+    entry = { el: use, kind: "token", symbolId, klass };
+    entities.set(id, entry);
     return entry;
   }
 
-  function removeDots(seenIds) {
-    for (const [id, entry] of dots) {
-      if (!seenIds.has(id)) {
-        entry.el.remove();
-        dots.delete(id);
+  function ensureShape(id, tag, klass, attrs) {
+    let entry = entities.get(id);
+    if (entry && entry.kind === "shape" && entry.tag === tag) {
+      if (entry.klass !== klass) {
+        entry.el.setAttribute("class", klass);
+        entry.klass = klass;
       }
+      return entry;
     }
+    if (entry) {
+      entry.el.remove();
+      entities.delete(id);
+    }
+    const layer = $("entities");
+    if (!layer) return null;
+    const el = document.createElementNS(SVG_NS, tag);
+    el.setAttribute("class", klass);
+    el.setAttribute("data-id", id);
+    if (attrs) {
+      for (const k in attrs) el.setAttribute(k, attrs[k]);
+    }
+    layer.appendChild(el);
+    attachClick(el, id);
+    entry = { el, kind: "shape", tag, klass };
+    entities.set(id, entry);
+    return entry;
+  }
+
+  function placeToken(entry, x, y) {
+    // 60x80 viewBox centered roughly on token's belt; scale 0.55 ⇒ visual ~33x44.
+    // Anchor so that (x,y) sits at the centre of the token's mass.
+    entry.el.setAttribute(
+      "transform",
+      `translate(${(x - 15).toFixed(2)} ${(y - 22).toFixed(2)}) scale(0.55)`,
+    );
   }
 
   function applyAgent(item, seenIds) {
     if (!item || !item.id) return;
     seenIds.add(item.id);
-    const entry = ensureCircle(item.id, item.marker_class || "npc");
-    if (!entry) return;
-    entry.el.setAttribute("cx", item.x);
-    entry.el.setAttribute("cy", item.y);
+
+    const tokenId = tokenIdFor(item);
+    const x = item.x || 0;
+    const y = item.y || 0;
+
+    if (tokenId) {
+      const klass = (item.marker_class || "char") === "man-in-yellow"
+        ? "yellow"
+        : (item.marker_class === "boy-in-white" ? "white" : "char");
+      const entry = ensureToken(item.id, tokenId, klass);
+      if (entry) placeToken(entry, x, y);
+      return;
+    }
+
+    // Fallback shapes by marker_class.
+    const mc = item.marker_class || "npc";
+    if (mc === "creature") {
+      // small jagged triangle, points roughly forming a creature glyph
+      const entry = ensureShape(item.id, "polygon", "creature", {
+        points: "0,-7 6,5 -2,2 -6,5",
+      });
+      if (entry) entry.el.setAttribute("transform", `translate(${x} ${y})`);
+      return;
+    }
+    if (mc === "anghkooey") {
+      const entry = ensureShape(item.id, "circle", "anghkooey", { r: 5 });
+      if (entry) {
+        entry.el.setAttribute("cx", x);
+        entry.el.setAttribute("cy", y);
+      }
+      return;
+    }
+    if (item.kind === "outsider" || mc === "outsider") {
+      const entry = ensureShape(item.id, "circle", "outsider", { r: 7 });
+      if (entry) {
+        entry.el.setAttribute("cx", x);
+        entry.el.setAttribute("cy", y);
+      }
+      return;
+    }
+    // Default: NPC dot.
+    const entry = ensureShape(item.id, "circle", "npc", { r: 6 });
+    if (entry) {
+      entry.el.setAttribute("cx", x);
+      entry.el.setAttribute("cy", y);
+    }
+  }
+
+  function removeEntities(seenIds) {
+    for (const [id, entry] of entities) {
+      if (!seenIds.has(id)) {
+        entry.el.remove();
+        entities.delete(id);
+      }
+    }
   }
 
   // ---------------------------------------------------------- HUD updates
@@ -155,7 +389,6 @@
     const y = payload.yellow || { mode: "DORMANT" };
     setText("stat-yellow", y.mode || "DORMANT");
 
-    // Roster summary chips
     const roster = $("roster-summary");
     if (roster) {
       roster.querySelector('[data-pool="char"]').textContent = counts.char + " chars";
@@ -173,13 +406,9 @@
     if (!Array.isArray(events) || events.length === 0) return;
     const ol = $("event-log");
     if (!ol) return;
-
-    // Append only new events since last tick (deduped by tick + type + subject).
     const latestTick = events[events.length - 1].tick;
     if (latestTick === lastEventTick) return;
     lastEventTick = latestTick;
-
-    // Replace contents — payload already last-50 from server.
     ol.innerHTML = "";
     for (let i = events.length - 1; i >= 0; i--) {
       const ev = events[i];
@@ -205,14 +434,11 @@
   function renderRosterList(agents) {
     const list = $("roster-list");
     if (!list) return;
-    // Re-render only when count changes — names rarely shift mid-tick.
     if (list.childElementCount === agents.length) return;
     list.innerHTML = "";
     for (const a of agents) {
       const li = document.createElement("li");
       const base = (a.name || a.id) + (a.role ? "  ·  " + a.role : "");
-      // Optional drift indicator: agent may carry a "drift" field per v2;
-      // when present (truthy), show a small "↕" glyph beside the name.
       const drifted = !!(a.drift || a.personality_drifted);
       li.textContent = base + (drifted ? "  ↕" : "");
       if (drifted) li.classList.add("drifted");
@@ -278,10 +504,7 @@
     const panel = $("narration-panel");
     const list = $("narration");
     if (!panel || !list) return;
-    if (!Array.isArray(items) || items.length === 0) {
-      // leave panel hidden if server has never sent any
-      return;
-    }
+    if (!Array.isArray(items) || items.length === 0) return;
     panel.style.display = "";
     list.innerHTML = "";
     items.slice(-10).reverse().forEach((line) => {
@@ -291,7 +514,7 @@
     });
   }
 
-  // ---------------------------------------------------------- v2: hash marks on buildings
+  // ---------------------------------------------------------- v2: hash marks
   function renderHashMarks(buildings, marks) {
     const overlays = $("overlays");
     if (!overlays) return;
@@ -302,7 +525,6 @@
       if (!b || !b.id) continue;
       const count = Math.max(0, Math.floor(safeMarks[b.id] || 0));
       if (count === 0) {
-        // Tear down any group we previously created for this building.
         const existing = hashGroups.get(b.id);
         if (existing) {
           existing.group.remove();
@@ -319,19 +541,19 @@
         entry = { group: g, lastCount: -1 };
         hashGroups.set(b.id, entry);
       }
-      // Anchor at (b.x + 30, b.y + 30).
-      const ox = (b.x || 0) + 30;
-      const oy = (b.y || 0) + 30;
+
+      // v3: per-building offset table for the 5 talisman set, fallback otherwise.
+      const off = HASH_OFFSET[b.id] || HASH_OFFSET_DEFAULT;
+      const ox = (b.x || 0) + off[0];
+      const oy = (b.y || 0) + off[1];
       entry.group.setAttribute("transform", `translate(${ox}, ${oy})`);
 
       if (entry.lastCount === count) continue;
       entry.lastCount = count;
 
-      // Clear and redraw — up to 12 tally lines + optional "+N" overflow label.
       while (entry.group.firstChild) entry.group.removeChild(entry.group.firstChild);
 
       const visible = Math.min(12, count);
-      // Render in groups of 5 — four uprights + diagonal slash.
       for (let i = 0; i < visible; i++) {
         const groupIdx = Math.floor(i / 5);
         const posInGroup = i % 5;
@@ -362,7 +584,6 @@
       }
     }
 
-    // Tear down groups for buildings that no longer have any marks.
     for (const [bid, entry] of hashGroups) {
       if (!seenBuildings.has(bid)) {
         entry.group.remove();
@@ -371,7 +592,7 @@
     }
   }
 
-  // ---------------------------------------------------------- v2: bus
+  // ---------------------------------------------------------- v2: bus marker
   function renderBus(bus) {
     const overlays = $("overlays");
     if (!overlays) return;
@@ -385,7 +606,6 @@
     if (!busGroup) {
       const g = document.createElementNS(SVG_NS, "g");
       g.setAttribute("class", "bus");
-      // Hand-drawn-feel yellow school bus, ~50 x 20 (centered on origin).
       g.innerHTML = [
         '<rect class="bus-body-rect" x="-25" y="-10" width="50" height="20" rx="3" ry="3"></rect>',
         '<rect class="bus-window" x="-21" y="-7" width="8" height="6"></rect>',
@@ -402,7 +622,7 @@
     busGroup.setAttribute("transform", `translate(${bus.x || 0}, ${bus.y || 0})`);
   }
 
-  // ---------------------------------------------------------- v2: outsider glyphs
+  // ---------------------------------------------------------- v2: outsider '+'
   function applyOutsiderGlyph(item, seenGlyphs) {
     if (!item || item.kind !== "outsider") return;
     seenGlyphs.add(item.id);
@@ -420,7 +640,6 @@
     glyph.setAttribute("x", item.x);
     glyph.setAttribute("y", (item.y || 0) - 8);
   }
-
   function pruneOutsiderGlyphs(seenGlyphs) {
     for (const [id, el] of outsiderGlyphs) {
       if (!seenGlyphs.has(id)) {
@@ -430,7 +649,7 @@
     }
   }
 
-  // ---------------------------------------------------------- v2: pulsing rings (tendrils + called)
+  // ---------------------------------------------------------- v2: pulsing rings
   function applyRing(id, x, y, kind) {
     let entry = rings.get(id);
     if (!entry) {
@@ -451,7 +670,6 @@
     entry.ring.setAttribute("cx", x);
     entry.ring.setAttribute("cy", y);
   }
-
   function pruneRings(seenRingIds) {
     for (const [id, entry] of rings) {
       if (!seenRingIds.has(id)) {
@@ -474,12 +692,10 @@
     const fragments = (legacy && Array.isArray(legacy.journal_fragments))
       ? legacy.journal_fragments : [];
     if (frag) frag.textContent = "📜 " + fragments.length + " fragments";
-    // Cheap change-key — only re-render when content shifts.
-    const key = fragments.map((f) => `${f.cycle}|${f.burned}|${f.text}`).join("");
+    const key = fragments.map((f) => `${f.cycle}|${f.burned}|${f.text}`).join("");
     if (key === lastJournalKey) return;
     lastJournalKey = key;
     ol.innerHTML = "";
-    // Oldest first (server already trims to last 12).
     for (const f of fragments) {
       const li = document.createElement("li");
       const burned = Math.max(0, Math.min(1, Number(f.burned) || 0));
@@ -489,7 +705,7 @@
     }
   }
 
-  // ---------------------------------------------------------- v2: lighthouse-voice panel
+  // ---------------------------------------------------------- v2: lighthouse-voice
   function renderLighthouseVoice(payload) {
     const panel = $("lighthouse-voice");
     const list = $("lighthouse-voice-list");
@@ -527,7 +743,6 @@
       return;
     }
     panel.style.display = "";
-    // Lookup agents by id.
     const agents = Array.isArray(payload.agents) ? payload.agents : [];
     const byId = new Map(agents.map((a) => [a.id, a]));
     const passengers = Array.isArray(bus.passengers) ? bus.passengers : [];
@@ -547,13 +762,15 @@
       li.textContent = "(no passengers boarded yet)";
       list.appendChild(li);
     }
-    // Departure countdown — next_arrival_cycle is a cycle counter, so display it raw.
     const next = bus.next_arrival_cycle;
     countdown.textContent = next != null ? ("Next bus: cycle " + next) : "—";
   }
 
   // ---------------------------------------------------------- main tick
   function handleTick(payload) {
+    // Forest scatter runs once per session, on the first real tick.
+    scatterForest();
+
     const seen = new Set();
     const counts = { char: 0, npc: 0, creature: 0, other: 0 };
 
@@ -579,7 +796,7 @@
       counts.other++;
     }
 
-    removeDots(seen);
+    removeEntities(seen);
     pruneOutsiderGlyphs(seenGlyphs);
 
     // ---- v2: rings (tendrils + called) ----
@@ -590,27 +807,25 @@
     const calledId = lighthouse.called || null;
 
     const seenRingIds = new Set();
-    const dotById = new Map();
-    for (const a of agents) dotById.set(a.id, a);
+    const agentById = new Map();
+    for (const a of agents) agentById.set(a.id, a);
 
     for (const id of tendrils) {
-      const a = dotById.get(id);
+      const a = agentById.get(id);
       if (!a) continue;
       const kind = (id === leader) ? "tendril-leader" : "tendril";
       applyRing(id, a.x, a.y, kind);
       seenRingIds.add(id);
     }
     if (calledId) {
-      const a = dotById.get(calledId);
+      const a = agentById.get(calledId);
       if (a) {
-        // If the called character is also a tendril, the called ring overrides (slow aqua pulse).
         applyRing(calledId, a.x, a.y, "called");
         seenRingIds.add(calledId);
       }
     }
     pruneRings(seenRingIds);
 
-    // ---- v2: hash marks + bus ----
     const buildings = Array.isArray(payload.buildings) ? payload.buildings : [];
     const legacy = payload.legacy || {};
     renderHashMarks(buildings, legacy.building_breach_marks);
@@ -622,7 +837,6 @@
     renderRosterList(agents);
     renderNarration(payload.narration);
 
-    // v2 right-column panels
     renderJournal(legacy);
     renderLighthouseVoice(payload);
     renderBusPanel(payload);

--- a/from-simulation/app/static/js/socket.js
+++ b/from-simulation/app/static/js/socket.js
@@ -37,9 +37,12 @@
   });
 
   socket.on("inspect_reply", (payload) => {
-    window.dispatchEvent(
-      new CustomEvent("from:inspect_reply", { detail: payload || {} })
-    );
+    // The legacy inline roster-detail still listens on "from:inspect_reply".
+    // The v6 dossier overlay (inspector.js) listens on the shorter "from:inspect"
+    // alias so it can be wired/unwired independently of the roster panel.
+    const detail = payload || {};
+    window.dispatchEvent(new CustomEvent("from:inspect_reply", { detail }));
+    window.dispatchEvent(new CustomEvent("from:inspect", { detail }));
   });
 
   socket.on("cycle_reset", (payload) => {

--- a/from-simulation/app/static/js/socket.js
+++ b/from-simulation/app/static/js/socket.js
@@ -1,0 +1,54 @@
+/*
+ * socket.js — connects to Flask-SocketIO and fans events out to
+ * the map / lighting / UI updaters via the window event bus.
+ *
+ * Server -> client events the server emits (see contracts.SocketEvent):
+ *   tick           — full snapshot_dict payload
+ *   inspect_reply  — full agent record for a clicked dot
+ *   cycle_reset    — village wipe overlay trigger
+ *
+ * Client -> server:
+ *   inspect        — {id: "<agent_id>"}
+ */
+(function () {
+  "use strict";
+
+  const socket = io({
+    transports: ["websocket", "polling"],
+    reconnection: true,
+  });
+
+  // Expose for map.js so it can emit `inspect` on a dot click.
+  window.FROM_SOCKET = socket;
+
+  socket.on("connect", () => {
+    console.log("[from-sim] socket connected", socket.id);
+  });
+  socket.on("disconnect", (reason) => {
+    console.warn("[from-sim] socket disconnected:", reason);
+  });
+  socket.on("connect_error", (err) => {
+    console.error("[from-sim] connect_error:", err && err.message);
+  });
+
+  socket.on("tick", (payload) => {
+    if (!payload) return;
+    window.dispatchEvent(new CustomEvent("from:tick", { detail: payload }));
+  });
+
+  socket.on("inspect_reply", (payload) => {
+    window.dispatchEvent(
+      new CustomEvent("from:inspect_reply", { detail: payload || {} })
+    );
+  });
+
+  socket.on("cycle_reset", (payload) => {
+    const cycle = (payload && payload.cycle) || "?";
+    const overlay = document.getElementById("cycle-reset-overlay");
+    const num = document.getElementById("cycle-reset-num");
+    if (!overlay) return;
+    if (num) num.textContent = String(cycle);
+    overlay.classList.remove("hidden");
+    setTimeout(() => overlay.classList.add("hidden"), 3000);
+  });
+})();

--- a/from-simulation/app/storage.py
+++ b/from-simulation/app/storage.py
@@ -119,7 +119,30 @@ class Memory:
         # Apply schema. ``schema.sql`` is idempotent (CREATE IF NOT EXISTS).
         with open(_SCHEMA_PATH, "r", encoding="utf-8") as fh:
             conn.executescript(fh.read())
+        # v9 — additive migrations. Safe on a fresh DB (column already exists)
+        # and on an upgraded DB (column gets added).
+        cls._migrate_v9(conn)
         return cls(conn)
+
+    # ----------------------------------------------------- v9 migrations
+    @staticmethod
+    def _migrate_v9(conn: sqlite3.Connection) -> None:
+        """Add ``preferred_home`` to sub_main_characters when missing.
+
+        SQLite has no ``ADD COLUMN IF NOT EXISTS``; we inspect the table and
+        emit ``ALTER`` only when needed. Failure is non-fatal — the caller
+        treats a busted migration like a busted DB (memory off).
+        """
+        try:
+            cols = {
+                r[1] for r in conn.execute("PRAGMA table_info(sub_main_characters)")
+            }
+            if "preferred_home" not in cols:
+                conn.execute(
+                    "ALTER TABLE sub_main_characters ADD COLUMN preferred_home TEXT"
+                )
+        except Exception:  # pragma: no cover — best-effort migration
+            pass
 
     # ----------------------------------------------------------------- log
     def _log_exc(self, world: Any, where: str) -> None:
@@ -221,6 +244,91 @@ class Memory:
             )
         except Exception:
             self._log_exc(world, "hydrate")
+
+    # -------------------------------------------------------- hydrate minds
+    def hydrate_minds(self, world: Any) -> None:
+        """v9 — lift open goals and recent beliefs back into each Mind.
+
+        Called from ``app.py`` AFTER ``build_characters`` so every character
+        already owns a fresh ``Mind`` instance. Walks ``world.agents`` once;
+        a missing ``mind`` attribute is fine (the agent simply skips).
+
+        Belief rows are scored by ``last_seen_tick`` so only the latest
+        ``RECENT_LIMIT`` per character are restored.
+        """
+        try:
+            from agents.mind import Belief, Goal, GoalKind  # local import — avoid cycle
+        except Exception:
+            return
+        try:
+            with self._lock:
+                for agent in list(getattr(world, "agents", {}).values()):
+                    mind = getattr(agent, "mind", None)
+                    if mind is None:
+                        continue
+                    aid = getattr(agent, "id", None)
+                    if not aid:
+                        continue
+                    # Restore the most recent 10 beliefs.
+                    belief_rows = self._conn.execute(
+                        "SELECT tick, subject, detail, payload FROM character_memory "
+                        "WHERE character_id = ? AND kind = 'belief' "
+                        "ORDER BY tick DESC LIMIT 10",
+                        (str(aid),),
+                    ).fetchall()
+                    for r in belief_rows:
+                        try:
+                            payload = json.loads(r["payload"] or "{}") if r["payload"] else {}
+                        except Exception:
+                            payload = {}
+                        key = str(r["subject"] or "")
+                        if not key:
+                            continue
+                        if key in mind.beliefs:
+                            continue
+                        mind.beliefs[key] = Belief(
+                            key=key,
+                            confidence=float(payload.get("confidence", 0.5)),
+                            polarity=float(payload.get("polarity", 1.0)),
+                            created_tick=int(r["tick"]),
+                            last_seen_tick=int(r["tick"]),
+                            note=str(r["detail"] or ""),
+                        )
+                    # Restore the latest open goal (if any). A goal is "open"
+                    # if a more recent goal_closed row hasn't superseded it.
+                    open_row = self._conn.execute(
+                        "SELECT tick, subject, detail, payload FROM character_memory "
+                        "WHERE character_id = ? AND kind = 'goal_open' "
+                        "ORDER BY tick DESC LIMIT 1",
+                        (str(aid),),
+                    ).fetchone()
+                    if open_row is None:
+                        continue
+                    closed_tick = self._conn.execute(
+                        "SELECT MAX(tick) AS t FROM character_memory "
+                        "WHERE character_id = ? AND kind = 'goal_closed'",
+                        (str(aid),),
+                    ).fetchone()
+                    last_closed = int(closed_tick["t"] or -1) if closed_tick else -1
+                    if int(open_row["tick"]) <= last_closed:
+                        continue
+                    try:
+                        payload = json.loads(open_row["payload"] or "{}") if open_row["payload"] else {}
+                        kind_val = str(open_row["subject"] or "")
+                        target = str(open_row["detail"] or "")
+                        kind = GoalKind(kind_val)
+                        mind.active_goal = Goal(
+                            kind=kind,
+                            target=target,
+                            priority=float(payload.get("priority", 0.5)),
+                            expires_at_tick=int(world.tick_count) + int(world.config.mind_goal_ttl_ticks),
+                            origin_belief_key=str(payload.get("origin_belief") or "") or None,
+                            opened_tick=int(open_row["tick"]),
+                        )
+                    except (KeyError, ValueError):
+                        continue
+        except Exception:
+            self._log_exc(world, "hydrate_minds")
 
     # --------------------------------------------------- buffered writes
     def record_event(self, world: Any, event: Any) -> None:
@@ -364,6 +472,37 @@ class Memory:
             # blow up trying to rename the NPC; the row just isn't persisted.
             return getattr(npc, "name", str(getattr(npc, "id", "Unknown")))
 
+    # ------------------------------------------------------- preferred home
+    def get_sub_main_preferred_home(self, npc_id: str) -> Optional[str]:
+        """v9 — read a sub-main NPC's preferred home (or None)."""
+        try:
+            with self._lock:
+                row = self._conn.execute(
+                    "SELECT preferred_home FROM sub_main_characters "
+                    "WHERE npc_id = ? AND died_at_cycle IS NULL",
+                    (str(npc_id),),
+                ).fetchone()
+            if row is None:
+                return None
+            val = row["preferred_home"]
+            return str(val) if val else None
+        except Exception:
+            return None
+
+    def set_sub_main_preferred_home(
+        self, world: Any, npc_id: str, building_id: Optional[str]
+    ) -> None:
+        """v9 — record (or clear) a sub-main's preferred home."""
+        try:
+            with self._lock:
+                self._conn.execute(
+                    "UPDATE sub_main_characters SET preferred_home = ? "
+                    "WHERE npc_id = ? AND died_at_cycle IS NULL",
+                    (str(building_id) if building_id else None, str(npc_id)),
+                )
+        except Exception:
+            self._log_exc(world, "set_sub_main_preferred_home")
+
     def mark_sub_main_dead(self, world: Any, npc_id: str, cause: str) -> None:
         """Close a sub-main's tombstone — they stop showing up in
         ``world.sub_mains`` on subsequent hydrates."""
@@ -443,12 +582,10 @@ class Memory:
                     pruned = sorted(self._recall_cache.items(), key=lambda kv: kv[1][0])
                     for k, _ in pruned[: len(pruned) // 2]:
                         self._recall_cache.pop(k, None)
-            from contracts import Event
-            world.emit(Event(
-                tick=world.tick_count, type="memory_recall",
-                subject=str(character_id),
-                detail=f"{len(rows)} rows ({','.join(sorted(kind_set))})",
-            ))
+            # Note: memory_recall used to emit an event per call, but that
+            # made the user-facing event log unreadable (10+ recalls per tick
+            # × hundreds of ticks). The SQLite write/read itself is the
+            # source of truth; metrics/telemetry still count the volume.
             return rows
         except Exception:
             self._log_exc(world, "recall_for")

--- a/from-simulation/app/storage.py
+++ b/from-simulation/app/storage.py
@@ -1,0 +1,748 @@
+"""
+v5 SQLite-backed Memory subsystem for the From simulation.
+
+The Memory class is the single durable surface bridging in-memory World state
+and on-disk SQLite. It is *optional*: when the DB cannot be opened, app.py
+sets ``world.memory = None`` and the simulation runs exactly as v4 did.
+
+Design notes
+------------
+* Stdlib ``sqlite3`` only (no SQLAlchemy / aiosqlite). The connection is opened
+  with ``check_same_thread=False`` so the simulation tick thread, the Flask
+  request thread, and ``atexit`` can all touch it. We serialise external
+  writes through ``self._lock``; SQLite's own write lock handles the rest.
+* WAL mode + a single connection — see ``schema.sql``. Reads on the same
+  connection block writes on the same connection but not vice-versa, which is
+  fine because every method here runs from the tick thread.
+* Buffered writes. ``record_event`` / ``record_character_memory`` /
+  ``record_inventory_change`` enqueue into per-instance lists; ``tick_flush``
+  drains them via ``executemany`` every ``config.memory_flush_every_ticks``
+  ticks (or sooner if any buffer crosses ``BUFFER_FLUSH_LIMIT``).
+* Every public method swallows its own exceptions and logs via
+  ``world.telemetry.get_logger()`` so a busted DB never kills a tick.
+  ``World.emit`` already wraps ``record_event`` in try/except as a backstop.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import threading
+from datetime import datetime
+from typing import Any, Dict, Iterable, List, Optional, Set, Tuple
+
+
+_SCHEMA_PATH = os.path.join(os.path.dirname(__file__), "schema.sql")
+
+# Force a flush if any single buffer crosses this — bounds memory growth
+# on a stalled or runaway tick.
+BUFFER_FLUSH_LIMIT = 256
+
+# Event kinds we persist to ``character_memory``. Everything else is treated
+# as noise — World.emit still mirrors it to telemetry counters, just not the DB.
+_PERSISTED_EVENT_KINDS: Set[str] = {
+    "journal_entry",
+    "meeting_outcome",
+    "imposter_banished",
+    "village_wipe",
+    "creature_breach",
+    "char_death",
+    "npc_death",
+    "homecoming",
+    "npc_promoted",
+    "sub_main_died",
+    "music_box_destroyed",
+    "lighthouse_enter",
+    "trust_shift",
+}
+
+# Surnames generated for promoted NPCs. Chosen with ``world.rng`` so a seeded
+# run is reproducible. Twenty entries — plenty of variety for 50 cycles.
+_SURNAMES: List[str] = [
+    "Tate", "Reyes", "Hollander", "Burke", "Akeyo",
+    "Vasquez", "Cromwell", "Okafor", "Hendrix", "Walsh",
+    "Marsh", "Quincey", "Dover", "Linde", "Stoker",
+    "Ashby", "Pendrake", "Yates", "Galt", "Roe",
+]
+
+
+def _now_iso() -> str:
+    return datetime.utcnow().isoformat()
+
+
+class Memory:
+    """SQLite-backed persistence handle attached to ``World.memory``.
+
+    Lifecycle: ``Memory.open(path)`` -> ``hydrate(world)`` -> ticks call
+    ``tick_flush(world)`` -> ``close()`` on shutdown.
+    """
+
+    # ------------------------------------------------------------------ ctor
+    def __init__(self, conn: sqlite3.Connection) -> None:
+        self._conn = conn
+        self._lock = threading.RLock()
+
+        # Per-table write buffers. Each entry is a tuple matching the columns
+        # listed in ``_flush_*`` below.
+        self._event_buf: List[Tuple[Any, ...]] = []        # -> character_memory
+        self._memory_buf: List[Tuple[Any, ...]] = []        # -> character_memory
+        self._inventory_buf: List[Tuple[Any, ...]] = []     # -> character_inventory
+
+        # Tiny TTL recall cache. Key = (character_id, frozenset(kinds), bucket).
+        # We invalidate it implicitly on flush so a recall right after a write
+        # sees fresh data.
+        self._recall_cache: Dict[Tuple[Any, ...], Tuple[int, List[Dict[str, Any]]]] = {}
+
+        # Last tick we flushed. Compared against ``world.tick_count`` and
+        # ``world.config.memory_flush_every_ticks`` in ``tick_flush``.
+        self._last_flush_tick: int = -1
+
+    # ----------------------------------------------------------------- open
+    @classmethod
+    def open(cls, path: str) -> "Memory":
+        """Open (or create) the SQLite DB at ``path`` and apply the schema.
+
+        Raises on failure — the caller (app.py) catches and sets
+        ``world.memory = None`` to disable persistence.
+        """
+        # Ensure parent dir exists; an empty dirname means cwd, leave it alone.
+        parent = os.path.dirname(path)
+        if parent:
+            os.makedirs(parent, exist_ok=True)
+        conn = sqlite3.connect(
+            path,
+            check_same_thread=False,
+            isolation_level=None,  # autocommit — we manage BEGIN/COMMIT manually
+        )
+        conn.row_factory = sqlite3.Row
+        # Apply schema. ``schema.sql`` is idempotent (CREATE IF NOT EXISTS).
+        with open(_SCHEMA_PATH, "r", encoding="utf-8") as fh:
+            conn.executescript(fh.read())
+        return cls(conn)
+
+    # ----------------------------------------------------------------- log
+    def _log_exc(self, world: Any, where: str) -> None:
+        tele = getattr(world, "telemetry", None)
+        if tele is None:
+            return
+        try:
+            tele.get_logger().exception("memory %s failed", where)
+        except Exception:
+            pass
+
+    # ------------------------------------------------------------- hydrate
+    def hydrate(self, world: Any) -> None:
+        """Restore ``world.legacy`` and ``world.sub_mains`` from disk.
+
+        Run once at boot, BEFORE ``build_characters`` so any restored
+        personality drift applies on rebuild.
+        """
+        try:
+            with self._lock:
+                # Most recent 40 fragments (across all cycles), preserving
+                # original chronological order.
+                rows = self._conn.execute(
+                    "SELECT cycle_no, text, burned FROM journal_fragments "
+                    "ORDER BY id DESC LIMIT 40"
+                ).fetchall()
+                from contracts import JournalFragment  # local import — avoids cycles
+                rows = list(reversed(rows))
+                world.legacy.journal_fragments = [
+                    JournalFragment(
+                        cycle_recorded=int(r["cycle_no"]),
+                        text=str(r["text"]),
+                        burned=float(r["burned"]),
+                    )
+                    for r in rows
+                ]
+
+                # Personality drift — restore every row.
+                drift_rows = self._conn.execute(
+                    "SELECT character_name, trait, delta FROM personality_drift"
+                ).fetchall()
+                drift_map: Dict[str, Dict[str, float]] = {}
+                for r in drift_rows:
+                    drift_map.setdefault(str(r["character_name"]), {})[
+                        str(r["trait"])
+                    ] = float(r["delta"])
+                world.legacy.personality_drift = drift_map
+
+                # Cycles witnessed = max(cycle_no) so far (0 if no rows).
+                max_row = self._conn.execute(
+                    "SELECT COALESCE(MAX(cycle_no), 0) AS m FROM cycles"
+                ).fetchone()
+                world.legacy.cycles_witnessed = int(max_row["m"]) if max_row else 0
+
+                # Building breach marks — only the latest cycle's marks.
+                if world.legacy.cycles_witnessed > 0:
+                    bm_rows = self._conn.execute(
+                        "SELECT building_id, count FROM building_breach_marks "
+                        "WHERE cycle_no = ?",
+                        (world.legacy.cycles_witnessed,),
+                    ).fetchall()
+                    world.legacy.building_breach_marks = {
+                        str(r["building_id"]): int(r["count"]) for r in bm_rows
+                    }
+
+                # Sub-mains: every npc whose tombstone is open.
+                sm_rows = self._conn.execute(
+                    "SELECT npc_id FROM sub_main_characters "
+                    "WHERE died_at_cycle IS NULL"
+                ).fetchall()
+                world.sub_mains = {str(r["npc_id"]) for r in sm_rows}
+
+                n_frags = len(world.legacy.journal_fragments)
+                n_subs = len(world.sub_mains)
+                n_cycles = world.legacy.cycles_witnessed
+
+                # Ensure a cycles row exists for the cycle we're about to
+                # live through (cycles_witnessed + 1). Without this, every
+                # FK-constrained insert silently fails on a fresh DB.
+                cur_no = int(world.legacy.cycles_witnessed) + 1
+                self._conn.execute(
+                    "INSERT OR IGNORE INTO cycles "
+                    "(cycle_no, started_real_ts, outcome) "
+                    "VALUES (?, ?, 'ongoing')",
+                    (cur_no, _now_iso()),
+                )
+
+            # Emit ONCE, outside the lock so the World.emit -> record_event
+            # path doesn't deadlock on the same lock.
+            from contracts import Event
+            world.emit(
+                Event(
+                    tick=world.tick_count,
+                    type="memory_hydrated",
+                    subject="world",
+                    detail=f"{n_frags} fragments, {n_subs} sub-mains, {n_cycles} cycles seen",
+                    severity="info",
+                )
+            )
+        except Exception:
+            self._log_exc(world, "hydrate")
+
+    # --------------------------------------------------- buffered writes
+    def record_event(self, world: Any, event: Any) -> None:
+        """Persist high-signal events as character_memory rows."""
+        try:
+            kind = getattr(event, "type", "") or ""
+            if kind not in _PERSISTED_EVENT_KINDS:
+                return
+            subject = getattr(event, "subject", "") or ""
+            detail = getattr(event, "detail", "") or ""
+            tick = int(getattr(event, "tick", world.tick_count))
+            cycle_no = self._current_cycle_no(world)
+            with self._lock:
+                self._memory_buf.append((
+                    cycle_no, tick, subject, kind, subject, detail, "", _now_iso(),
+                ))
+                if len(self._memory_buf) >= BUFFER_FLUSH_LIMIT:
+                    self._drain_memory_buf()
+        except Exception:
+            self._log_exc(world, "record_event")
+
+    def record_meeting_outcome(self, world: Any, outcome: Any) -> None:
+        """Persist a MeetingOutcome — one row per attendee for easy recall."""
+        try:
+            tick = int(getattr(outcome, "tick", world.tick_count))
+            topic = str(getattr(outcome, "topic", ""))
+            decision = str(getattr(outcome, "decision", ""))
+            attendees = list(getattr(outcome, "attendees", []) or [])
+            payload_blob = json.dumps(getattr(outcome, "payload", {}) or {})
+            cycle_no = self._current_cycle_no(world)
+            ts = _now_iso()
+            with self._lock:
+                for aid in attendees:
+                    self._memory_buf.append((
+                        cycle_no, tick, str(aid), "meeting_outcome",
+                        topic, decision, payload_blob, ts,
+                    ))
+                if len(self._memory_buf) >= BUFFER_FLUSH_LIMIT:
+                    self._drain_memory_buf()
+        except Exception:
+            self._log_exc(world, "record_meeting_outcome")
+
+    def record_character_memory(
+        self,
+        world: Any,
+        character_id: str,
+        kind: str,
+        subject: str = "",
+        detail: str = "",
+        payload: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """Direct write into ``character_memory`` (buffered)."""
+        try:
+            payload_blob = "" if payload is None else json.dumps(payload)
+            cycle_no = self._current_cycle_no(world)
+            with self._lock:
+                self._memory_buf.append((
+                    cycle_no, int(world.tick_count), str(character_id),
+                    str(kind), str(subject), str(detail), payload_blob, _now_iso(),
+                ))
+                if len(self._memory_buf) >= BUFFER_FLUSH_LIMIT:
+                    self._drain_memory_buf()
+        except Exception:
+            self._log_exc(world, "record_character_memory")
+
+    def record_inventory_change(
+        self,
+        world: Any,
+        character_id: str,
+        item: Any,
+        delta: int,
+        total: int,
+    ) -> None:
+        """Buffer a single inventory delta row."""
+        try:
+            # ``item`` may be an Item enum or a string.
+            item_val = getattr(item, "value", item)
+            cycle_no = self._current_cycle_no(world)
+            with self._lock:
+                self._inventory_buf.append((
+                    cycle_no, int(world.tick_count), str(character_id),
+                    str(item_val), int(delta), int(total), _now_iso(),
+                ))
+                if len(self._inventory_buf) >= BUFFER_FLUSH_LIMIT:
+                    self._drain_inventory_buf()
+        except Exception:
+            self._log_exc(world, "record_inventory_change")
+
+    def record_journal_fragment(self, world: Any, fragment: Any) -> None:
+        """Persist a journal fragment immediately — they're tiny and rare."""
+        try:
+            with self._lock:
+                self._conn.execute(
+                    "INSERT INTO journal_fragments (cycle_no, text, burned, real_ts) "
+                    "VALUES (?, ?, ?, ?)",
+                    (
+                        int(getattr(fragment, "cycle_recorded", 0)),
+                        str(getattr(fragment, "text", "")),
+                        float(getattr(fragment, "burned", 0.0)),
+                        _now_iso(),
+                    ),
+                )
+        except Exception:
+            self._log_exc(world, "record_journal_fragment")
+
+    # ---------------------------------------------------- promotion / death
+    def promote_npc(
+        self, world: Any, npc: Any, reason: str, score: float
+    ) -> str:
+        """Persist a new sub-main row and return the generated full name.
+
+        Caller (agent C) is responsible for setting ``npc.name`` and
+        ``npc.is_sub_main`` and adding ``npc.id`` to ``world.sub_mains``.
+        """
+        try:
+            first = getattr(npc, "name", None) or getattr(npc, "id", "Unknown")
+            # Strip any digits from the auto-generated npc handles (e.g. ``npc_07``).
+            first = str(first).strip() or "Unknown"
+            surname = world.rng.choice(_SURNAMES)
+            full_name = f"{first} {surname}"
+            cycle_no = self._current_cycle_no(world)
+            with self._lock:
+                self._conn.execute(
+                    "INSERT OR REPLACE INTO sub_main_characters "
+                    "(npc_id, full_name, promoted_at_cycle, promoted_at_tick, "
+                    " reason, score, died_at_cycle, died_at_tick, cause_of_death) "
+                    "VALUES (?, ?, ?, ?, ?, ?, NULL, NULL, NULL)",
+                    (
+                        str(getattr(npc, "id", "")),
+                        full_name,
+                        cycle_no,
+                        int(world.tick_count),
+                        str(reason or ""),
+                        float(score),
+                    ),
+                )
+            return full_name
+        except Exception:
+            self._log_exc(world, "promote_npc")
+            # On failure, hand back a plausible name so the caller doesn't
+            # blow up trying to rename the NPC; the row just isn't persisted.
+            return getattr(npc, "name", str(getattr(npc, "id", "Unknown")))
+
+    def mark_sub_main_dead(self, world: Any, npc_id: str, cause: str) -> None:
+        """Close a sub-main's tombstone — they stop showing up in
+        ``world.sub_mains`` on subsequent hydrates."""
+        try:
+            cycle_no = self._current_cycle_no(world)
+            with self._lock:
+                self._conn.execute(
+                    "UPDATE sub_main_characters SET "
+                    " died_at_cycle = ?, died_at_tick = ?, cause_of_death = ? "
+                    "WHERE npc_id = ? AND died_at_cycle IS NULL",
+                    (cycle_no, int(world.tick_count), str(cause or ""), str(npc_id)),
+                )
+        except Exception:
+            self._log_exc(world, "mark_sub_main_dead")
+
+    # ------------------------------------------------------------ recall
+    def recall_for(
+        self,
+        world: Any,
+        character_id: str,
+        kinds: Iterable[str],
+        lookback_ticks: int,
+    ) -> List[Dict[str, Any]]:
+        """Return up to ~50 recent character_memory rows for this character.
+
+        Result shape: ``[{"tick", "kind", "subject", "detail", "cycle_no"}, ...]``.
+        Cached for ~10 ticks per (character, kinds, lookback-bucket) so several
+        per-tick callers don't repeatedly hit the disk.
+        """
+        try:
+            kind_set = frozenset(str(k) for k in kinds)
+            bucket = int(lookback_ticks) // 100
+            now_tick = int(world.tick_count)
+            key = (str(character_id), kind_set, bucket)
+            with self._lock:
+                cached = self._recall_cache.get(key)
+                if cached is not None:
+                    cached_at, rows = cached
+                    if now_tick - cached_at < 10:
+                        return rows
+                # Build the query: explicit IN-list because sqlite3 doesn't
+                # bind sets, and the kind list is always small (<10).
+                if kind_set:
+                    placeholders = ",".join("?" for _ in kind_set)
+                    sql = (
+                        "SELECT tick, cycle_no, kind, subject, detail "
+                        "FROM character_memory "
+                        "WHERE character_id = ? "
+                        f"  AND kind IN ({placeholders}) "
+                        "  AND tick >= ? "
+                        "ORDER BY tick DESC LIMIT 50"
+                    )
+                    params: List[Any] = [str(character_id), *kind_set, max(0, now_tick - int(lookback_ticks))]
+                else:
+                    sql = (
+                        "SELECT tick, cycle_no, kind, subject, detail "
+                        "FROM character_memory "
+                        "WHERE character_id = ? AND tick >= ? "
+                        "ORDER BY tick DESC LIMIT 50"
+                    )
+                    params = [str(character_id), max(0, now_tick - int(lookback_ticks))]
+                cur = self._conn.execute(sql, params)
+                rows = [
+                    {
+                        "tick": int(r["tick"]),
+                        "cycle_no": int(r["cycle_no"]),
+                        "kind": str(r["kind"]),
+                        "subject": str(r["subject"]),
+                        "detail": str(r["detail"]),
+                    }
+                    for r in cur.fetchall()
+                ]
+                self._recall_cache[key] = (now_tick, rows)
+                # Trim cache to avoid unbounded growth.
+                if len(self._recall_cache) > 256:
+                    # Drop the oldest entries.
+                    pruned = sorted(self._recall_cache.items(), key=lambda kv: kv[1][0])
+                    for k, _ in pruned[: len(pruned) // 2]:
+                        self._recall_cache.pop(k, None)
+            from contracts import Event
+            world.emit(Event(
+                tick=world.tick_count, type="memory_recall",
+                subject=str(character_id),
+                detail=f"{len(rows)} rows ({','.join(sorted(kind_set))})",
+            ))
+            return rows
+        except Exception:
+            self._log_exc(world, "recall_for")
+            return []
+
+    # ------------------------------------------------------ cycle lifecycle
+    def start_cycle(self, world: Any) -> None:
+        """Open the cycle row for the cycle we're about to live through.
+
+        Called from ``reset_world`` AFTER ``cycles_witnessed`` has been bumped.
+        The previous cycle (if any) is closed with outcome="wiped".
+
+        Cycle numbering matches ``world.cycle_number`` (cycles_witnessed + 1)
+        so it lines up with ``JournalFragment.cycle_recorded`` and the UI.
+        """
+        try:
+            cur_no = int(getattr(world.legacy, "cycles_witnessed", 0)) + 1
+            with self._lock:
+                # Close the previous cycle (the one we just finished living through).
+                if cur_no > 1:
+                    self._conn.execute(
+                        "UPDATE cycles SET ended_real_ts = ?, outcome = 'wiped' "
+                        "WHERE cycle_no = ? AND outcome = 'ongoing'",
+                        (_now_iso(), cur_no - 1),
+                    )
+                self._conn.execute(
+                    "INSERT OR IGNORE INTO cycles "
+                    "(cycle_no, started_real_ts, outcome) VALUES (?, ?, 'ongoing')",
+                    (cur_no, _now_iso()),
+                )
+        except Exception:
+            self._log_exc(world, "start_cycle")
+
+    def prune_old_cycles(self, world: Any) -> None:
+        """Drop cycle rows older than ``memory_cycle_window`` cycles.
+
+        Cascades to journal_fragments, character_memory, character_inventory,
+        and building_breach_marks via ``ON DELETE CASCADE``. Sub-mains and
+        personality_drift are intentionally untouched.
+        """
+        try:
+            window = int(getattr(world.config, "memory_cycle_window", 50))
+            cutoff = int(getattr(world.legacy, "cycles_witnessed", 0)) - window
+            if cutoff <= 0:
+                return
+            with self._lock:
+                self._conn.execute("BEGIN")
+                try:
+                    self._conn.execute(
+                        "DELETE FROM journal_fragments WHERE cycle_no < ?", (cutoff,)
+                    )
+                    self._conn.execute(
+                        "DELETE FROM character_memory WHERE cycle_no < ?", (cutoff,)
+                    )
+                    self._conn.execute(
+                        "DELETE FROM character_inventory WHERE cycle_no < ?", (cutoff,)
+                    )
+                    self._conn.execute(
+                        "DELETE FROM building_breach_marks WHERE cycle_no < ?", (cutoff,)
+                    )
+                    self._conn.execute(
+                        "DELETE FROM cycles WHERE cycle_no < ?", (cutoff,)
+                    )
+                    self._conn.execute("COMMIT")
+                except Exception:
+                    self._conn.execute("ROLLBACK")
+                    raise
+            from contracts import Event
+            world.emit(Event(
+                tick=world.tick_count, type="db_pruned",
+                subject="world", detail=f"pruned cycles < {cutoff}",
+            ))
+        except Exception:
+            self._log_exc(world, "prune_old_cycles")
+
+    # ----------------------------------------------------------- tick flush
+    def tick_flush(self, world: Any) -> None:
+        """Called from simulation._do_tick. Drains buffers + updates gauges."""
+        try:
+            cfg = world.config
+            every = max(1, int(getattr(cfg, "memory_flush_every_ticks", 60)))
+            due = (world.tick_count - self._last_flush_tick) >= every
+            big = (
+                len(self._event_buf) >= BUFFER_FLUSH_LIMIT
+                or len(self._memory_buf) >= BUFFER_FLUSH_LIMIT
+                or len(self._inventory_buf) >= BUFFER_FLUSH_LIMIT
+            )
+            if not (due or big):
+                return
+            self._flush_all(world)
+            self._last_flush_tick = world.tick_count
+            self._sync_personality_drift(world)
+            self._sync_breach_marks(world)
+            self._update_gauges(world)
+        except Exception:
+            self._log_exc(world, "tick_flush")
+
+    def _flush_all(self, world: Any) -> None:
+        with self._lock:
+            if not (self._event_buf or self._memory_buf or self._inventory_buf):
+                return
+            self._conn.execute("BEGIN")
+            try:
+                self._drain_memory_buf(skip_lock=True)
+                self._drain_event_buf(skip_lock=True)
+                self._drain_inventory_buf(skip_lock=True)
+                self._conn.execute("COMMIT")
+            except Exception:
+                self._conn.execute("ROLLBACK")
+                raise
+            # Recall cache may be stale after a flush; cheap to drop wholesale.
+            self._recall_cache.clear()
+
+    def _drain_memory_buf(self, skip_lock: bool = False) -> None:
+        lock = (lambda: _NullCtx()) if skip_lock else (lambda: self._lock)
+        ctx = lock()
+        with ctx:
+            if not self._memory_buf:
+                return
+            rows = self._memory_buf
+            self._memory_buf = []
+            self._conn.executemany(
+                "INSERT INTO character_memory "
+                "(cycle_no, tick, character_id, kind, subject, detail, payload, real_ts) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                rows,
+            )
+
+    def _drain_event_buf(self, skip_lock: bool = False) -> None:
+        # Reserved for a future generic events_log table. Currently a no-op
+        # (we route event persistence through ``_memory_buf``) but kept so
+        # the buffer name in the contract isn't a lie.
+        lock = (lambda: _NullCtx()) if skip_lock else (lambda: self._lock)
+        with lock():
+            self._event_buf.clear()
+
+    def _drain_inventory_buf(self, skip_lock: bool = False) -> None:
+        lock = (lambda: _NullCtx()) if skip_lock else (lambda: self._lock)
+        with lock():
+            if not self._inventory_buf:
+                return
+            rows = self._inventory_buf
+            self._inventory_buf = []
+            self._conn.executemany(
+                "INSERT INTO character_inventory "
+                "(cycle_no, tick, character_id, item, delta, total, real_ts) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?)",
+                rows,
+            )
+
+    def _sync_personality_drift(self, world: Any) -> None:
+        """Mirror ``world.legacy.personality_drift`` to disk.
+
+        Cheap UPSERT — drift dict is tiny (a few characters x a few traits).
+        """
+        try:
+            drift = getattr(world.legacy, "personality_drift", None) or {}
+            if not drift:
+                return
+            cur_no = int(getattr(world.legacy, "cycles_witnessed", 0))
+            rows: List[Tuple[Any, ...]] = []
+            for name, traits in drift.items():
+                if not isinstance(traits, dict):
+                    continue
+                for trait, delta in traits.items():
+                    rows.append((str(name), str(trait), float(delta), cur_no))
+            if not rows:
+                return
+            with self._lock:
+                self._conn.executemany(
+                    "INSERT INTO personality_drift "
+                    "(character_name, trait, delta, updated_at_cycle) "
+                    "VALUES (?, ?, ?, ?) "
+                    "ON CONFLICT(character_name, trait) DO UPDATE SET "
+                    "  delta = excluded.delta, "
+                    "  updated_at_cycle = excluded.updated_at_cycle",
+                    rows,
+                )
+        except Exception:
+            self._log_exc(world, "_sync_personality_drift")
+
+    def _sync_breach_marks(self, world: Any) -> None:
+        """Mirror this cycle's breach-mark counters to disk."""
+        try:
+            marks = getattr(world.legacy, "building_breach_marks", None) or {}
+            if not marks:
+                return
+            cur_no = int(getattr(world.legacy, "cycles_witnessed", 0))
+            rows = [(cur_no, str(bid), int(cnt)) for bid, cnt in marks.items()]
+            with self._lock:
+                self._conn.executemany(
+                    "INSERT INTO building_breach_marks (cycle_no, building_id, count) "
+                    "VALUES (?, ?, ?) "
+                    "ON CONFLICT(cycle_no, building_id) DO UPDATE SET "
+                    "  count = excluded.count",
+                    rows,
+                )
+        except Exception:
+            self._log_exc(world, "_sync_breach_marks")
+
+    def _update_gauges(self, world: Any) -> None:
+        tele = getattr(world, "telemetry", None)
+        if tele is None:
+            return
+        try:
+            from contracts import Metric
+            with self._lock:
+                row = self._conn.execute(
+                    "SELECT COUNT(*) AS n FROM character_memory"
+                ).fetchone()
+                mem_rows = int(row["n"]) if row else 0
+                alive = self._conn.execute(
+                    "SELECT COUNT(*) AS n FROM sub_main_characters "
+                    "WHERE died_at_cycle IS NULL"
+                ).fetchone()
+                dead = self._conn.execute(
+                    "SELECT COUNT(*) AS n FROM sub_main_characters "
+                    "WHERE died_at_cycle IS NOT NULL"
+                ).fetchone()
+            tele.gauge_set(Metric.MEMORY_ROWS, float(mem_rows))
+            tele.gauge_set(Metric.SUB_MAINS_ALIVE, float(alive["n"] if alive else 0))
+            tele.gauge_set(Metric.SUB_MAINS_DEAD_TOTAL, float(dead["n"] if dead else 0))
+            # Total inventory items currently held — read off the live agents,
+            # not the DB (the DB is a churn log, not a current-state mirror).
+            total_items = 0
+            for a in getattr(world, "agents", {}).values():
+                inv = getattr(a, "inventory", None)
+                if isinstance(inv, dict):
+                    for v in inv.values():
+                        try:
+                            total_items += int(v)
+                        except (TypeError, ValueError):
+                            continue
+            tele.gauge_set(Metric.INVENTORY_ITEMS, float(total_items))
+        except Exception:
+            self._log_exc(world, "_update_gauges")
+
+    # ----------------------------------------------------------------- util
+    def _current_cycle_no(self, world: Any) -> int:
+        """The cycle the village is currently living through.
+
+        Matches ``world.cycle_number`` (== ``cycles_witnessed + 1``) so the
+        cycles table row aligns with ``JournalFragment.cycle_recorded`` and
+        the UI's ``cycle`` badge. We do NOT use raw ``cycles_witnessed``
+        because that counts the *closed* cycles only.
+        """
+        legacy = getattr(world, "legacy", None)
+        return int(getattr(legacy, "cycles_witnessed", 0)) + 1
+
+    # ----------------------------------------------------------------- close
+    def close(self) -> None:
+        """Final flush + close. Best-effort: never raises."""
+        try:
+            with self._lock:
+                # Flush any pending rows so a graceful shutdown doesn't lose data.
+                # We don't have a world here, but the buffers don't need it.
+                self._conn.execute("BEGIN")
+                try:
+                    if self._memory_buf:
+                        self._conn.executemany(
+                            "INSERT INTO character_memory "
+                            "(cycle_no, tick, character_id, kind, subject, "
+                            " detail, payload, real_ts) "
+                            "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                            self._memory_buf,
+                        )
+                        self._memory_buf.clear()
+                    if self._inventory_buf:
+                        self._conn.executemany(
+                            "INSERT INTO character_inventory "
+                            "(cycle_no, tick, character_id, item, delta, total, real_ts) "
+                            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+                            self._inventory_buf,
+                        )
+                        self._inventory_buf.clear()
+                    self._conn.execute("COMMIT")
+                except Exception:
+                    try:
+                        self._conn.execute("ROLLBACK")
+                    except Exception:
+                        pass
+                try:
+                    self._conn.close()
+                except Exception:
+                    pass
+        except Exception:
+            pass
+
+
+class _NullCtx:
+    """No-op context manager used when a helper is already running inside the lock."""
+
+    def __enter__(self) -> "_NullCtx":
+        return self
+
+    def __exit__(self, *exc: Any) -> None:
+        return None

--- a/from-simulation/app/telemetry.py
+++ b/from-simulation/app/telemetry.py
@@ -58,6 +58,11 @@ _V2_GAUGE_NAMES = (
     Metric.OUTSIDERS_ACTIVE,
     Metric.YELLOW_TENDRILS,
     Metric.TRUST_AVG,
+    # v4 gauges
+    Metric.MUSIC_BOX_ACTIVE,
+    Metric.MUSIC_BOX_PHASE,
+    Metric.HOUSES_COOLING_OFF,
+    Metric.WORMS_INFECTED,
 )
 
 

--- a/from-simulation/app/telemetry.py
+++ b/from-simulation/app/telemetry.py
@@ -43,7 +43,22 @@ from opentelemetry.sdk.metrics.view import View
 import pyroscope
 from pyroscope.otel import PyroscopeSpanProcessor
 
-from contracts import Config, SimTelemetry as SimTelemetryProtocol
+from contracts import Config, Metric, SimTelemetry as SimTelemetryProtocol
+
+
+# v2 — gauges we know exist from the engine and want present at startup, even
+# before the first tick fires (so dashboards don't show "no data" on a fresh
+# process). Counters auto-register on first inc; observable gauges only show
+# up once ``_ensure_gauge`` has been called for them at least once.
+_V2_GAUGE_NAMES = (
+    Metric.DREAMS_ACTIVE,
+    Metric.LIGHTHOUSE_VOICE_ACTIVE,
+    Metric.LEGACY_JOURNAL_FRAGMENTS,
+    Metric.LEGACY_CYCLES_WITNESSED,
+    Metric.OUTSIDERS_ACTIVE,
+    Metric.YELLOW_TENDRILS,
+    Metric.TRUST_AVG,
+)
 
 
 def _http_to_grpc(http_endpoint: str) -> str:
@@ -80,6 +95,9 @@ class SimTelemetry(SimTelemetryProtocol):
         self._setup_tracing()
         self._setup_metrics()
         self._setup_profiling()
+        # Pre-register v2 gauges so they appear in /v1/metrics from tick 0.
+        for _name in _V2_GAUGE_NAMES:
+            self._ensure_gauge(_name)
 
     # ------------------------------------------------------------------ logs
     def _setup_logging(self, level_name: str) -> None:

--- a/from-simulation/app/telemetry.py
+++ b/from-simulation/app/telemetry.py
@@ -1,0 +1,210 @@
+"""
+OpenTelemetry + Pyroscope wiring for the From simulation.
+
+Concrete implementation of the ``SimTelemetry`` interface declared in
+``contracts.py``. Subagents B/C/D call ``world.telemetry.get_logger()`` /
+``get_tracer()`` / ``gauge_set()`` / ``counter_inc()`` — they never import the
+OTel SDK directly.
+
+Transport:
+  * Logs   — OTLP HTTP at ``${otlp_endpoint}/v1/logs``
+  * Traces — OTLP gRPC. The HTTP endpoint in config (default ``http://alloy:4318``)
+             is rewritten to the gRPC counterpart on port 4317.
+  * Metrics — OTLP HTTP at ``${otlp_endpoint}/v1/metrics``
+  * Profiles — Pyroscope v2 push via ``pyroscope.configure``; the OTel span
+               processor stitches profile samples to active spans so Tempo /
+               Pyroscope can cross-link.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from typing import Dict, Optional
+from urllib.parse import urlparse
+
+from opentelemetry import trace
+from opentelemetry.sdk.resources import SERVICE_NAME, Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+
+from opentelemetry._logs import set_logger_provider
+from opentelemetry.exporter.otlp.proto.http._log_exporter import OTLPLogExporter
+from opentelemetry.sdk._logs import LoggerProvider, LoggingHandler
+from opentelemetry.sdk._logs.export import BatchLogRecordProcessor
+
+from opentelemetry import metrics
+from opentelemetry.exporter.otlp.proto.http.metric_exporter import OTLPMetricExporter
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
+from opentelemetry.sdk.metrics.view import View
+
+import pyroscope
+from pyroscope.otel import PyroscopeSpanProcessor
+
+from contracts import Config, SimTelemetry as SimTelemetryProtocol
+
+
+def _http_to_grpc(http_endpoint: str) -> str:
+    """Translate an OTLP HTTP endpoint (port 4318) to the gRPC counterpart (4317).
+
+    ``http://alloy:4318`` -> ``http://alloy:4317``. If the user already provided
+    a non-4318 endpoint we honour it as-is.
+    """
+    parsed = urlparse(http_endpoint)
+    host = parsed.hostname or "alloy"
+    port = parsed.port
+    scheme = parsed.scheme or "http"
+    if port == 4318 or port is None:
+        return f"{scheme}://{host}:4317"
+    return http_endpoint
+
+
+class SimTelemetry(SimTelemetryProtocol):
+    """Concrete telemetry impl. Construct once at app start, attach to world."""
+
+    def __init__(self, config: Config) -> None:
+        self.service_name = config.service_name
+        self.otlp_http = config.otlp_endpoint.rstrip("/")
+        self.otlp_grpc = _http_to_grpc(self.otlp_http)
+        self.pyroscope_endpoint = config.pyroscope_endpoint
+        self.resource = Resource.create({SERVICE_NAME: self.service_name})
+
+        # Latest-value cache for the observable-gauge callback.
+        # Keyed by (metric_name, frozenset(attrs.items())) -> value.
+        self._gauge_lock = threading.Lock()
+        self._gauge_values: Dict[tuple, float] = {}
+
+        self._setup_logging(config.log_level)
+        self._setup_tracing()
+        self._setup_metrics()
+        self._setup_profiling()
+
+    # ------------------------------------------------------------------ logs
+    def _setup_logging(self, level_name: str) -> None:
+        self.logger_provider = LoggerProvider(resource=self.resource)
+        set_logger_provider(self.logger_provider)
+
+        log_exporter = OTLPLogExporter(endpoint=f"{self.otlp_http}/v1/logs")
+        self.logger_provider.add_log_record_processor(
+            BatchLogRecordProcessor(
+                exporter=log_exporter,
+                max_queue_size=200,
+                max_export_batch_size=20,
+            )
+        )
+
+        level = getattr(logging, (level_name or "INFO").upper(), logging.INFO)
+        handler = LoggingHandler(level=logging.NOTSET, logger_provider=self.logger_provider)
+        root = logging.getLogger()
+        # Avoid duplicating handlers if instantiated twice (test reuse).
+        if not any(isinstance(h, LoggingHandler) for h in root.handlers):
+            root.addHandler(handler)
+        root.setLevel(level)
+        self.logger = logging.getLogger(self.service_name)
+
+    # ---------------------------------------------------------------- traces
+    def _setup_tracing(self) -> None:
+        provider = TracerProvider(resource=self.resource)
+        trace.set_tracer_provider(provider)
+        span_exporter = OTLPSpanExporter(endpoint=f"{self.otlp_grpc}/v1/traces", insecure=True)
+        provider.add_span_processor(
+            BatchSpanProcessor(span_exporter=span_exporter, max_export_batch_size=8)
+        )
+        self.tracer = trace.get_tracer(self.service_name)
+
+    # --------------------------------------------------------------- metrics
+    def _setup_metrics(self) -> None:
+        metric_exporter = OTLPMetricExporter(endpoint=f"{self.otlp_http}/v1/metrics")
+        reader = PeriodicExportingMetricReader(metric_exporter, export_interval_millis=5000)
+        provider = MeterProvider(resource=self.resource, metric_readers=[reader], views=[View(instrument_name="*")])
+        metrics.set_meter_provider(provider)
+        self._meter_provider = provider
+        self.meter = metrics.get_meter(self.service_name)
+
+        # Counters are created lazily on first use; we keep a registry to avoid
+        # rebuilding instruments per call.
+        self._counters: Dict[str, "metrics.Counter"] = {}
+        self._gauges: Dict[str, "metrics.ObservableGauge"] = {}
+
+    def _gauge_callback_factory(self, name: str):
+        """Build a callback that snapshots all (name, attrs) -> value pairs."""
+        def _cb(_options):
+            out = []
+            with self._gauge_lock:
+                for (m_name, attr_items), value in self._gauge_values.items():
+                    if m_name != name:
+                        continue
+                    out.append(metrics.Observation(value, dict(attr_items)))
+            return out
+        return _cb
+
+    def _ensure_gauge(self, name: str) -> None:
+        if name in self._gauges:
+            return
+        self._gauges[name] = self.meter.create_observable_gauge(
+            name=name,
+            callbacks=[self._gauge_callback_factory(name)],
+        )
+
+    def _ensure_counter(self, name: str) -> "metrics.Counter":
+        c = self._counters.get(name)
+        if c is None:
+            c = self.meter.create_counter(name)
+            self._counters[name] = c
+        return c
+
+    # -------------------------------------------------------------- profiles
+    def _setup_profiling(self) -> None:
+        try:
+            pyroscope.configure(
+                application_name=self.service_name,
+                server_address=self.pyroscope_endpoint,
+                tags={"service_name": self.service_name},
+                oncpu=True,
+                gil_only=True,
+            )
+            trace.get_tracer_provider().add_span_processor(PyroscopeSpanProcessor())
+        except Exception:
+            # Profiling is best-effort — missing/locked agent should not break sim.
+            self.logger.warning("pyroscope configuration failed; continuing without profiles", exc_info=True)
+
+    # ----------------------------------------------------- public interface
+    def get_logger(self):
+        return self.logger
+
+    def get_tracer(self):
+        return self.tracer
+
+    def gauge_set(self, name: str, value: float, attrs: Optional[Dict[str, str]] = None) -> None:
+        """Record the latest value for an observable gauge.
+
+        Observable gauges poll their callback at export time, so we just stash
+        the latest value in a dict. Attributes are folded into the key so the
+        same metric with different attrs (e.g. ``role=SHERIFF`` vs
+        ``role=PRIEST``) coexist.
+        """
+        self._ensure_gauge(name)
+        items = tuple(sorted((attrs or {}).items()))
+        key = (name, items)
+        with self._gauge_lock:
+            self._gauge_values[key] = float(value)
+
+    def counter_inc(self, name: str, value: float = 1.0, attrs: Optional[Dict[str, str]] = None) -> None:
+        try:
+            self._ensure_counter(name).add(value, attributes=attrs or {})
+        except Exception:
+            # Never let telemetry tip over the simulation thread.
+            pass
+
+    def shutdown(self) -> None:
+        for fn in (
+            lambda: trace.get_tracer_provider().shutdown(),
+            lambda: self.logger_provider.shutdown(),
+            lambda: self._meter_provider.shutdown(),
+        ):
+            try:
+                fn()
+            except Exception:
+                pass

--- a/from-simulation/app/templates/_map_svg.html
+++ b/from-simulation/app/templates/_map_svg.html
@@ -248,6 +248,21 @@
         <path d="M 16 65 Q 30 58 44 65 L 46 76 L 14 76 Z" fill="#e8e0d0" stroke="#7a8090" stroke-width="0.9"/>
       </g>
     </symbol>
+
+    <!-- v6: battered arrival hatchback. 40x20 viewBox so map.js can use the
+         token with width=40 height=20 at the agent's (x, y). Rust browns and
+         dark grey to match the dark-Americana palette. -->
+    <symbol id="token-car" viewBox="0 0 40 20">
+      <rect x="2" y="6" width="36" height="9" rx="2" fill="#7d5a3a" stroke="#1a1611" stroke-width="0.9"/>
+      <rect x="6" y="3" width="12" height="6" fill="#5a4630" stroke="#1a1611" stroke-width="0.7"/>
+      <rect x="22" y="3" width="12" height="6" fill="#5a4630" stroke="#1a1611" stroke-width="0.7"/>
+      <circle cx="10" cy="16" r="2.6" fill="#1a1611"/>
+      <circle cx="30" cy="16" r="2.6" fill="#1a1611"/>
+      <rect x="34" y="9" width="3" height="2" fill="#d8a83a"/>
+      <!-- rust patches -->
+      <circle cx="14" cy="11" r="1.2" fill="#3a2a18" opacity="0.5"/>
+      <circle cx="27" cy="12" r="1" fill="#3a2a18" opacity="0.4"/>
+    </symbol>
   </defs>
 
   <!-- LAYER 1: FOREST BASE -->
@@ -479,6 +494,7 @@
       <rect x="410" y="396" width="3" height="3" fill="#f6c869"/>
       <rect x="424" y="396" width="3" height="3" fill="#f6c869"/>
     </g>
+    <use href="#talisman" transform="translate(418 386) scale(0.42)"/>
 
     <!-- 3 SHED -->
     <g transform="translate(442 388)">
@@ -542,6 +558,7 @@
       <rect x="412" y="486" width="3" height="3" fill="#f6c869"/>
       <rect x="426" y="486" width="3" height="3" fill="#f6c869"/>
     </g>
+    <use href="#talisman" transform="translate(420 476) scale(0.42)"/>
 
     <!-- 9 BLUE HOUSE -->
     <g transform="translate(440 490) rotate(2)">
@@ -553,6 +570,7 @@
       <rect x="432" y="486" width="3" height="3" fill="#f6c869"/>
       <rect x="446" y="486" width="3" height="3" fill="#f6c869"/>
     </g>
+    <use href="#talisman" transform="translate(440 476) scale(0.42)"/>
 
     <!-- 10 POOL -->
     <g transform="translate(462 478)">
@@ -571,6 +589,7 @@
       <rect x="471" y="458" width="3" height="3" fill="#f6c869"/>
       <rect x="483" y="458" width="3" height="3" fill="#f6c869"/>
     </g>
+    <use href="#talisman" transform="translate(478 448) scale(0.42)"/>
 
     <!-- 12 BAR -->
     <g transform="translate(510 458) rotate(-2)">
@@ -658,6 +677,7 @@
       <rect x="373" y="548" width="3" height="3" fill="#f6c869"/>
       <rect x="386" y="548" width="3" height="3" fill="#f6c869"/>
     </g>
+    <use href="#talisman" transform="translate(382 538) scale(0.42)"/>
 
   </g>
 

--- a/from-simulation/app/templates/_map_svg.html
+++ b/from-simulation/app/templates/_map_svg.html
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<svg viewBox="0 0 1000 700" xmlns="http://www.w3.org/2000/svg" id="map">
+<svg viewBox="0 0 1000 700" xmlns="http://www.w3.org/2000/svg" id="map" preserveAspectRatio="xMidYMid meet">
   <defs>
     <filter id="wobble" x="-2%" y="-2%" width="104%" height="104%">
       <feTurbulence type="fractalNoise" baseFrequency="0.018" numOctaves="2" seed="3" />
@@ -15,7 +14,6 @@
       <feComposite in2="SourceGraphic" operator="in"/>
     </filter>
 
-    <!-- patterns -->
     <pattern id="meadow" patternUnits="userSpaceOnUse" width="26" height="26">
       <rect width="26" height="26" fill="#b3b285"/>
       <path d="M3 18 q1 -4 2 0 M9 22 q1 -3 2 0 M16 16 q1 -4 2 0 M21 21 q1 -3 2 0 M14 7 q1 -3 2 0"
@@ -65,7 +63,6 @@
       <stop offset="100%" stop-color="#fff6c8" stop-opacity="0"/>
     </linearGradient>
 
-    <!-- TREES -->
     <g id="tree">
       <circle cx="0" cy="0" r="10" fill="#2c3a25" />
       <circle cx="-2" cy="-2" r="7.5" fill="#3e4f33" />
@@ -82,7 +79,6 @@
       <polygon points="0,-2 4,4 -4,4" fill="#4a6240"/>
     </g>
 
-    <!-- FARAWAY/BOTTLE TREE -->
     <g id="faraway-tree">
       <circle cx="0" cy="0" r="18" fill="#1d2616"/>
       <circle cx="-3" cy="-3" r="14" fill="#2b3a22"/>
@@ -100,7 +96,6 @@
       <circle cx="16" cy="-1" r="1.2" fill="#d8a83a"/>
     </g>
 
-    <!-- TALISMAN -->
     <g id="talisman">
       <circle cx="0" cy="0" r="7" fill="#f0e6c8" stroke="#1a1611" stroke-width="0.7"/>
       <path d="M0 -5 L2 -1 L6 0 L2.5 2.5 L3.3 6.5 L0 4.2 L-3.3 6.5 L-2.5 2.5 L-6 0 L-2 -1 Z"
@@ -108,25 +103,21 @@
       <circle cx="0" cy="0" r="1.1" fill="#a83a2a"/>
     </g>
 
-    <!-- SPAWN MARKER -->
     <g id="spawn-mark">
       <path d="M 0 -7 L 6 5 L -6 5 Z" fill="#e8dec0" stroke="#1a1611" stroke-width="0.9"/>
       <path d="M -2.5 -2 L -3.5 2 M 0 -3 L 0 2 M 2.5 -2 L 3.5 2"
             stroke="#1a1611" stroke-width="0.9" stroke-linecap="round" fill="none"/>
     </g>
 
-    <!-- NUMBERED PIN -->
     <g id="num-pin">
       <circle r="7.5" fill="#a83a2a" stroke="#1a1611" stroke-width="0.8"/>
     </g>
-    <!-- LANDMARK PIN -->
     <g id="lm-pin">
       <circle r="3.5" fill="#a83a2a" stroke="#1a1611" stroke-width="0.6"/>
     </g>
 
     <!-- ====================================================== -->
     <!--   CHARACTER TOKEN SYMBOLS (60x80 viewBox each)         -->
-    <!--   Mounted via <use href="#token-{name}"> by map.js     -->
     <!-- ====================================================== -->
     <symbol id="token-boyd" viewBox="0 0 60 80">
       <ellipse cx="30" cy="76" rx="18" ry="2" fill="#1a1611" opacity="0.3"/>
@@ -259,16 +250,10 @@
     </symbol>
   </defs>
 
-  <!-- ========================================== -->
-  <!--   LAYER 1: FOREST BASE                     -->
-  <!-- ========================================== -->
+  <!-- LAYER 1: FOREST BASE -->
   <rect width="1000" height="700" fill="url(#forest-floor)"/>
 
-  <!-- ========================================== -->
-  <!--   LAYER 2: BIG MEADOW (most of the map)    -->
-  <!--   The township sits inside this clearing,  -->
-  <!--   surrounded by forest at the edges.       -->
-  <!-- ========================================== -->
+  <!-- LAYER 2: BIG MEADOW -->
   <g filter="url(#wobble)">
     <path d="M 60 220
              C 80 130, 220 70, 380 80
@@ -281,7 +266,6 @@
           fill="url(#meadow)" stroke="#7a7256" stroke-width="0.9"/>
   </g>
 
-  <!-- contour wisps (topo lines) — subtle paper texture -->
   <g stroke="#8c8662" stroke-width="0.6" fill="none" opacity="0.35" filter="url(#wobble-soft)">
     <path d="M 90 140 Q 180 100 280 130 T 460 160"/>
     <path d="M 60 200 Q 160 170 270 200 T 460 220"/>
@@ -291,9 +275,7 @@
     <path d="M 100 540 Q 180 580 270 580"/>
   </g>
 
-  <!-- ========================================== -->
-  <!--   LAYER 3: ROCK OUTCROPS                   -->
-  <!-- ========================================== -->
+  <!-- LAYER 3: ROCK OUTCROPS -->
   <g id="outcrops" filter="url(#wobble-soft)" opacity="0.85">
     <path d="M 70 90 q 50 -30 90 -10 q 30 30 -10 50 q -50 20 -80 -20 z" fill="url(#rock)" stroke="#a89b76" stroke-width="0.6"/>
     <path d="M 210 130 q 60 -20 80 10 q 10 30 -40 30 q -60 0 -40 -40 z" fill="url(#rock)" stroke="#a89b76" stroke-width="0.6"/>
@@ -309,34 +291,20 @@
     <path d="M 480 660 q 40 -10 60 10 q 0 20 -40 20 q -40 -10 -20 -30 z" fill="url(#rock)" stroke="#a89b76" stroke-width="0.6"/>
   </g>
 
-  <!-- ========================================== -->
-  <!--   LAYER 4: WATER                           -->
-  <!-- ========================================== -->
+  <!-- LAYER 4: WATER -->
   <g id="water-bodies" filter="url(#wobble-soft)">
-    <!-- LAKE upper-right -->
     <path d="M 700 200 q 50 -20 90 10 q 30 40 0 80 q -50 30 -90 -10 q -30 -40 0 -80 z"
           fill="url(#water)" stroke="#456d7c" stroke-width="1"/>
-    <!-- stream feeding lake -->
     <path d="M 660 30 q 20 60 50 100 q 20 40 -10 70" stroke="#7da9b8" stroke-width="3" fill="none" opacity="0.85"/>
-
-    <!-- BRUNDLES pond -->
     <ellipse cx="375" cy="335" rx="22" ry="14" fill="url(#water)" stroke="#456d7c" stroke-width="0.8"/>
-
-    <!-- small upper-left pond -->
     <ellipse cx="155" cy="220" rx="20" ry="12" fill="url(#water)" stroke="#456d7c" stroke-width="0.8"/>
   </g>
 
-  <!-- ========================================== -->
-  <!--   LAYER 5: FOREST CANOPY (perimeter)       -->
-  <!--   Populated by map.js mulberry32 scatter   -->
-  <!-- ========================================== -->
+  <!-- LAYER 5: FOREST CANOPY (populated by map.js) -->
   <g id="forest"></g>
 
-  <!-- ========================================== -->
-  <!--   LAYER 6: ROADS                           -->
-  <!-- ========================================== -->
+  <!-- LAYER 6: ROADS -->
   <g id="roads" filter="url(#wobble-soft)">
-    <!-- shoulder -->
     <path d="M -20 200
              C 80 240, 160 280, 240 320
              C 300 350, 360 380, 395 405
@@ -346,7 +314,6 @@
              C 580 595, 640 640, 720 690
              L 760 720"
           stroke="#2a2622" stroke-width="22" fill="none" stroke-linejoin="round" opacity="0.5"/>
-    <!-- asphalt -->
     <path d="M -20 200
              C 80 240, 160 280, 240 320
              C 300 350, 360 380, 395 405
@@ -356,7 +323,6 @@
              C 580 595, 640 640, 720 690
              L 760 720"
           stroke="url(#asphalt)" stroke-width="16" fill="none" stroke-linejoin="round"/>
-    <!-- center dashes -->
     <path d="M -20 200
              C 80 240, 160 280, 240 320
              C 300 350, 360 380, 395 405
@@ -367,39 +333,20 @@
              L 760 720"
           stroke="#e8dec0" stroke-width="0.8" stroke-dasharray="5 8" fill="none" opacity="0.55"/>
 
-    <!-- internal town streets (dirt lanes inside the cluster) -->
     <g opacity="0.95">
-      <!-- vertical Main Street through town -->
       <path d="M 450 410 L 450 555" stroke="#3a3024" stroke-width="13" fill="none" opacity="0.45" stroke-linecap="round"/>
       <path d="M 450 410 L 450 555" stroke="url(#dirt)" stroke-width="8" fill="none" stroke-linecap="round"/>
-      <!-- east-west cross lane -->
       <path d="M 380 485 L 555 485" stroke="#3a3024" stroke-width="11" fill="none" opacity="0.45" stroke-linecap="round"/>
       <path d="M 380 485 L 555 485" stroke="url(#dirt)" stroke-width="7" fill="none" stroke-linecap="round"/>
-      <!-- small lane to barn -->
       <path d="M 510 462 L 555 458" stroke="url(#dirt)" stroke-width="5" fill="none" stroke-linecap="round" opacity="0.85"/>
     </g>
   </g>
 
-  <!-- ========================================== -->
-  <!--   LAYER 7: NON-TOWN LANDMARKS              -->
-  <!-- ========================================== -->
+  <!-- LAYER 7: NON-TOWN LANDMARKS -->
+  <g transform="translate(560 55)"><use href="#faraway-tree"/></g>
+  <g transform="translate(735 485)"><use href="#faraway-tree"/></g>
+  <g transform="translate(575 660)"><use href="#faraway-tree" transform="scale(0.85)"/></g>
 
-  <!-- BOTTLE TREE (Boyd / Sara) -->
-  <g transform="translate(560 55)">
-    <use href="#faraway-tree"/>
-  </g>
-
-  <!-- FARWAY TREE (Victor / Ethan) -->
-  <g transform="translate(735 485)">
-    <use href="#faraway-tree"/>
-  </g>
-
-  <!-- FARWAY / BOTTLE TREE (bottom) -->
-  <g transform="translate(575 660)">
-    <use href="#faraway-tree" transform="scale(0.85)"/>
-  </g>
-
-  <!-- TALISMAN TOME (small monolith / open book on stone) -->
   <g transform="translate(465 195)" filter="url(#wobble-soft)">
     <rect x="-8" y="-3" width="16" height="10" fill="#6a5238" stroke="#1a1611" stroke-width="0.8"/>
     <rect x="-8" y="-8" width="16" height="6" fill="#e8dec0" stroke="#1a1611" stroke-width="0.6"/>
@@ -407,7 +354,6 @@
     <path d="M -6 -6 h 4 M -6 -4 h 4 M 2 -6 h 4 M 2 -4 h 4" stroke="#1a1611" stroke-width="0.3" opacity="0.6"/>
   </g>
 
-  <!-- LOG CABINS (small cluster of 3 cabins) -->
   <g transform="translate(620 230)" filter="url(#wobble-soft)">
     <g transform="translate(-12 -8)">
       <rect x="-9" y="-6" width="18" height="12" fill="#7a5a3a" stroke="#1a1611" stroke-width="0.7"/>
@@ -424,14 +370,12 @@
     </g>
   </g>
 
-  <!-- SHACK -->
   <g transform="translate(615 335)" filter="url(#wobble-soft)">
     <rect x="-10" y="-6" width="20" height="12" fill="#5a4632" stroke="#1a1611" stroke-width="0.8"/>
     <polygon points="-12,-6 12,-6 9,-13 -9,-13" fill="#2a1810" stroke="#1a1611" stroke-width="0.8"/>
     <rect x="-2" y="-2" width="4" height="8" fill="#2a1810"/>
   </g>
 
-  <!-- STONE CIRCLE -->
   <g transform="translate(260 510)" filter="url(#wobble-soft)">
     <ellipse cx="0" cy="0" rx="25" ry="14" fill="#9c9276" stroke="#7a7050" stroke-width="0.6" opacity="0.5"/>
     <g fill="#5a4f3a" stroke="#1a1611" stroke-width="0.6">
@@ -446,14 +390,12 @@
     </g>
   </g>
 
-  <!-- ABBY'S GRAVE -->
   <g transform="translate(345 580)" filter="url(#wobble-soft)">
     <rect x="-6" y="-4" width="12" height="6" fill="#9c9276" stroke="#1a1611" stroke-width="0.6"/>
     <rect x="-3" y="-10" width="6" height="6" fill="#cabd9a" stroke="#1a1611" stroke-width="0.6"/>
     <path d="M -1 -8 v 4 M -2 -7 h 2" stroke="#3a3024" stroke-width="0.5"/>
   </g>
 
-  <!-- VICTOR'S HIDEOUT TRUCK -->
   <g transform="translate(275 610) rotate(-10)" filter="url(#wobble-soft)">
     <rect x="-13" y="-4" width="20" height="9" fill="#5a6a52" stroke="#1a1611" stroke-width="0.8"/>
     <rect x="7" y="-7" width="8" height="12" fill="#445040" stroke="#1a1611" stroke-width="0.8"/>
@@ -463,7 +405,6 @@
     <circle cx="12" cy="6" r="2.5" fill="#1a1611"/>
   </g>
 
-  <!-- CAR GRAVEYARD -->
   <g transform="translate(470 615)" filter="url(#wobble-soft)">
     <g transform="translate(-12 4) rotate(15)"><rect x="-10" y="-4" width="20" height="8" rx="2" fill="#6a3a2a" stroke="#1a1611" stroke-width="0.7"/></g>
     <g transform="translate(8 2) rotate(-20)"><rect x="-9" y="-3" width="18" height="6" rx="2" fill="#4a4036" stroke="#1a1611" stroke-width="0.7"/></g>
@@ -471,30 +412,26 @@
     <g transform="translate(-2 12) rotate(-5)"><rect x="-9" y="-3" width="18" height="6" rx="2" fill="#3a4036" stroke="#1a1611" stroke-width="0.7"/></g>
   </g>
 
-  <!-- DUNGEON (cave mouth) -->
   <g transform="translate(240 650)" filter="url(#wobble-soft)">
     <ellipse cx="0" cy="0" rx="14" ry="9" fill="#cdc4a3" stroke="#7a7050" stroke-width="0.6"/>
     <path d="M -10 4 q 0 -14 10 -14 q 10 0 10 14 z" fill="#0e0a08" stroke="#1a1611" stroke-width="0.8"/>
     <path d="M -7 0 L -4 -6 M 0 -10 L 0 -4 M 6 -8 L 4 -2" stroke="#3a3024" stroke-width="0.4" opacity="0.8"/>
   </g>
 
-  <!-- CAVE ENTRY -->
   <g transform="translate(390 670)" filter="url(#wobble-soft)">
     <ellipse cx="0" cy="2" rx="12" ry="7" fill="#cdc4a3" stroke="#7a7050" stroke-width="0.6"/>
     <path d="M -8 4 q 0 -12 8 -12 q 8 0 8 12 z" fill="#0e0a08" stroke="#1a1611" stroke-width="0.7"/>
   </g>
 
-  <!-- CRASH SITE -->
   <g transform="translate(720 670) rotate(35)" filter="url(#wobble-soft)">
     <rect x="-12" y="-6" width="24" height="12" rx="2" fill="#6a3a2a" stroke="#1a1611" stroke-width="0.8"/>
     <rect x="-8" y="-4" width="6" height="6" fill="#2a2d2a"/>
     <rect x="2" y="-4" width="6" height="6" fill="#2a2d2a"/>
     <path d="M -16 -2 L -12 -6 M 14 -2 L 18 -6 M 0 -10 L 0 -6" stroke="#a83a2a" stroke-width="0.6"/>
-    <!-- smoke -->
     <path d="M -2 -8 q -3 -8 2 -14 q 5 -4 0 -10" stroke="#5a5650" stroke-width="0.8" fill="none" opacity="0.5"/>
   </g>
 
-  <!-- LIGHTHOUSE (140, 585) — lower-left, separate from town -->
+  <!-- LIGHTHOUSE (140, 585) -->
   <g filter="url(#wobble-soft)">
     <ellipse cx="140" cy="585" rx="38" ry="26" fill="url(#meadow)" stroke="#7a7256" stroke-width="0.8"/>
   </g>
@@ -506,17 +443,14 @@
     <circle cx="0" cy="0" r="6" fill="#f6c869" stroke="#1a1611" stroke-width="0.9"/>
     <circle cx="0" cy="0" r="2.5" fill="#fff6c8"/>
   </g>
-  <!-- lighthouse rotating beam -->
   <g class="lighthouse-beam">
     <polygon points="140,585 105,310 175,310" fill="url(#beamGrad)" opacity="0.55"/>
   </g>
 
-  <!-- ========================================== -->
-  <!--   LAYER 8: TOWN BUILDINGS (numbered 1–18) -->
-  <!-- ========================================== -->
+  <!-- LAYER 8: TOWN BUILDINGS -->
   <g id="town" filter="url(#wobble-soft)">
 
-    <!-- 1 COLONY HOUSE (385, 420) — NW corner, Victorian, 3-story -->
+    <!-- 1 COLONY HOUSE -->
     <g transform="translate(385 420)">
       <rect x="-22" y="-15" width="44" height="30" fill="#7c5a3e" stroke="#1a1611" stroke-width="1.2"/>
       <polygon points="-25,-15 25,-15 19,-25 -19,-25" fill="#3a261a" stroke="#1a1611" stroke-width="1.2"/>
@@ -535,7 +469,7 @@
     </g>
     <use href="#talisman" transform="translate(385 388) scale(0.55)"/>
 
-    <!-- 2 GREEN HOUSE (418, 400) — small green-roof house -->
+    <!-- 2 GREEN HOUSE -->
     <g transform="translate(418 400) rotate(-3)">
       <rect x="-10" y="-7" width="20" height="14" fill="#a8b07a" stroke="#1a1611" stroke-width="0.9"/>
       <polygon points="-12,-7 12,-7 8,-13 -8,-13" fill="#4a5e34" stroke="#1a1611" stroke-width="0.9"/>
@@ -546,13 +480,13 @@
       <rect x="424" y="396" width="3" height="3" fill="#f6c869"/>
     </g>
 
-    <!-- 3 SHED (442, 388) — tiny shed -->
+    <!-- 3 SHED -->
     <g transform="translate(442 388)">
       <rect x="-6" y="-5" width="12" height="10" fill="#5a4632" stroke="#1a1611" stroke-width="0.8"/>
       <polygon points="-7,-5 7,-5 5,-9 -5,-9" fill="#2a1810" stroke="#1a1611" stroke-width="0.8"/>
     </g>
 
-    <!-- 4 CLINIC (478, 402) -->
+    <!-- 4 CLINIC -->
     <g transform="translate(478 402) rotate(2)">
       <rect x="-13" y="-9" width="26" height="18" fill="#c9bca0" stroke="#1a1611" stroke-width="1"/>
       <polygon points="-15,-9 15,-9 12,-15 -12,-15" fill="#5d4a3a" stroke="#1a1611" stroke-width="1"/>
@@ -565,21 +499,21 @@
     </g>
     <use href="#talisman" transform="translate(478 376) scale(0.5)"/>
 
-    <!-- 5 ROOT CELLAR (495, 432) — partly-underground -->
+    <!-- 5 ROOT CELLAR -->
     <g transform="translate(495 432)">
       <ellipse cx="0" cy="2" rx="10" ry="6" fill="#7a5a3a" stroke="#1a1611" stroke-width="0.9"/>
       <ellipse cx="0" cy="2" rx="6" ry="3" fill="#2a1810"/>
       <path d="M -2 1 v -3 M 2 1 v -3" stroke="#3a2418" stroke-width="0.6"/>
     </g>
 
-    <!-- 6 CHOOSING CEREMONY STONE (390, 470) -->
+    <!-- 6 CHOOSING CEREMONY STONE -->
     <g transform="translate(390 470)">
       <ellipse cx="0" cy="5" rx="7" ry="2" fill="#3a3024" opacity="0.5"/>
       <polygon points="-3,4 -4,-5 -1,-9 3,-7 4,4" fill="#6a5f48" stroke="#1a1611" stroke-width="0.7"/>
       <path d="M -2 -4 q 2 -2 4 0" stroke="#3a3024" stroke-width="0.4" fill="none"/>
     </g>
 
-    <!-- 7 CHURCH (385, 510) -->
+    <!-- 7 CHURCH -->
     <g transform="translate(385 510)">
       <rect x="-18" y="-10" width="36" height="20" fill="#9a8e72" stroke="#1a1611" stroke-width="1"/>
       <polygon points="-21,-10 21,-10 16,-18 -16,-18" fill="#3a3024" stroke="#1a1611" stroke-width="1"/>
@@ -598,7 +532,7 @@
     </g>
     <use href="#talisman" transform="translate(385 476) scale(0.5)"/>
 
-    <!-- 8 GREY HOUSE (420, 490) -->
+    <!-- 8 GREY HOUSE -->
     <g transform="translate(420 490) rotate(-2)">
       <rect x="-10" y="-7" width="20" height="14" fill="#7a7468" stroke="#1a1611" stroke-width="0.9"/>
       <polygon points="-12,-7 12,-7 8,-13 -8,-13" fill="#3a3a32" stroke="#1a1611" stroke-width="0.9"/>
@@ -609,7 +543,7 @@
       <rect x="426" y="486" width="3" height="3" fill="#f6c869"/>
     </g>
 
-    <!-- 9 BLUE HOUSE (440, 490) -->
+    <!-- 9 BLUE HOUSE -->
     <g transform="translate(440 490) rotate(2)">
       <rect x="-10" y="-7" width="20" height="14" fill="#6a7e92" stroke="#1a1611" stroke-width="0.9"/>
       <polygon points="-12,-7 12,-7 8,-13 -8,-13" fill="#3a4250" stroke="#1a1611" stroke-width="0.9"/>
@@ -620,14 +554,14 @@
       <rect x="446" y="486" width="3" height="3" fill="#f6c869"/>
     </g>
 
-    <!-- 10 POOL (462, 478) -->
+    <!-- 10 POOL -->
     <g transform="translate(462 478)">
       <rect x="-10" y="-6" width="20" height="12" rx="1" fill="#cabd9a" stroke="#1a1611" stroke-width="0.9"/>
       <rect x="-7" y="-4" width="14" height="8" rx="1" fill="url(#pooltile)" stroke="#1a1611" stroke-width="0.7"/>
       <path d="M -5 -2 L 1 0 L 4 2 M -2 3 L 1 1" stroke="#3a3024" stroke-width="0.4" fill="none" opacity="0.8"/>
     </g>
 
-    <!-- 11 LIUS' HOME (478, 462) -->
+    <!-- 11 LIUS' HOME -->
     <g transform="translate(478 462)">
       <rect x="-9" y="-7" width="18" height="14" fill="#8a6a48" stroke="#1a1611" stroke-width="0.9"/>
       <polygon points="-11,-7 11,-7 8,-13 -8,-13" fill="#4a3024" stroke="#1a1611" stroke-width="0.9"/>
@@ -638,7 +572,7 @@
       <rect x="483" y="458" width="3" height="3" fill="#f6c869"/>
     </g>
 
-    <!-- 12 BAR (510, 458) — former gas station -->
+    <!-- 12 BAR -->
     <g transform="translate(510 458) rotate(-2)">
       <rect x="-12" y="-9" width="24" height="4" fill="#3a2820" stroke="#1a1611" stroke-width="0.8"/>
       <rect x="-7" y="-5" width="2" height="3" fill="#a83a2a"/>
@@ -652,7 +586,7 @@
       <rect x="514" y="460" width="3" height="2" fill="#f6c869"/>
     </g>
 
-    <!-- 13 BARN (555, 454) -->
+    <!-- 13 BARN -->
     <g transform="translate(555 454) rotate(3)">
       <rect x="-15" y="-10" width="30" height="20" fill="#a83a2a" stroke="#1a1611" stroke-width="1"/>
       <polygon points="-17,-10 17,-10 13,-18 -13,-18" fill="#2a1810" stroke="#1a1611" stroke-width="1"/>
@@ -661,7 +595,7 @@
       <circle cx="0" cy="-13" r="1.5" fill="#d8a83a" stroke="#1a1611" stroke-width="0.3"/>
     </g>
 
-    <!-- 14 SHERIFF'S OFFICE (490, 510) -->
+    <!-- 14 SHERIFF'S OFFICE -->
     <g transform="translate(490 510)">
       <rect x="-13" y="-9" width="26" height="18" fill="#7a5c3e" stroke="#1a1611" stroke-width="1"/>
       <polygon points="-15,-9 15,-9 12,-16 -12,-16" fill="#3a2820" stroke="#1a1611" stroke-width="1"/>
@@ -676,7 +610,7 @@
     </g>
     <use href="#talisman" transform="translate(490 484) scale(0.5)"/>
 
-    <!-- 15 BUS (460, 538) -->
+    <!-- 15 BUS -->
     <g transform="translate(460 538) rotate(-5)">
       <rect x="-18" y="-5" width="36" height="9" rx="1.5" fill="#d8a83a" stroke="#1a1611" stroke-width="0.9"/>
       <rect x="-15" y="-3" width="4" height="3" fill="#2a3038"/>
@@ -689,7 +623,7 @@
       <circle cx="12" cy="5" r="2" fill="#1a1611"/>
     </g>
 
-    <!-- 16 MATTHEWS' HOME (collapsed) (430, 545) -->
+    <!-- 16 MATTHEWS' HOME -->
     <g transform="translate(430 545) rotate(4)">
       <rect x="-11" y="-7" width="22" height="14" fill="#7a5640" stroke="#1a1611" stroke-width="0.9"/>
       <polygon points="-13,-7 -2,-7 -4,-12 -10,-13 -13,-7" fill="#3a2820" stroke="#1a1611" stroke-width="0.9"/>
@@ -701,7 +635,7 @@
     </g>
     <use href="#talisman" transform="translate(430 526) scale(0.5)"/>
 
-    <!-- 17 DINER (405, 530) -->
+    <!-- 17 DINER -->
     <g transform="translate(405 530) rotate(-2)">
       <rect x="-12" y="-6" width="24" height="12" fill="#b07a3a" stroke="#1a1611" stroke-width="0.9"/>
       <path d="M -12 -6 Q 0 -12 12 -6" fill="#cdc6b4" stroke="#1a1611" stroke-width="0.9"/>
@@ -714,7 +648,7 @@
       <rect x="394" y="528" width="20" height="2" fill="#f6c869"/>
     </g>
 
-    <!-- 18 MYERS' HOME (382, 552) -->
+    <!-- 18 MYERS' HOME -->
     <g transform="translate(382 552) rotate(3)">
       <rect x="-10" y="-7" width="20" height="14" fill="#8a6a48" stroke="#1a1611" stroke-width="0.9"/>
       <polygon points="-12,-7 12,-7 8,-13 -8,-13" fill="#4a3024" stroke="#1a1611" stroke-width="0.9"/>
@@ -727,9 +661,10 @@
 
   </g>
 
-  <!-- ========================================== -->
-  <!--   LAYER 9: COMPASS + CARTOUCHE             -->
-  <!-- ========================================== -->
+  <!-- LAYER 9: OVERLAYS (hash marks, bus, rings, tendrils, halo, dream dialogs) -->
+  <g id="overlays"></g>
+
+  <!-- LAYER 10: COMPASS + CARTOUCHE -->
   <g id="compass" transform="translate(60 60)">
     <circle r="26" fill="#e3d8b4" stroke="#1a1611" stroke-width="1.1" opacity="0.92"/>
     <polygon points="0,-20 4,0 0,20 -4,0" fill="#1a1611"/>
@@ -746,9 +681,7 @@
     <text x="0" y="9" text-anchor="middle" font-size="8.5" font-family="Georgia, serif" fill="#5a4632" letter-spacing="2">— the town &amp; its surroundings —</text>
   </g>
 
-  <!-- ========================================== -->
-  <!--   LAYER 10: ENTITIES (populated by map.js) -->
-  <!-- ========================================== -->
+  <!-- LAYER 11: ENTITIES (populated by map.js) -->
   <g id="entities"></g>
 
   <!-- grain overlay (always last) -->

--- a/from-simulation/app/templates/index.html
+++ b/from-simulation/app/templates/index.html
@@ -34,6 +34,31 @@
   <div class="hud-cell yellow">
     <span id="hud-yellow" class="hud-chip yellow-dormant hidden">DORMANT</span>
   </div>
+  <!-- v9: minds heatmap — Director pressure + goal-mix at a glance. -->
+  <div class="hud-cell minds" id="hud-minds-cell">
+    <span class="hud-label">Minds</span>
+    <div class="minds-row">
+      <div class="minds-pressure" title="Director pressure (0 = quiet, 1 = breaking)">
+        <div class="bar"><div id="hud-pressure-fill" class="bar-fill pressure"></div></div>
+        <span id="hud-pressure-text" class="bar-text">0.00</span>
+      </div>
+      <div class="minds-goals" id="hud-goals">
+        <span class="goal-pip goal-protect" title="PROTECT">P<span data-kind="protect">0</span></span>
+        <span class="goal-pip goal-investigate" title="INVESTIGATE">I<span data-kind="investigate">0</span></span>
+        <span class="goal-pip goal-revenge" title="REVENGE">R<span data-kind="revenge">0</span></span>
+        <span class="goal-pip goal-flee" title="FLEE">F<span data-kind="flee">0</span></span>
+        <span class="goal-pip goal-find_item" title="FIND ITEM">$<span data-kind="find_item">0</span></span>
+      </div>
+      <div class="minds-popstress" title="Population-stress: how much the Director is escalating because the town is thriving (0..0.4)">
+        <span class="minds-label">PS</span>
+        <span id="hud-pop-stress">0.00</span>
+      </div>
+      <div class="minds-beliefs" title="active beliefs across all minds">
+        <span class="minds-label">Beliefs</span>
+        <span id="hud-beliefs-count">0</span>
+      </div>
+    </div>
+  </div>
 </div>
 {% endblock %}
 
@@ -44,6 +69,9 @@
     {% include "_map_svg.html" %}
   </div>
 </section>
+
+<!-- v6: floating dossier overlay populated by inspector.js on inspect_reply. -->
+<aside class="dossier hidden" id="dossier"></aside>
 
 <aside class="side-pane">
   <details class="panel" open>
@@ -79,6 +107,8 @@
       <dt>NPCs</dt><dd id="stat-npcs">0</dd>
       <dt>Creatures</dt><dd id="stat-creatures">0</dd>
       <dt>Yellow Man</dt><dd id="stat-yellow">DORMANT</dd>
+      <dt>Cave clues</dt><dd id="stat-cave-clues">0</dd>
+      <dt>Barn</dt><dd id="stat-barn">intact</dd>
     </dl>
   </details>
 
@@ -192,5 +222,6 @@
 </script>
 <script src="{{ url_for('static', filename='js/lighting.js') }}"></script>
 <script src="{{ url_for('static', filename='js/map.js') }}"></script>
+<script src="{{ url_for('static', filename='js/inspector.js') }}"></script>
 <script src="{{ url_for('static', filename='js/socket.js') }}"></script>
 {% endblock %}

--- a/from-simulation/app/templates/index.html
+++ b/from-simulation/app/templates/index.html
@@ -1,0 +1,110 @@
+{% extends "layout.html" %}
+
+{% block title %}Fromville — Live{% endblock %}
+
+{% block hud %}
+<div class="hud">
+  <div class="hud-cell clock">
+    <span class="hud-label">Clock</span>
+    <span id="hud-clock" class="hud-value">D0 06:00 DAY</span>
+  </div>
+  <div class="hud-cell phase">
+    <span class="hud-label">Phase</span>
+    <span id="hud-phase" class="hud-chip phase-day">DAY</span>
+  </div>
+  <div class="hud-cell cycle">
+    <span class="hud-label">Cycle</span>
+    <span id="hud-cycle" class="hud-badge">1</span>
+  </div>
+  <div class="hud-cell food">
+    <span class="hud-label">Food</span>
+    <div class="bar"><div id="hud-food-fill" class="bar-fill"></div></div>
+    <span id="hud-food-text" class="bar-text">100 / 200</span>
+  </div>
+  <div class="hud-cell farm">
+    <span class="hud-label">Farm</span>
+    <div class="bar"><div id="hud-farm-fill" class="bar-fill"></div></div>
+    <span id="hud-farm-text" class="bar-text">100%</span>
+  </div>
+  <div class="hud-cell yellow">
+    <span id="hud-yellow" class="hud-chip yellow-dormant hidden">DORMANT</span>
+  </div>
+</div>
+{% endblock %}
+
+{% block main %}
+<section class="map-pane">
+  <svg
+    id="world"
+    viewBox="0 0 1000 700"
+    preserveAspectRatio="xMidYMid meet"
+    role="img"
+    aria-label="Fromville map"
+  >
+    <image
+      href="{{ url_for('static', filename='img/fromville.svg') }}"
+      x="0"
+      y="0"
+      width="1000"
+      height="700"
+    />
+    <g id="overlays"></g>
+    <g id="lighting"></g>
+    <g id="entities"></g>
+  </svg>
+</section>
+
+<aside class="side-pane">
+  <details class="panel" open>
+    <summary>Event Log</summary>
+    <ol id="event-log" class="event-log"></ol>
+  </details>
+
+  <details class="panel" open>
+    <summary>Roster</summary>
+    <div class="roster">
+      <div class="roster-summary" id="roster-summary">
+        <span class="roster-count" data-pool="char">0 chars</span>
+        <span class="roster-count" data-pool="npc">0 NPCs</span>
+        <span class="roster-count" data-pool="creature">0 creatures</span>
+      </div>
+      <ul id="roster-list" class="roster-list"></ul>
+      <div id="roster-detail" class="roster-detail">
+        <div class="roster-empty">Click any dot on the map to inspect.</div>
+      </div>
+    </div>
+  </details>
+
+  <details class="panel" open>
+    <summary>Stats</summary>
+    <dl id="stats" class="stats">
+      <dt>Tick</dt><dd id="stat-tick">0</dd>
+      <dt>Cycle</dt><dd id="stat-cycle">1</dd>
+      <dt>Village wipes</dt><dd id="stat-wipes">0</dd>
+      <dt>Lighting</dt><dd id="stat-lighting">1.000</dd>
+      <dt>Food</dt><dd id="stat-food">100 / 200</dd>
+      <dt>Farm health</dt><dd id="stat-farm">100%</dd>
+      <dt>Characters</dt><dd id="stat-chars">0</dd>
+      <dt>NPCs</dt><dd id="stat-npcs">0</dd>
+      <dt>Creatures</dt><dd id="stat-creatures">0</dd>
+      <dt>Yellow Man</dt><dd id="stat-yellow">DORMANT</dd>
+    </dl>
+  </details>
+
+  <details class="panel narration-panel" id="narration-panel" style="display:none;">
+    <summary>Narration</summary>
+    <ol id="narration" class="narration"></ol>
+  </details>
+</aside>
+{% endblock %}
+
+{% block scripts %}
+<script>
+  window.FROM_SIM = {
+    llmEnabled: {{ 'true' if llm_enabled else 'false' }},
+  };
+</script>
+<script src="{{ url_for('static', filename='js/lighting.js') }}"></script>
+<script src="{{ url_for('static', filename='js/map.js') }}"></script>
+<script src="{{ url_for('static', filename='js/socket.js') }}"></script>
+{% endblock %}

--- a/from-simulation/app/templates/index.html
+++ b/from-simulation/app/templates/index.html
@@ -38,25 +38,11 @@
 {% endblock %}
 
 {% block main %}
-<section class="map-pane">
-  <svg
-    id="world"
-    viewBox="0 0 1000 700"
-    preserveAspectRatio="xMidYMid meet"
-    role="img"
-    aria-label="Fromville map"
-  >
-    <image
-      href="{{ url_for('static', filename='img/fromville.svg') }}"
-      x="0"
-      y="0"
-      width="1000"
-      height="700"
-    />
-    <g id="overlays"></g>
-    <g id="lighting"></g>
-    <g id="entities"></g>
-  </svg>
+<section class="map-pane" id="world">
+  <div class="map-wrap" id="mapWrap" data-time="day">
+    <div class="lighting" id="lighting"></div>
+    {% include "_map_svg.html" %}
+  </div>
 </section>
 
 <aside class="side-pane">
@@ -75,7 +61,7 @@
       </div>
       <ul id="roster-list" class="roster-list"></ul>
       <div id="roster-detail" class="roster-detail">
-        <div class="roster-empty">Click any dot on the map to inspect.</div>
+        <div class="roster-empty">Click any token on the map to inspect.</div>
       </div>
     </div>
   </details>
@@ -94,6 +80,83 @@
       <dt>Creatures</dt><dd id="stat-creatures">0</dd>
       <dt>Yellow Man</dt><dd id="stat-yellow">DORMANT</dd>
     </dl>
+  </details>
+
+  <details class="panel" id="township-index" open>
+    <summary>Township Index</summary>
+    <div class="index-list" id="indexList">
+      <div class="n">1</div>
+      <div class="ic"><svg viewBox="-1 0 18 17"><rect x="2" y="7" width="12" height="8" fill="#7c5a3e" stroke="#1a1611" stroke-width="0.5"/><polygon points="1,7 15,7 13,4 3,4" fill="#3a261a" stroke="#1a1611" stroke-width="0.5"/><circle cx="5" cy="7" r="1.7" fill="#8a6a4a" stroke="#1a1611" stroke-width="0.4"/><polygon points="3.3,7 6.7,7 5,4.5" fill="#3a261a" stroke="#1a1611" stroke-width="0.4"/><rect x="7" y="11" width="2" height="4" fill="#2a1810"/></svg></div>
+      <div class="t">Colony House<span class="tag">&#x2605;</span></div>
+
+      <div class="n">2</div>
+      <div class="ic"><svg viewBox="-1 0 18 17"><rect x="3" y="8" width="10" height="7" fill="#a8b07a" stroke="#1a1611" stroke-width="0.5"/><polygon points="2,8 14,8 12,4 4,4" fill="#4a5e34" stroke="#1a1611" stroke-width="0.5"/><rect x="7" y="11" width="2" height="4" fill="#2a2a18"/></svg></div>
+      <div class="t">Green House</div>
+
+      <div class="n">3</div>
+      <div class="ic"><svg viewBox="-1 0 18 17"><rect x="4" y="9" width="8" height="6" fill="#5a4632" stroke="#1a1611" stroke-width="0.5"/><polygon points="3,9 13,9 11,5 5,5" fill="#2a1810" stroke="#1a1611" stroke-width="0.5"/></svg></div>
+      <div class="t">Shed</div>
+
+      <div class="n">4</div>
+      <div class="ic"><svg viewBox="-1 0 18 17"><rect x="3" y="8" width="10" height="7" fill="#c9bca0" stroke="#1a1611" stroke-width="0.5"/><polygon points="2,8 14,8 12,4 4,4" fill="#5d4a3a" stroke="#1a1611" stroke-width="0.5"/><rect x="7" y="10" width="2" height="4" fill="#a83a2a"/><rect x="6" y="11" width="4" height="2" fill="#a83a2a"/></svg></div>
+      <div class="t">Clinic<span class="tag">&#x2605;</span></div>
+
+      <div class="n">5</div>
+      <div class="ic"><svg viewBox="-1 0 18 17"><ellipse cx="8" cy="13" rx="6" ry="3" fill="#3a3024" opacity="0.5"/><ellipse cx="8" cy="11" rx="7" ry="4" fill="#7a5a3a" stroke="#1a1611" stroke-width="0.5"/><rect x="7" y="10" width="2" height="4" fill="#2a1810"/></svg></div>
+      <div class="t">Root Cellar</div>
+
+      <div class="n">6</div>
+      <div class="ic"><svg viewBox="-1 0 18 17"><ellipse cx="8" cy="14" rx="5" ry="1" fill="#3a3024" opacity="0.5"/><polygon points="5.5,14 5,5 7.5,3 10,5 9.5,14" fill="#6a5f48" stroke="#1a1611" stroke-width="0.5"/><path d="M 6.5 7 q 1.5 -1.5 3 0" stroke="#3a3024" stroke-width="0.4" fill="none"/></svg></div>
+      <div class="t">Choosing Ceremony Stone</div>
+
+      <div class="n">7</div>
+      <div class="ic"><svg viewBox="-1 0 18 17"><rect x="3" y="9" width="10" height="6" fill="#9a8e72" stroke="#1a1611" stroke-width="0.5"/><polygon points="2,9 14,9 12,6 4,6" fill="#3a3024" stroke="#1a1611" stroke-width="0.5"/><rect x="7" y="4" width="2" height="3" fill="#7a6e58" stroke="#1a1611" stroke-width="0.4"/><polygon points="6.8,4 9.2,4 8,1.5" fill="#3a3024"/><rect x="7.7" y="0" width="0.6" height="3" fill="#1a1611"/><rect x="6.8" y="1" width="2.4" height="0.5" fill="#1a1611"/><circle cx="8" cy="11.5" r="0.7" fill="#d4a85a"/></svg></div>
+      <div class="t">Church<span class="tag">&#x2605;</span></div>
+
+      <div class="n">8</div>
+      <div class="ic"><svg viewBox="-1 0 18 17"><rect x="3" y="8" width="10" height="7" fill="#7a7468" stroke="#1a1611" stroke-width="0.5"/><polygon points="2,8 14,8 12,4 4,4" fill="#3a3a32" stroke="#1a1611" stroke-width="0.5"/><rect x="7" y="11" width="2" height="4" fill="#2a2a22"/></svg></div>
+      <div class="t">Grey House</div>
+
+      <div class="n">9</div>
+      <div class="ic"><svg viewBox="-1 0 18 17"><rect x="3" y="8" width="10" height="7" fill="#6a7e92" stroke="#1a1611" stroke-width="0.5"/><polygon points="2,8 14,8 12,4 4,4" fill="#3a4250" stroke="#1a1611" stroke-width="0.5"/><rect x="7" y="11" width="2" height="4" fill="#2a3038"/></svg></div>
+      <div class="t">Blue House</div>
+
+      <div class="n">10</div>
+      <div class="ic"><svg viewBox="-1 0 18 17"><rect x="2" y="7" width="12" height="8" rx="0.6" fill="#cabd9a" stroke="#1a1611" stroke-width="0.5"/><rect x="4" y="9" width="8" height="4" fill="#6a8a8e" stroke="#1a1611" stroke-width="0.4"/><path d="M4 11 h8 M8 9 v4" stroke="#4a6e72" stroke-width="0.4"/></svg></div>
+      <div class="t">Pool</div>
+
+      <div class="n">11</div>
+      <div class="ic"><svg viewBox="-1 0 18 17"><rect x="3" y="8" width="10" height="7" fill="#8a6a48" stroke="#1a1611" stroke-width="0.5"/><polygon points="2,8 14,8 12,4 4,4" fill="#4a3024" stroke="#1a1611" stroke-width="0.5"/><rect x="7" y="11" width="2" height="4" fill="#2a1810"/></svg></div>
+      <div class="t">Lius' Home</div>
+
+      <div class="n">12</div>
+      <div class="ic"><svg viewBox="-1 0 18 17"><rect x="2" y="7" width="12" height="2" fill="#3a2820" stroke="#1a1611" stroke-width="0.4"/><rect x="3" y="9" width="1.8" height="2" fill="#a83a2a" stroke="#1a1611" stroke-width="0.3"/><rect x="2" y="9" width="12" height="6" fill="#5a4632" stroke="#1a1611" stroke-width="0.5"/><rect x="5" y="11" width="6" height="2" fill="#1a1611"/><text x="8" y="12.6" font-size="1.9" fill="#d8a83a" text-anchor="middle" font-family="Georgia, serif" font-weight="bold">BAR</text></svg></div>
+      <div class="t">Bar</div>
+
+      <div class="n">13</div>
+      <div class="ic"><svg viewBox="-1 0 18 17"><rect x="2" y="7" width="12" height="8" fill="#a83a2a" stroke="#1a1611" stroke-width="0.5"/><polygon points="1,7 15,7 13,4 3,4" fill="#2a1810" stroke="#1a1611" stroke-width="0.5"/><rect x="6" y="10" width="4" height="5" fill="#3a2418" stroke="#1a1611" stroke-width="0.4"/><path d="M6 10 L10 15 M10 10 L6 15" stroke="#f0e6c8" stroke-width="0.5"/></svg></div>
+      <div class="t">Barn</div>
+
+      <div class="n">14</div>
+      <div class="ic"><svg viewBox="-1 0 18 17"><path d="M 8 2 L 9.5 6.2 L 14 6.2 L 10.4 8.8 L 11.7 13 L 8 10.6 L 4.3 13 L 5.6 8.8 L 2 6.2 L 6.5 6.2 Z" fill="#d8a83a" stroke="#1a1611" stroke-width="0.6" stroke-linejoin="round"/></svg></div>
+      <div class="t">Sheriff's Office<span class="tag">&#x2605;</span></div>
+
+      <div class="n">15</div>
+      <div class="ic"><svg viewBox="-1 0 18 17"><rect x="1.5" y="7" width="13" height="6" rx="1" fill="#d8a83a" stroke="#1a1611" stroke-width="0.5"/><rect x="2.5" y="8" width="2" height="2" fill="#2a3038"/><rect x="5" y="8" width="2" height="2" fill="#2a3038"/><rect x="7.5" y="8" width="2" height="2" fill="#2a3038"/><rect x="10" y="8" width="2" height="2" fill="#2a3038"/><rect x="12.5" y="8" width="1.5" height="2" fill="#2a3038"/><circle cx="4" cy="13.5" r="1.2" fill="#1a1611"/><circle cx="12" cy="13.5" r="1.2" fill="#1a1611"/></svg></div>
+      <div class="t">Bus</div>
+
+      <div class="n">16</div>
+      <div class="ic"><svg viewBox="-1 0 18 17"><rect x="3" y="9" width="10" height="6" fill="#7a5640" stroke="#1a1611" stroke-width="0.5"/><polygon points="2,9 7,9 6,5 4,5" fill="#3a2820" stroke="#1a1611" stroke-width="0.5"/><polygon points="9,9 14,9 13,6 10,8" fill="#3a2820" stroke="#1a1611" stroke-width="0.5"/><line x1="7" y1="9" x2="9" y2="9" stroke="#1a1611" stroke-width="0.4"/><circle cx="6" cy="12" r="0.6" fill="#3a2820"/><circle cx="10" cy="13" r="0.5" fill="#3a2820"/></svg></div>
+      <div class="t">Matthews' Home<span class="tag">&#x2605;</span></div>
+
+      <div class="n">17</div>
+      <div class="ic"><svg viewBox="-1 0 18 17"><rect x="3" y="-1" width="4.5" height="3" fill="#a83a2a" stroke="#1a1611" stroke-width="0.4"/><text x="5.3" y="1.2" font-size="1.8" fill="#f0e6c8" text-anchor="middle" font-family="Georgia, serif" font-weight="bold">DINER</text><line x1="5.3" y1="2" x2="5.3" y2="9" stroke="#1a1611" stroke-width="0.6"/><rect x="2" y="9" width="12" height="6" fill="#b07a3a" stroke="#1a1611" stroke-width="0.5"/><path d="M2 9 Q8 4 14 9" fill="#cdc6b4" stroke="#1a1611" stroke-width="0.5"/><rect x="3" y="11" width="10" height="2" fill="#1a1611" opacity="0.5"/></svg></div>
+      <div class="t">Diner</div>
+
+      <div class="n">18</div>
+      <div class="ic"><svg viewBox="-1 0 18 17"><rect x="3" y="8" width="10" height="7" fill="#8a6a48" stroke="#1a1611" stroke-width="0.5"/><polygon points="2,8 14,8 12,4 4,4" fill="#4a3024" stroke="#1a1611" stroke-width="0.5"/><rect x="7" y="11" width="2" height="4" fill="#2a1810"/></svg></div>
+      <div class="t">Myers' Home</div>
+    </div>
   </details>
 
   <details class="panel narration-panel" id="narration-panel" style="display:none;">

--- a/from-simulation/app/templates/index.html
+++ b/from-simulation/app/templates/index.html
@@ -15,6 +15,11 @@
   <div class="hud-cell cycle">
     <span class="hud-label">Cycle</span>
     <span id="hud-cycle" class="hud-badge">1</span>
+    <span id="hud-fragments" class="hud-fragments" title="journal fragments preserved">&#x1F4DC; 0 fragments</span>
+  </div>
+  <div class="hud-cell witnessed">
+    <span class="hud-label">Witnessed</span>
+    <span id="hud-cycles-witnessed" class="hud-witnessed">Cycle 1 of all that has ever been</span>
   </div>
   <div class="hud-cell food">
     <span class="hud-label">Food</span>
@@ -94,6 +99,24 @@
   <details class="panel narration-panel" id="narration-panel" style="display:none;">
     <summary>Narration</summary>
     <ol id="narration" class="narration"></ol>
+  </details>
+
+  <details class="panel" id="journal">
+    <summary>Khatri's Journal</summary>
+    <ol id="journal-list" class="journal-list"></ol>
+  </details>
+
+  <details class="panel" id="lighthouse-voice" style="display:none;">
+    <summary>Voice from the Lighthouse</summary>
+    <ol id="lighthouse-voice-list" class="lighthouse-voice-list"></ol>
+  </details>
+
+  <details class="panel" id="bus-panel" style="display:none;">
+    <summary>The Bus</summary>
+    <div class="bus-body">
+      <div id="bus-countdown" class="bus-countdown">—</div>
+      <ul id="bus-passengers" class="bus-passengers"></ul>
+    </div>
   </details>
 </aside>
 {% endblock %}

--- a/from-simulation/app/templates/layout.html
+++ b/from-simulation/app/templates/layout.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>{% block title %}From — Fromville{% endblock %}</title>
+    <link
+      rel="stylesheet"
+      href="{{ url_for('static', filename='css/style.css') }}"
+    />
+    <script
+      src="https://cdn.socket.io/4.7.5/socket.io.min.js"
+      crossorigin="anonymous"
+    ></script>
+  </head>
+  <body class="theme-dread">
+    <header class="topbar">
+      <div class="brand">
+        <span class="brand-mark">FROM</span>
+        <span class="brand-sub">Fromville Telemetry</span>
+      </div>
+      {% block hud %}{% endblock %}
+    </header>
+
+    <main class="layout">{% block main %}{% endblock %}</main>
+
+    <div id="cycle-reset-overlay" class="cycle-reset hidden" aria-hidden="true">
+      <div class="cycle-reset-inner">
+        <div class="cycle-reset-title">THE TOWN HAS FALLEN</div>
+        <div class="cycle-reset-sub">Cycle <span id="cycle-reset-num">1</span> begins</div>
+      </div>
+    </div>
+
+    {% block scripts %}{% endblock %}
+  </body>
+</html>

--- a/from-simulation/app/time_cycle.py
+++ b/from-simulation/app/time_cycle.py
@@ -1,0 +1,69 @@
+"""
+Day/night cycle helpers.
+
+The simulation runs 24 sim-hours per cycle. Phases are derived purely from
+``SimTime`` so they can be computed at any point without needing extra state.
+
+    DAWN : 05:00 -> 06:00     (lighting ramps 0 -> 1)
+    DAY  : 06:00 -> 18:00     (lighting = 1)
+    DUSK : 18:00 -> 20:00     (lighting ramps 1 -> 0)
+    NIGHT: 20:00 -> 05:00     (lighting = 0)
+
+``update_lighting`` uses a smooth cosine ramp during DAWN/DUSK so the UI gets a
+gentle, continuous brightness curve instead of a step function. Lighting feeds
+the SVG day/night overlay (Agent D) and the creature spawn gate (Agent A).
+"""
+
+from __future__ import annotations
+
+import math
+
+from contracts import Phase, SimTime, World
+
+
+# Boundaries in sim-minutes from midnight.
+_DAWN_START = 5 * 60      # 05:00
+_DAY_START = 6 * 60       # 06:00
+_DUSK_START = 18 * 60     # 18:00
+_NIGHT_START = 20 * 60    # 20:00
+
+
+def phase_for(sim_time: SimTime) -> Phase:
+    """Return the current ``Phase`` strictly as a function of ``sim_time``.
+
+    Boundaries are inclusive of the lower bound and exclusive of the upper.
+    """
+    m = sim_time.minutes_today
+    if _DAWN_START <= m < _DAY_START:
+        return Phase.DAWN
+    if _DAY_START <= m < _DUSK_START:
+        return Phase.DAY
+    if _DUSK_START <= m < _NIGHT_START:
+        return Phase.DUSK
+    return Phase.NIGHT
+
+
+def _smooth_ramp(progress: float) -> float:
+    """Half-cosine ease: 0 -> 1 as progress goes 0 -> 1."""
+    p = max(0.0, min(1.0, progress))
+    # (1 - cos(pi * p)) / 2 produces a soft S-curve in [0, 1].
+    return 0.5 * (1.0 - math.cos(math.pi * p))
+
+
+def update_lighting(world: World) -> None:
+    """Recompute ``world.lighting`` from ``world.time``.
+
+    Lighting is a float in [0, 1]. The cosine ramp gives the dusk/dawn
+    transitions a soft S-curve rather than a linear fade.
+    """
+    m = world.time.minutes_today
+    if _DAY_START <= m < _DUSK_START:
+        world.lighting = 1.0
+    elif _NIGHT_START <= m or m < _DAWN_START:
+        world.lighting = 0.0
+    elif _DAWN_START <= m < _DAY_START:
+        progress = (m - _DAWN_START) / float(_DAY_START - _DAWN_START)
+        world.lighting = _smooth_ramp(progress)
+    else:  # DUSK
+        progress = (m - _DUSK_START) / float(_NIGHT_START - _DUSK_START)
+        world.lighting = 1.0 - _smooth_ramp(progress)

--- a/from-simulation/app/world.py
+++ b/from-simulation/app/world.py
@@ -120,6 +120,16 @@ def reset_world(world: World) -> None:
     world.music_box_carrier = None
     world.worms_infected.clear()
     world.rhyme_heard.clear()
+
+    # v5 — sub_mains persist across wipes (they're tracked in SQLite forever);
+    # in-memory set survives this reset. Memory handle stays attached too.
+    # If memory is attached, log the new cycle's start + prune the old.
+    if world.memory is not None:
+        try:
+            world.memory.start_cycle(world)
+            world.memory.prune_old_cycles(world)
+        except Exception:
+            pass
     # Bus: preserve next_arrival_cycle counter (so the cadence persists), reset
     # the rest. If we just left a cycle whose number IS the scheduled arrival,
     # the bus tick logic will activate after rebuild.

--- a/from-simulation/app/world.py
+++ b/from-simulation/app/world.py
@@ -21,13 +21,16 @@ import random
 from contracts import (
     BUILDING_LAYOUT,
     Building,
+    BusState,
     Config,
+    Legacy,
     Phase,
     SimTime,
     World,
     YellowState,
 )
 from events import make_event_buffer
+from legacy import distill_legacy_from
 
 
 def _apply_building_layout(world: World) -> None:
@@ -78,11 +81,16 @@ def reset_world(world: World) -> None:
     increments the wipe counter, and clears the ``pending_reset`` flag.
     Engine time is reset to D0 06:00 of a fresh cycle.
 
-    Owner-of-field discipline: we intentionally clear ``world.agents``,
-    ``yellow_touched_npcs``, and ``meeting_outcomes`` here because the reset is
-    the one moment the engine is allowed to bulldoze cross-slice state — every
-    other tick those dicts/lists are owned by B/C.
+    v2: ``world.legacy`` and ``world.bus.next_arrival_cycle`` SURVIVE the wipe.
+    Before bulldozing, we ``distill_legacy_from(world)`` — that scans the dying
+    cycle's events and applies the marks/drift/fragment-burning to the Legacy.
+    Pending prophecies for the next cycle survive too.
     """
+    # 1) Distill the lessons of this cycle into the Legacy BEFORE the wipe.
+    distill_legacy_from(world)
+
+    # 2) Bump the legacy counter once per wipe.
+    world.legacy.cycles_witnessed += 1
     world.village_wipes += 1
     world.pending_reset = False
 
@@ -98,6 +106,17 @@ def reset_world(world: World) -> None:
     world.yellow_active = YellowState()
     world.expedition_authorised = False
     world.expedition_active = False
+
+    # v2 — transient state cleared, persistent state preserved.
+    world.trust = {}  # baseline gets re-seeded by Agent B on character build
+    world.active_dreams.clear()
+    world.lighthouse_called = None
+    world.lighthouse_voice_active = False
+    # Bus: preserve next_arrival_cycle counter (so the cadence persists), reset
+    # the rest. If we just left a cycle whose number IS the scheduled arrival,
+    # the bus tick logic will activate after rebuild.
+    preserved_next = world.bus.next_arrival_cycle
+    world.bus = BusState(next_arrival_cycle=preserved_next)
 
     # Engine state
     world.food_supply = 100.0

--- a/from-simulation/app/world.py
+++ b/from-simulation/app/world.py
@@ -46,6 +46,7 @@ def _apply_building_layout(world: World) -> None:
             has_talisman=bool(has_talisman),
             role_tag=role_tag,
             locked=False,
+            original_talisman=bool(has_talisman),
         )
 
 
@@ -120,6 +121,26 @@ def reset_world(world: World) -> None:
     world.music_box_carrier = None
     world.worms_infected.clear()
     world.rhyme_heard.clear()
+
+    # v6 — any live arrival car gets cleared (the Car object is in supernaturals
+    # which we wiped above). Legacy.permanent_wrecks is preserved automatically.
+    world.active_car_id = None
+    world.car_pending_npc_id = None
+    # v7 — barn state is per-cycle; reset on wipe so the new village starts
+    # with a working food store.
+    world.barn_destroyed_until_tick = 0
+    world.barn_repair_progress = 0.0
+    # v8 — construction state is per-cycle; new houses don't survive wipes.
+    world.construction_progress.clear()
+    world.consumed_lots.clear()
+    # And remove any built houses from the NPC home pool we appended into.
+    try:
+        from contracts import NPC_HOME_BUILDINGS
+        NPC_HOME_BUILDINGS[:] = [
+            bid for bid in NPC_HOME_BUILDINGS if not bid.startswith("built_house_")
+        ]
+    except Exception:
+        pass
 
     # v5 — sub_mains persist across wipes (they're tracked in SQLite forever);
     # in-memory set survives this reset. Memory handle stays attached too.

--- a/from-simulation/app/world.py
+++ b/from-simulation/app/world.py
@@ -112,6 +112,14 @@ def reset_world(world: World) -> None:
     world.active_dreams.clear()
     world.lighthouse_called = None
     world.lighthouse_voice_active = False
+
+    # v4 — transient music-box state cleared on wipe.
+    world.music_box_phase = "DORMANT"
+    world.music_box_phase_until_tick = 0
+    world.music_box_id = None
+    world.music_box_carrier = None
+    world.worms_infected.clear()
+    world.rhyme_heard.clear()
     # Bus: preserve next_arrival_cycle counter (so the cadence persists), reset
     # the rest. If we just left a cycle whose number IS the scheduled arrival,
     # the bus tick logic will activate after rebuild.

--- a/from-simulation/app/world.py
+++ b/from-simulation/app/world.py
@@ -1,0 +1,115 @@
+"""
+World construction and reset helpers.
+
+The ``World`` dataclass itself lives in ``contracts.py`` — DO NOT redefine it
+here. This module is responsible for:
+
+  * ``build_world(config)``    — first-time construction of a fresh world.
+  * ``reset_world(world)``     — village-wipe reseed: clear non-engine entities,
+                                  re-apply ``BUILDING_LAYOUT``, reset food and
+                                  farm health, bump ``village_wipes``.
+
+Both functions touch ONLY engine-owned fields (per contracts.py ownership map).
+Agent B and Agent C re-populate ``world.agents`` after a reset; we just clear
+the dict so they can repopulate from a clean slate.
+"""
+
+from __future__ import annotations
+
+import random
+
+from contracts import (
+    BUILDING_LAYOUT,
+    Building,
+    Config,
+    Phase,
+    SimTime,
+    World,
+    YellowState,
+)
+from events import make_event_buffer
+
+
+def _apply_building_layout(world: World) -> None:
+    """(Re)materialise ``world.buildings`` from the static layout table."""
+    world.buildings.clear()
+    for (b_id, name, x, y, footprint, has_talisman, role_tag) in BUILDING_LAYOUT:
+        world.buildings[b_id] = Building(
+            id=b_id,
+            name=name,
+            x=float(x),
+            y=float(y),
+            footprint=int(footprint),
+            has_talisman=bool(has_talisman),
+            role_tag=role_tag,
+            locked=False,
+        )
+
+
+def build_world(config: Config) -> World:
+    """Construct a brand-new world.
+
+    Seeds the RNG (deterministic when ``config.seed`` is set), installs the
+    building layout, wires up the bounded event buffer, and returns the world.
+    Telemetry is attached later by ``simulation.start()``.
+    """
+    rng = random.Random(config.seed) if config.seed is not None else random.Random()
+    world = World(
+        config=config,
+        rng=rng,
+        tick_count=0,
+        time=SimTime(day=0, hour=6, minute=0, phase=Phase.DAY),
+        lighting=1.0,
+        food_supply=100.0,
+        food_capacity=200.0,
+        farm_health=1.0,
+        last_phase=Phase.DAY,
+    )
+    world.events = make_event_buffer()
+    _apply_building_layout(world)
+    return world
+
+
+def reset_world(world: World) -> None:
+    """Wipe-and-reseed in place. Called by the engine when a wipe is pending.
+
+    Clears creatures, supernaturals, and characters (Agent B/C will repopulate
+    on their next tick). Re-applies the building layout, resets food/farm,
+    increments the wipe counter, and clears the ``pending_reset`` flag.
+    Engine time is reset to D0 06:00 of a fresh cycle.
+
+    Owner-of-field discipline: we intentionally clear ``world.agents``,
+    ``yellow_touched_npcs``, and ``meeting_outcomes`` here because the reset is
+    the one moment the engine is allowed to bulldoze cross-slice state — every
+    other tick those dicts/lists are owned by B/C.
+    """
+    world.village_wipes += 1
+    world.pending_reset = False
+
+    # Engine-owned entities
+    world.creatures.clear()
+    world.supernaturals.clear()
+
+    # Cross-slice state — cleared here because a wipe is global.
+    world.agents.clear()
+    world.meeting_outcomes.clear()
+    world.recognition_counts.clear()
+    world.yellow_touched_npcs.clear()
+    world.yellow_active = YellowState()
+    world.expedition_authorised = False
+    world.expedition_active = False
+
+    # Engine state
+    world.food_supply = 100.0
+    world.farm_health = 1.0
+    world.farm_disaster_until_tick = 0
+    world.tick_count = 0
+    world.time = SimTime(day=0, hour=6, minute=0, phase=Phase.DAY)
+    world.last_phase = Phase.DAY
+    world.lighting = 1.0
+
+    # Buildings reseed from layout (clears occupants, re-locks doors, etc.)
+    _apply_building_layout(world)
+
+    # Fresh event buffer so the post-reset UI isn't haunted by the last cycle.
+    world.events = make_event_buffer()

--- a/from-simulation/config.alloy
+++ b/from-simulation/config.alloy
@@ -1,0 +1,64 @@
+/*
+ * Alloy pipeline for the From simulation scenario.
+ * Receives OTLP traces, logs, and metrics from the from-sim app
+ * and forwards them to Tempo, Loki, and Prometheus respectively.
+ * Also receives pprof profiles and forwards to Pyroscope.
+ */
+
+otelcol.receiver.otlp "default" {
+  http {}
+  grpc {}
+
+  output {
+    metrics = [otelcol.processor.batch.default.input]
+    logs    = [otelcol.processor.batch.default.input]
+    traces  = [otelcol.processor.batch.default.input]
+  }
+}
+
+otelcol.processor.batch "default" {
+  output {
+    traces  = [otelcol.exporter.otlp.tempo.input]
+    logs    = [otelcol.exporter.otlphttp.logs.input]
+    metrics = [otelcol.exporter.otlphttp.metrics.input]
+  }
+}
+
+otelcol.exporter.otlp "tempo" {
+  client {
+    endpoint = "tempo:4317"
+    tls {
+      insecure = true
+    }
+  }
+}
+
+otelcol.exporter.otlphttp "logs" {
+  client {
+    endpoint = "http://loki:3100/otlp"
+  }
+}
+
+otelcol.exporter.otlphttp "metrics" {
+  client {
+    endpoint = "http://prometheus:9090/api/v1/otlp"
+  }
+}
+
+pyroscope.receive_http "default" {
+  http {
+    listen_address = "0.0.0.0"
+    listen_port    = 9999
+  }
+  forward_to = [pyroscope.write.default.receiver]
+}
+
+pyroscope.write "default" {
+  endpoint {
+    url = "http://pyroscope:4040"
+  }
+}
+
+livedebugging {
+  enabled = true
+}

--- a/from-simulation/docker-compose.yml
+++ b/from-simulation/docker-compose.yml
@@ -85,7 +85,7 @@ services:
       - SERVICE_NAME=from-sim
       - OTEL_EXPORTER_OTLP_ENDPOINT=http://alloy:4318
       - PYROSCOPE_SERVER_ADDRESS=http://alloy:9999
-      - TICK_HZ=2
+      - TICK_HZ=5
       - TIME_SCALE=1.0
       # Optional LLM driver — leave blank to run pure deterministic
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}

--- a/from-simulation/docker-compose.yml
+++ b/from-simulation/docker-compose.yml
@@ -104,9 +104,18 @@ services:
       - YELLOW_APPEARANCE_DAYS_MAX=10
       - YELLOW_IMPOSTER_PROB=0.7
       - YELLOW_DEADLINE_TICKS=1500
+      # v5 — SQLite memory
+      - FROM_DB_PATH=/data/from.db
+      - MEMORY_CYCLE_WINDOW=50
+      - MEMORY_FLUSH_EVERY_TICKS=60
+      - MEMORY_RECALL_WINDOW_TICKS=1200
+      - NPC_PROMOTION_SCORE_THRESHOLD=1.0
       - LOG_LEVEL=INFO
+    volumes:
+      - from-data:/data
     depends_on:
       - alloy
 
 volumes:
   pyroscope-data:
+  from-data:

--- a/from-simulation/docker-compose.yml
+++ b/from-simulation/docker-compose.yml
@@ -1,0 +1,112 @@
+services:
+  loki:
+    image: grafana/loki:${GRAFANA_LOKI_VERSION:-3.6.10}
+    ports:
+      - "3100:3100"
+    volumes:
+      - ./loki-config.yaml:/etc/loki/local-config.yaml
+    command: -config.file=/etc/loki/local-config.yaml
+
+  prometheus:
+    image: prom/prometheus:${PROMETHEUS_VERSION:-v3.11.3}
+    command:
+      - --web.enable-remote-write-receiver
+      - --web.enable-otlp-receiver
+      - --enable-feature=native-histograms
+      - --enable-feature=exemplar-storage
+      - --config.file=/etc/prometheus/prometheus.yml
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./prom-config.yaml:/etc/prometheus/prometheus.yml
+
+  tempo:
+    image: grafana/tempo:${GRAFANA_TEMPO_VERSION:-2.10.4}
+    command: ["-config.file=/etc/tempo.yaml"]
+    ports:
+      - "3200:3200"
+    volumes:
+      - ./tempo-config.yaml:/etc/tempo.yaml
+    depends_on:
+      - prometheus
+
+  pyroscope:
+    image: grafana/pyroscope:${GRAFANA_PYROSCOPE_VERSION:-2.0.1}
+    ports:
+      - "4040:4040"
+    command:
+      - "-config.file=/etc/pyroscope/config.yaml"
+      - "-architecture.storage=v1-v2-dual"
+    volumes:
+      - ./pyroscope-config.yaml:/etc/pyroscope/config.yaml
+      - pyroscope-data:/data
+
+  grafana:
+    image: grafana/grafana:${GRAFANA_VERSION:-13.0.1}
+    environment:
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
+      - GF_AUTH_DISABLE_LOGIN_FORM=true
+      - GF_SECURITY_ALLOW_EMBEDDING=true
+    volumes:
+      - ./grafana:/etc/grafana/provisioning
+    ports:
+      - "3000:3000"
+    depends_on:
+      - prometheus
+      - tempo
+      - pyroscope
+      - loki
+
+  alloy:
+    image: grafana/alloy:${GRAFANA_ALLOY_VERSION:-v1.16.1}
+    ports:
+      - "12345:12345"
+      - "4317:4317"
+      - "4318:4318"
+      - "9999:9999"
+    volumes:
+      - ./config.alloy:/etc/alloy/config.alloy
+    command: run --server.http.listen-addr=0.0.0.0:12345 --storage.path=/var/lib/alloy/data /etc/alloy/config.alloy
+    depends_on:
+      - pyroscope
+      - tempo
+      - loki
+      - prometheus
+
+  from-sim:
+    build:
+      context: ./app
+      dockerfile: Dockerfile
+    ports:
+      - "8080:8080"
+    environment:
+      - IN_DOCKER=1
+      - SERVICE_NAME=from-sim
+      - OTEL_EXPORTER_OTLP_ENDPOINT=http://alloy:4318
+      - PYROSCOPE_SERVER_ADDRESS=http://alloy:9999
+      - TICK_HZ=2
+      - TIME_SCALE=1.0
+      # Optional LLM driver — leave blank to run pure deterministic
+      - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
+      - LLM_MODEL=claude-haiku-4-5
+      - LLM_DECISION_RATE=0.05
+      - LLM_YELLOW_RATE=0.25
+      - LLM_MIN_TICK_GAP=30
+      - LLM_GLOBAL_RPM=6
+      # Population / loop tuning
+      - NPC_FLOOR=18
+      - RESURRECTION_BASE_TICKS=700
+      - RESURRECTION_JITTER=150
+      - RECOGNITION_THRESHOLD=3
+      # Yellow Man
+      - YELLOW_APPEARANCE_DAYS_MIN=5
+      - YELLOW_APPEARANCE_DAYS_MAX=10
+      - YELLOW_IMPOSTER_PROB=0.7
+      - YELLOW_DEADLINE_TICKS=1500
+      - LOG_LEVEL=INFO
+    depends_on:
+      - alloy
+
+volumes:
+  pyroscope-data:

--- a/from-simulation/grafana/datasources/defaults.yml
+++ b/from-simulation/grafana/datasources/defaults.yml
@@ -1,0 +1,58 @@
+apiVersion: 1
+datasources:
+- name: prometheus
+  uid: prometheus
+  type: prometheus
+  orgId: 1
+  url: http://prometheus:9090
+  basicAuth: false
+  isDefault: false
+  version: 1
+  editable: false
+  jsonData:
+    exemplarTraceIdDestinations:
+      - datasourceUid: "tempo"
+        name: "trace_id"
+- name: tempo
+  uid: tempo
+  type: tempo
+  access: proxy
+  orgId: 1
+  url: http://tempo:3200
+  basicAuth: false
+  isDefault: true
+  version: 1
+  editable: false
+  jsonData:
+    serviceMap:
+      datasourceUid: 'prometheus'
+    nodeGraph:
+      enabled: true
+    tracesToLogsV2:
+      datasourceUid: 'loki'
+      filterBySpanID: true
+    tracesToMetrics:
+      datasourceUid: 'prometheus'
+    tracesToProfilesV2:
+      datasourceUid: 'pyroscope'
+      tags:
+        - key: 'service.name'
+          value: 'service_name'
+      profileTypeId: 'process_cpu:cpu:nanoseconds:cpu:nanoseconds'
+- name: loki
+  uid: loki
+  type: loki
+  access: proxy
+  orgId: 1
+  url: http://loki:3100
+  basicAuth: false
+  isDefault: false
+- name: pyroscope
+  uid: pyroscope
+  type: grafana-pyroscope-datasource
+  access: proxy
+  orgId: 1
+  url: http://pyroscope:4040
+  basicAuth: false
+  isDefault: false
+  editable: false

--- a/from-simulation/loki-config.yaml
+++ b/from-simulation/loki-config.yaml
@@ -1,0 +1,34 @@
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+  grpc_listen_port: 9096
+  log_level: info
+
+common:
+  instance_addr: 127.0.0.1
+  path_prefix: /tmp/storage
+  storage:
+    filesystem:
+      chunks_directory: /tmp/storage/chunks
+      rules_directory: /tmp/storage/rules
+  replication_factor: 1
+  ring:
+    kvstore:
+      store: inmemory
+
+schema_config:
+  configs:
+    - from: 2020-10-24
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
+ruler:
+  alertmanager_url: http://localhost:9093
+
+frontend:
+  encoding: protobuf

--- a/from-simulation/prom-config.yaml
+++ b/from-simulation/prom-config.yaml
@@ -1,0 +1,6 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+otlp:
+  keep_identifying_resource_attributes: true

--- a/from-simulation/pyroscope-config.yaml
+++ b/from-simulation/pyroscope-config.yaml
@@ -1,0 +1,8 @@
+---
+server:
+  http_listen_port: 4040
+
+storage:
+  backend: filesystem
+  filesystem:
+    dir: /data

--- a/from-simulation/tempo-config.yaml
+++ b/from-simulation/tempo-config.yaml
@@ -1,0 +1,51 @@
+stream_over_http_enabled: true
+server:
+  http_listen_port: 3200
+  log_level: info
+
+distributor:
+  receivers:
+    otlp:
+      protocols:
+        grpc:
+          endpoint: "tempo:4317"
+        http:
+          endpoint: "tempo:4318"
+
+ingester:
+  max_block_duration: 5m
+
+compactor:
+  compaction:
+    block_retention: 720h
+
+metrics_generator:
+  registry:
+    external_labels:
+      source: tempo
+      cluster: docker-compose
+  storage:
+    path: /var/tempo/generator/wal
+    remote_write:
+      - url: http://prometheus:9090/api/v1/write
+        send_exemplars: true
+  traces_storage:
+    path: /var/tempo/generator/traces
+  processor:
+    local_blocks:
+      filter_server_spans: false
+      flush_to_storage: true
+
+storage:
+  trace:
+    backend: local
+    wal:
+      path: /var/tempo/wal
+    local:
+      path: /var/tempo/blocks
+
+overrides:
+  defaults:
+    metrics_generator:
+      processors: [service-graphs, span-metrics, local-blocks]
+      generate_native_histograms: both


### PR DESCRIPTION
A self-running "mini universe" inspired by the MGM+ series From. The village ticks through day/night cycles with ten named characters, dynamic NPC arrivals/deaths, creatures that emerge at dusk, the Boy in White, anghkooey children, Faraway Tree portals, and a Man in Yellow who can shroud as a villager and trigger a full village wipe + reseed if the town fails to identify him in time.

The app is built around a Flask + Flask-SocketIO server that broadcasts a snapshot of the world every tick (2 Hz) to a hand-drawn SVG map with animated entity layer, day/night lighting overlay, and four side panels (event log, character roster, village stats, optional LLM narration). Each named character has a role-weighted state machine with personality biases; if ANTHROPIC_API_KEY is set, an optional LLMDecider picks from a constrained menu so it can colour decisions without breaking determinism.

Telemetry hooks (logs, traces, Pyroscope, metrics) are wired against the standard Alloy pipeline pattern from game-of-tracing/war_map so the scenario slots straight into the LGMT stack for follow-up dashboard work.