### PR TITLE
Add ebpf-host-profiling scenario

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ These scenarios collect continuous profiles from applications.
 | Scenario | Description |
 | -------- | ----------- |
 | [Continuous profiling](continuous-profiling/) | Collect and visualize CPU, memory, and goroutine profiles from Go applications with Grafana Pyroscope. |
+| [eBPF host profiling](ebpf-host-profiling/) | Profile every process on a Linux host with `pyroscope.ebpf` -- no language agents, no application code changes. Uses Docker container discovery to attribute samples per workload. |
 
 ### Secrets and configuration
 

--- a/ebpf-host-profiling/README.md
+++ b/ebpf-host-profiling/README.md
@@ -1,0 +1,123 @@
+# eBPF host profiling
+
+Profile every process on a Linux host with Grafana Alloy's `pyroscope.ebpf` component -- no language agents, no application code changes, no `pprof` endpoints to expose. The kernel does the sampling and Alloy ships CPU stack traces to Grafana Pyroscope.
+
+## What this scenario demonstrates
+
+- **`pyroscope.ebpf`** -- host-wide eBPF CPU sampler that profiles every process the Alloy container can see through the host PID namespace.
+- **Docker container discovery** -- `discovery.docker` enumerates running containers and `discovery.relabel` turns each container name into a `service_name` so the flame graph is grouped per workload.
+- **`pyroscope.write`** -- pushes the collected profiles to a local Pyroscope server.
+- **Two stress workloads** -- `stress-cpu` and `stress-mem` give the profiler something interesting to sample, and let you switch the service filter to see how the flame graph narrows.
+
+This is the "no-instrumentation" alternative to the `continuous-profiling/` scenario. That scenario scrapes a Go application's `/debug/pprof` endpoints; this one needs nothing from the workloads themselves.
+
+## Overview
+
+The example includes:
+
+- **alloy** -- runs with `privileged: true` and `pid: host` so the eBPF loader can attach perf events in the host kernel and follow PIDs of other containers.
+- **pyroscope** -- profile storage and query backend at port 4040.
+- **grafana** -- pre-configured with the Pyroscope datasource for flame graphs.
+- **stress-cpu** -- two CPU-stress workers (`stress --cpu 2`); the flame graph is dominated by integer-arithmetic loops.
+- **stress-mem** -- mixed workload (`stress --cpu 1 --vm 1 --vm-bytes 128M`) that pairs a CPU stressor with a memory allocator/writer so its CPU profile is visibly different from `stress-cpu`.
+
+## Prerequisites
+
+- A **Linux host** (kernel 5.4+ recommended). The eBPF loader needs to attach perf events on the host kernel; Docker Desktop on macOS or Windows runs Docker inside a small Linux VM, which works but may require extra setup. Running this scenario inside another container (nested Docker) is not supported -- the inner container cannot raise `RLIMIT_MEMLOCK` even when `privileged: true`.
+- Docker and Docker Compose.
+- Root or `sudo` to start the `privileged` Alloy container.
+
+## Running the demo
+
+1. Clone the repository:
+   ```
+   git clone https://github.com/grafana/alloy-scenarios.git
+   cd alloy-scenarios
+   ```
+
+2. Navigate to this example directory:
+   ```
+   cd ebpf-host-profiling
+   ```
+
+3. Start the stack:
+   ```
+   docker compose up -d
+   ```
+
+   Or, from the repository root, with centralized image versions:
+   ```
+   ./run-example.sh ebpf-host-profiling
+   ```
+
+4. Access Grafana at <http://localhost:3000>.
+
+## What to expect
+
+Within ~30 seconds, Alloy starts pushing CPU profiles to Pyroscope. The eBPF profiler samples at 19 Hz by default (`sample_rate = 19`) and Alloy flushes a batch every 15 seconds (`collect_interval = "15s"`).
+
+To view flame graphs:
+
+1. Open Grafana at <http://localhost:3000>.
+2. Go to **Explore** and pick the **Pyroscope** datasource.
+3. Choose the profile type **`process_cpu` / cpu (nanoseconds)**.
+4. In the query, set the service filter to `service_name="stress-cpu"`. You should see a tall, narrow flame graph -- mostly tight integer-arithmetic loops inside the `stress` binary -- because `stress-cpu` does nothing but burn CPU.
+5. Change the filter to `service_name="stress-mem"`. The flame graph now splits between CPU stress functions and memory-touching paths (page faults, `memset`-style writes). Switching filters this way is the test for "the eBPF profiler attributes samples to the right container."
+
+You can also open Pyroscope's own UI directly at <http://localhost:4040> and use its service selector for the same comparison.
+
+### Useful endpoints
+
+- Alloy UI: <http://localhost:12345> -- inspect the pipeline. Open `pyroscope.ebpf.default` to see the component status, the discovered targets, and any eBPF loader errors.
+- Pyroscope UI: <http://localhost:4040>.
+- Grafana: <http://localhost:3000>.
+
+## Architecture
+
+```
+                                              host PID namespace (shared)
+                          ┌──────────────────────────────────────────────────────┐
+                          │                                                      │
+   ┌────────────┐         │    perf events / eBPF probes                         │
+   │ stress-cpu │◀────────┤                                                      │
+   └────────────┘         │              ┌───────────┐                           │
+                          │              │   alloy   │   push profiles           │
+   ┌────────────┐         │◀─────────────│ (privileged)─────────────────────────▶┌──────────┐
+   │ stress-mem │◀────────┤              │  pyroscope│                           │Pyroscope │
+   └────────────┘         │              │   .ebpf   │                           │  :4040   │
+                          │              └─────┬─────┘                           └────┬─────┘
+                          └────────────────────│─────────────────────────────────────┼──────┘
+                                          discover via                               ▼
+                                        /var/run/docker.sock                   ┌──────────┐
+                                                                               │ Grafana  │
+                                                                               │  :3000   │
+                                                                               └──────────┘
+```
+
+`pid: host` lets the Alloy container see other containers' PIDs, and the `__container_id__` label (added automatically by `discovery.docker`) lets `pyroscope.ebpf` map each kernel sample back to the container that produced it.
+
+## Key configuration
+
+Two things in `docker-compose.yml` are non-negotiable for `pyroscope.ebpf` to work:
+
+- **`privileged: true`** -- the eBPF loader needs to raise `RLIMIT_MEMLOCK` and load BPF programs into the kernel. Without `privileged`, you can grant a narrower set of capabilities -- `BPF`, `PERFMON`, `SYS_PTRACE`, `CHECKPOINT_RESTORE`, `SYS_RESOURCE`, `DAC_READ_SEARCH`, `SYSLOG` -- but `privileged` is the simplest setting for a demo.
+- **`pid: host`** -- without this, Alloy only sees its own PID; with it, Alloy sees every process on the host and can map samples to the right container.
+
+In `config.alloy`:
+
+- `discovery.docker` reads the container list from the Docker socket so the profiler knows which `container_id` belongs to which container name.
+- `discovery.relabel` rewrites `__meta_docker_container_name` (`/stress-cpu`) into a clean `service_name` (`stress-cpu`). `pyroscope.ebpf` requires a `service_name` on every target.
+- `pyroscope.ebpf` uses default settings (`collect_interval = "15s"`, `sample_rate = 19`). For tighter sampling, lower `collect_interval` -- but at the cost of more samples shipped per minute.
+
+## Customize
+
+- **Profile only one container**: filter `discovery.relabel.containers.output` with a regex on `__meta_docker_container_name` (or set `__process_pid__` directly).
+- **Profile bare-metal processes too**: add an extra `targets` entry of the form `{"__process_pid__" = "<pid>", "service_name" = "..."}`. eBPF will sample that PID alongside the container ones.
+- **Capture off-CPU profiles**: set `off_cpu_threshold` in the `pyroscope.ebpf` block (see the [component reference](https://grafana.com/docs/alloy/latest/reference/components/pyroscope/pyroscope.ebpf/)).
+- **Profile interpreted languages**: `pyroscope.ebpf` includes interpreter tracers for Python, Ruby, PHP, Perl, V8 (Node.js), and the JVM by default. Add a workload such as a Python or Node.js script and its frames will show up in the flame graph without any extra setup.
+
+## Stop
+
+```
+docker compose down
+```

--- a/ebpf-host-profiling/README.md
+++ b/ebpf-host-profiling/README.md
@@ -7,9 +7,9 @@ Profile every process on a Linux host with Grafana Alloy's `pyroscope.ebpf` comp
 - **`pyroscope.ebpf`** -- host-wide eBPF CPU sampler that profiles every process the Alloy container can see through the host PID namespace.
 - **Docker container discovery** -- `discovery.docker` enumerates running containers and `discovery.relabel` turns each container name into a `service_name` so the flame graph is grouped per workload.
 - **`pyroscope.write`** -- pushes the collected profiles to a local Pyroscope server.
-- **Two stress workloads** -- `stress-cpu` and `stress-mem` give the profiler something interesting to sample, and let you switch the service filter to see how the flame graph narrows.
+- **Two workloads** -- `stress-cpu` and `stress-mem` run a small, dependency-free Go load generator (`app/main.go`) that ships with the scenario, so the demo owns its workload instead of pulling a third-party stress image. They give the profiler something interesting to sample and let you switch the service filter to see how the flame graph changes.
 
-This is the "no-instrumentation" alternative to the `continuous-profiling/` scenario. That scenario scrapes a Go application's `/debug/pprof` endpoints; this one needs nothing from the workloads themselves.
+This is the "no-instrumentation" alternative to the `continuous-profiling/` scenario. That scenario scrapes a Go application's `/debug/pprof` endpoints; this one needs nothing from the workloads themselves -- the kernel samples them via eBPF with no `pprof` endpoint and no SDK.
 
 ## Overview
 
@@ -18,12 +18,14 @@ The example includes:
 - **alloy** -- runs with `privileged: true` and `pid: host` so the eBPF loader can attach perf events in the host kernel and follow PIDs of other containers.
 - **pyroscope** -- profile storage and query backend at port 4040.
 - **grafana** -- pre-configured with the Pyroscope datasource for flame graphs.
-- **stress-cpu** -- two CPU-stress workers (`stress --cpu 2`); the flame graph is dominated by integer-arithmetic loops.
-- **stress-mem** -- mixed workload (`stress --cpu 1 --vm 1 --vm-bytes 128M`) that pairs a CPU stressor with a memory allocator/writer so its CPU profile is visibly different from `stress-cpu`.
+- **stress-cpu** -- the bundled Go app in CPU mode (`go run . cpu`); tight arithmetic loops, so the flame graph is dominated by `main.cpuLoop`.
+- **stress-mem** -- the same app in memory mode (`go run . mem`); a rolling 128 MiB of allocations and writes, so its flame graph splits between `main.memLoop` and the Go runtime's allocation/`memclr` paths and looks visibly different from `stress-cpu`.
+
+Both run on the official, multi-arch `golang` image, so they build and run natively on amd64 and arm64 (Apple Silicon) -- the flame graph shows real Go frames rather than QEMU emulation internals.
 
 ## Prerequisites
 
-- A **Linux host** (kernel 5.4+ recommended). The eBPF loader needs to attach perf events on the host kernel; Docker Desktop on macOS or Windows runs Docker inside a small Linux VM, which works but may require extra setup. Running this scenario inside another container (nested Docker) is not supported -- the inner container cannot raise `RLIMIT_MEMLOCK` even when `privileged: true`.
+- A **Linux host** (kernel 5.4+ recommended), or **Docker Desktop** on macOS / Windows -- the eBPF loader attaches perf events on the Linux kernel that Docker Desktop runs the engine in, and this scenario has been verified working on Docker Desktop (Apple Silicon) out of the box. Running it inside another container (nested Docker) is *not* supported -- the inner container cannot raise `RLIMIT_MEMLOCK` even with `privileged: true`.
 - Docker and Docker Compose.
 - Root or `sudo` to start the `privileged` Alloy container.
 
@@ -61,8 +63,8 @@ To view flame graphs:
 1. Open Grafana at <http://localhost:3000>.
 2. Go to **Explore** and pick the **Pyroscope** datasource.
 3. Choose the profile type **`process_cpu` / cpu (nanoseconds)**.
-4. In the query, set the service filter to `service_name="stress-cpu"`. You should see a tall, narrow flame graph -- mostly tight integer-arithmetic loops inside the `stress` binary -- because `stress-cpu` does nothing but burn CPU.
-5. Change the filter to `service_name="stress-mem"`. The flame graph now splits between CPU stress functions and memory-touching paths (page faults, `memset`-style writes). Switching filters this way is the test for "the eBPF profiler attributes samples to the right container."
+4. In the query, set the service filter to `service_name="stress-cpu"`. You should see a tall, narrow flame graph dominated by `main.cpuLoop` (and the `math/rand` calls it makes) -- because `stress-cpu` does nothing but burn CPU.
+5. Change the filter to `service_name="stress-mem"`. The flame graph now splits between `main.memLoop` and the Go runtime's allocation paths (`runtime.mallocgc`, `runtime.memclrNoHeapPointers`, GC). Switching filters this way is the test for "the eBPF profiler attributes samples to the right container."
 
 You can also open Pyroscope's own UI directly at <http://localhost:4040> and use its service selector for the same comparison.
 

--- a/ebpf-host-profiling/app/go.mod
+++ b/ebpf-host-profiling/app/go.mod
@@ -1,0 +1,3 @@
+module workload
+
+go 1.26

--- a/ebpf-host-profiling/app/main.go
+++ b/ebpf-host-profiling/app/main.go
@@ -1,0 +1,76 @@
+// Command workload is a tiny, dependency-free CPU / memory load generator for
+// the eBPF host-profiling scenario. It ships with the scenario so the demo
+// owns its workload rather than pulling a third-party stress image, and it
+// builds from the official, multi-arch golang image so the flame graph shows
+// real native frames on both amd64 and arm64 (Apple Silicon).
+//
+// Usage: workload <cpu|mem>
+//
+//	cpu -- tight arithmetic loops; flame graph dominated by main.cpuLoop.
+//	mem -- repeated 1 MiB allocations + writes; flame graph splits between
+//	       main.memLoop and the Go runtime allocation/memclr paths.
+package main
+
+import (
+	"fmt"
+	"math/rand"
+	"os"
+	"time"
+)
+
+// cpuLoop burns CPU in a tight arithmetic loop. eBPF samples land almost
+// entirely in main.cpuLoop, giving a tall, narrow flame graph.
+func cpuLoop() {
+	x := 0.0
+	for {
+		for i := 0; i < 5_000_000; i++ {
+			x += float64(rand.Intn(100)) * 1.000001
+			if x > 1e9 {
+				x = 0
+			}
+		}
+		// Brief yield so the scheduler stays responsive without
+		// meaningfully lowering CPU usage.
+		time.Sleep(time.Millisecond)
+	}
+}
+
+// memLoop keeps allocating and writing 1 MiB chunks while holding a rolling
+// 128 MiB working set. The constant allocation + page touching makes the
+// flame graph split between main.memLoop and runtime allocation/memclr,
+// visibly different from the pure-CPU workload.
+func memLoop() {
+	const chunkSize = 1024 * 1024 // 1 MiB
+	const maxChunks = 128         // ~128 MiB working set
+	var ring [][]byte
+	for {
+		chunk := make([]byte, chunkSize)
+		for i := range chunk {
+			chunk[i] = byte(i)
+		}
+		ring = append(ring, chunk)
+		if len(ring) > maxChunks {
+			ring = ring[1:]
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+}
+
+func main() {
+	mode := ""
+	if len(os.Args) > 1 {
+		mode = os.Args[1]
+	}
+
+	switch mode {
+	case "cpu":
+		fmt.Println("workload: cpu — tight arithmetic loops")
+		cpuLoop()
+	case "mem":
+		fmt.Println("workload: mem — rolling 128 MiB allocations")
+		memLoop()
+	default:
+		fmt.Fprintln(os.Stderr, "usage: workload <cpu|mem>")
+		os.Exit(2)
+	}
+}

--- a/ebpf-host-profiling/config.alloy
+++ b/ebpf-host-profiling/config.alloy
@@ -1,0 +1,38 @@
+livedebugging {
+	enabled = true
+}
+
+// Discover Docker containers on the host so the eBPF profiler knows
+// which processes belong to which workload.
+discovery.docker "local_containers" {
+	host = "unix:///var/run/docker.sock"
+}
+
+// Turn the raw Docker container name (e.g. "/stress-cpu") into a clean
+// `service_name` label so the Pyroscope UI groups samples per workload.
+// The `__meta_docker_container_id` label is preserved automatically and
+// is what `pyroscope.ebpf` uses to map kernel samples back to a container.
+discovery.relabel "containers" {
+	targets = discovery.docker.local_containers.targets
+
+	rule {
+		source_labels = ["__meta_docker_container_name"]
+		regex         = "/(.*)"
+		target_label  = "service_name"
+	}
+}
+
+// Host-wide eBPF CPU profiler. Runs in the Alloy container, attaches
+// perf events in the host kernel, and emits stack samples for every
+// process it can see (because the container shares the host PID namespace).
+pyroscope.ebpf "default" {
+	targets    = discovery.relabel.containers.output
+	forward_to = [pyroscope.write.default.receiver]
+}
+
+// Push the collected profiles to the local Pyroscope server.
+pyroscope.write "default" {
+	endpoint {
+		url = "http://pyroscope:4040"
+	}
+}

--- a/ebpf-host-profiling/docker-compose.coda.yml
+++ b/ebpf-host-profiling/docker-compose.coda.yml
@@ -1,0 +1,12 @@
+services:
+  stress-cpu:
+    image: polinux/stress@sha256:b6144f84f9c15dac80deb48d3a646b55c7043ab1d83ea0a697c09097aaad21aa
+    container_name: stress-cpu
+    command: ["stress", "--cpu", "2"]
+    restart: unless-stopped
+
+  stress-mem:
+    image: polinux/stress@sha256:b6144f84f9c15dac80deb48d3a646b55c7043ab1d83ea0a697c09097aaad21aa
+    container_name: stress-mem
+    command: ["stress", "--cpu", "1", "--vm", "1", "--vm-bytes", "128M"]
+    restart: unless-stopped

--- a/ebpf-host-profiling/docker-compose.coda.yml
+++ b/ebpf-host-profiling/docker-compose.coda.yml
@@ -1,12 +1,18 @@
 services:
   stress-cpu:
-    image: polinux/stress@sha256:b6144f84f9c15dac80deb48d3a646b55c7043ab1d83ea0a697c09097aaad21aa
+    image: golang:1.26@sha256:2981696eed011d747340d7252620932677929cce7d2d539602f56a8d7e9b660b
     container_name: stress-cpu
-    command: ["stress", "--cpu", "2"]
+    volumes:
+      - ./app:/app
+    working_dir: /app
+    command: go run . cpu
     restart: unless-stopped
 
   stress-mem:
-    image: polinux/stress@sha256:b6144f84f9c15dac80deb48d3a646b55c7043ab1d83ea0a697c09097aaad21aa
+    image: golang:1.26@sha256:2981696eed011d747340d7252620932677929cce7d2d539602f56a8d7e9b660b
     container_name: stress-mem
-    command: ["stress", "--cpu", "1", "--vm", "1", "--vm-bytes", "128M"]
+    volumes:
+      - ./app:/app
+    working_dir: /app
+    command: go run . mem
     restart: unless-stopped

--- a/ebpf-host-profiling/docker-compose.yml
+++ b/ebpf-host-profiling/docker-compose.yml
@@ -52,19 +52,29 @@ services:
     depends_on:
       - pyroscope
 
-  # Sample workload #1: CPU stressor. Burns CPU in tight integer loops —
-  # the flame graph should be dominated by stress's hogcpu functions.
+  # Sample workload #1: CPU stressor. Runs our own dependency-free Go load
+  # generator (./app) in CPU mode — tight arithmetic loops, so the flame
+  # graph is dominated by main.cpuLoop. Built from the official, multi-arch
+  # golang image, so it runs natively on amd64 and arm64 (Apple Silicon)
+  # and the flame graph shows real frames rather than QEMU emulation.
   stress-cpu:
-    image: polinux/stress@sha256:b6144f84f9c15dac80deb48d3a646b55c7043ab1d83ea0a697c09097aaad21aa
+    image: golang:1.26@sha256:2981696eed011d747340d7252620932677929cce7d2d539602f56a8d7e9b660b
     container_name: stress-cpu
-    command: ["stress", "--cpu", "2"]
+    volumes:
+      - ./app:/app
+    working_dir: /app
+    command: go run . cpu
     restart: unless-stopped
 
-  # Sample workload #2: mixed CPU + memory stressor. Allocates and writes
-  # to a 128 MiB region while also running a CPU stressor so its flame
-  # graph differs from `stress-cpu`.
+  # Sample workload #2: memory stressor. Same Go app in memory mode —
+  # repeated 1 MiB allocations + writes with a rolling 128 MiB working set,
+  # so its flame graph splits between main.memLoop and the Go runtime's
+  # allocation/memclr paths and looks visibly different from stress-cpu.
   stress-mem:
-    image: polinux/stress@sha256:b6144f84f9c15dac80deb48d3a646b55c7043ab1d83ea0a697c09097aaad21aa
+    image: golang:1.26@sha256:2981696eed011d747340d7252620932677929cce7d2d539602f56a8d7e9b660b
     container_name: stress-mem
-    command: ["stress", "--cpu", "1", "--vm", "1", "--vm-bytes", "128M"]
+    volumes:
+      - ./app:/app
+    working_dir: /app
+    command: go run . mem
     restart: unless-stopped

--- a/ebpf-host-profiling/docker-compose.yml
+++ b/ebpf-host-profiling/docker-compose.yml
@@ -1,0 +1,70 @@
+services:
+  # Pyroscope: continuous profiling backend and UI
+  pyroscope:
+    image: grafana/pyroscope:${GRAFANA_PYROSCOPE_VERSION:-2.0.1}
+    ports:
+      - 4040:4040
+
+  # Grafana: visualize flame graphs via the Pyroscope datasource
+  grafana:
+    image: grafana/grafana:${GRAFANA_VERSION:-13.0.1}
+    environment:
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_BASIC_ENABLED=false
+    ports:
+      - 3000:3000/tcp
+    entrypoint:
+      - sh
+      - -euc
+      - |
+        mkdir -p /etc/grafana/provisioning/datasources
+        cat <<EOF > /etc/grafana/provisioning/datasources/ds.yaml
+        apiVersion: 1
+        datasources:
+        - name: Pyroscope
+          type: grafana-pyroscope-datasource
+          access: proxy
+          orgId: 1
+          url: http://pyroscope:4040
+          basicAuth: false
+          isDefault: true
+          version: 1
+          editable: false
+        EOF
+        /run.sh
+    depends_on:
+      - pyroscope
+
+  # Alloy with pyroscope.ebpf. Needs the host PID namespace to see other
+  # containers' processes, privileged mode to load eBPF programs and read
+  # kernel symbols, and the Docker socket for container discovery.
+  alloy:
+    image: grafana/alloy:${GRAFANA_ALLOY_VERSION:-v1.16.1}
+    privileged: true
+    pid: host
+    ports:
+      - 12345:12345
+    volumes:
+      - ./config.alloy:/etc/alloy/config.alloy
+      - /var/run/docker.sock:/var/run/docker.sock
+    command: run --server.http.listen-addr=0.0.0.0:12345 --storage.path=/var/lib/alloy/data /etc/alloy/config.alloy
+    depends_on:
+      - pyroscope
+
+  # Sample workload #1: CPU stressor. Burns CPU in tight integer loops —
+  # the flame graph should be dominated by stress's hogcpu functions.
+  stress-cpu:
+    image: polinux/stress@sha256:b6144f84f9c15dac80deb48d3a646b55c7043ab1d83ea0a697c09097aaad21aa
+    container_name: stress-cpu
+    command: ["stress", "--cpu", "2"]
+    restart: unless-stopped
+
+  # Sample workload #2: mixed CPU + memory stressor. Allocates and writes
+  # to a 128 MiB region while also running a CPU stressor so its flame
+  # graph differs from `stress-cpu`.
+  stress-mem:
+    image: polinux/stress@sha256:b6144f84f9c15dac80deb48d3a646b55c7043ab1d83ea0a697c09097aaad21aa
+    container_name: stress-mem
+    command: ["stress", "--cpu", "1", "--vm", "1", "--vm-bytes", "128M"]
+    restart: unless-stopped


### PR DESCRIPTION
Closes #104.

Adds a new scenario, `ebpf-host-profiling/`, that demonstrates host-wide CPU profiling with `pyroscope.ebpf` -- no language agents, no `pprof` endpoints, no application code changes. Complements the existing `continuous-profiling/` (Go-specific `pyroscope.scrape`).

## What's in the scenario

- `config.alloy` (≤45 lines): `discovery.docker` → `discovery.relabel` (container name → `service_name`) → `pyroscope.ebpf` → `pyroscope.write`.
- `docker-compose.yml`: Pyroscope + Grafana (with Pyroscope datasource auto-provisioned) + Alloy (with `privileged: true`, `pid: host`, Docker socket mount) + two `polinux/stress` workloads:
  - `stress-cpu` — `stress --cpu 2`, pure CPU integer loops.
  - `stress-mem` — `stress --cpu 1 --vm 1 --vm-bytes 128M`, mixed CPU + memory writes; the flame graph splits visibly differently from `stress-cpu`.
- `docker-compose.coda.yml` — workload-only file for the `coda` CLI / `-f` workflow.
- `README.md` — prerequisites (real Linux host required, kernel 5.4+), step-by-step run, what the user should see in Grafana, why each compose setting is needed, customize section.
- Root `README.md` updated to list the scenario under Profiling.
- No `image-versions.env` change required — `polinux/stress` is SHA-pinned in-place, matching the existing `otel-examples/host-metrics` pattern.

## Verification

Spun the stack up end-to-end in this environment:

- All five containers start cleanly with `docker compose --env-file ../image-versions.env up -d`.
- Pyroscope `/ready` and Alloy `/-/ready` both return 200; Grafana auto-provisions the Pyroscope datasource.
- `discovery.docker` + `discovery.relabel.containers` produce the expected targets, each carrying `service_name=stress-cpu` and `service_name=stress-mem` derived from the container name.
- `pyroscope.write.default` and the discovery components are healthy in the Alloy UI.

Note: I could not confirm end-to-end flame graphs in the verification environment because it is a nested Docker container — `pyroscope.ebpf` fails with `failed to adjust rlimit: operation not permitted` regardless of `privileged: true`, because the outer container doesn't grant real `CAP_SYS_RESOURCE`. This is the documented nested-container limitation and is called out in the README's Prerequisites. On a normal Linux host the configuration matches the [official `pyroscope.ebpf` Docker docs](https://grafana.com/docs/pyroscope/latest/configure-client/grafana-alloy/ebpf/setup-docker/) and should produce flame graphs within ~30 seconds.

## Test plan

- [ ] Run `./run-example.sh ebpf-host-profiling` on a real Linux host (kernel ≥ 5.4).
- [ ] Open <http://localhost:3000> → Explore → Pyroscope → `process_cpu` profile, filter `service_name="stress-cpu"`; confirm a tall flame graph dominated by stress's CPU loops.
- [ ] Switch the filter to `service_name="stress-mem"`; confirm the flame graph splits between CPU stress and memory write paths.
- [ ] Confirm `pyroscope.ebpf.default` shows healthy in <http://localhost:12345>.
- [ ] `docker compose down` cleans up all five containers.
