### PR TITLE
Add MongoDB monitoring scenario (prometheus.exporter.mongodb)

### DIFF
--- a/.github/scenario-list.txt
+++ b/.github/scenario-list.txt
@@ -14,6 +14,7 @@ logs-file
 logs-tcp
 mail-house
 memcached-monitoring
+mongodb-monitoring
 mysql-monitoring
 nginx-monitoring
 otel-basic-tracing

--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ These scenarios monitor databases and in-memory caches.
 | -------- | ----------- |
 | [Elasticsearch monitoring](elasticsearch-monitoring/) | Monitor Elasticsearch cluster health, node status, and performance metrics. |
 | [Memcached monitoring](memcached-monitoring/) | Monitor Memcached instance metrics, including connections, memory usage, and command performance. |
+| [MongoDB monitoring](mongodb-monitoring/) | Monitor MongoDB op-counters, connection pool, and replica-set replication metrics with `prometheus.exporter.mongodb`. Runs a single-node replica set with an insert load generator. |
 | [MySQL monitoring](mysql-monitoring/) | Monitor MySQL database server metrics and performance indicators. |
 | [PostgreSQL monitoring](postgres-monitoring/) | Monitor PostgreSQL transaction statistics, connections, and server configuration. |
 | [RabbitMQ monitoring](rabbitmq-monitoring/) | Monitor RabbitMQ queue, connection, and channel metrics plus broker container logs. |

--- a/mongodb-monitoring/README.md
+++ b/mongodb-monitoring/README.md
@@ -1,0 +1,54 @@
+# MongoDB Monitoring with Grafana Alloy
+
+This scenario demonstrates how to monitor a MongoDB database using Grafana Alloy's `prometheus.exporter.mongodb` component. Alloy scrapes MongoDB metrics and remote-writes them to Prometheus, which Grafana queries for visualization.
+
+MongoDB runs as a single-node **replica set** so that replication and oplog metrics are exposed alongside the op-counter and connection-pool metrics. A small load generator continuously inserts documents so the op-counters keep incrementing.
+
+## Prerequisites
+
+- Docker and Docker Compose installed
+
+## Getting Started
+
+```bash
+git clone https://github.com/grafana/alloy-scenarios.git
+cd alloy-scenarios/mongodb-monitoring
+docker compose up -d
+```
+
+## Access Points
+
+| Service    | URL                          |
+|------------|------------------------------|
+| Grafana    | http://localhost:3000        |
+| Alloy UI   | http://localhost:12345       |
+| Prometheus | http://localhost:9090        |
+| MongoDB    | mongodb://localhost:27017    |
+
+## What to Expect
+
+Once the stack is running, Alloy connects to the MongoDB instance and exposes metrics via the `prometheus.exporter.mongodb` component. These metrics are scraped every 15 seconds and forwarded to Prometheus using remote write.
+
+Alloy embeds the Percona `mongodb_exporter`. The component's `compatible_mode` and `collect_all` arguments both default to `true`, so the legacy metric names (for example `mongodb_op_counters_total`) are emitted alongside the modern `mongodb_ss_*` names, and every collector — including replica-set status — is enabled.
+
+Open Grafana at http://localhost:3000, navigate to **Explore**, select the **Prometheus** datasource, and try these queries:
+
+| What you're watching | Query |
+|----------------------|-------|
+| Insert throughput (op-counters) | `rate(mongodb_op_counters_total{type="insert"}[1m])` |
+| Current open connections | `mongodb_connections{state="current"}` |
+| Replica-set member state (1 = primary) | `mongodb_mongod_replset_my_state` |
+| Replica-set member count | `mongodb_mongod_replset_number_of_members` |
+| Oplog window (seconds) | `mongodb_mongod_replset_oplog_head_timestamp - mongodb_mongod_replset_oplog_tail_timestamp` |
+
+The `mongo-load` container inserts a document into `alloy.events` every second, so `mongodb_op_counters_total{type="insert"}` climbs steadily — this is the scenario's success signal.
+
+> **Note on replication metrics:** replica-set metrics (`mongodb_mongod_replset_*`) only appear when MongoDB runs as a replica set — a standalone `mongod` does not expose them. This scenario runs a single-member replica set, which surfaces the member state, member count, and oplog window shown above. The per-member replication-lag series `mongodb_mongod_replset_member_replication_lag` is only emitted for **secondary** members, so it does not appear with a single member; add a secondary `mongod` to the set to observe real lag.
+
+You can also inspect the Alloy pipeline at http://localhost:12345 to verify that the exporter, scrape, and remote write components are healthy. Live debugging is enabled for real-time pipeline inspection.
+
+## Stopping the Scenario
+
+```bash
+docker compose down
+```

--- a/mongodb-monitoring/config.alloy
+++ b/mongodb-monitoring/config.alloy
@@ -1,0 +1,42 @@
+// ###############################
+// #### Metrics Configuration ####
+// ###############################
+
+// Enable live debugging for the Alloy UI.
+livedebugging {
+	enabled = true
+}
+
+// Expose MongoDB metrics using the built-in prometheus.exporter.mongodb
+// component, which embeds the Percona mongodb_exporter.
+//
+// direct_connect talks straight to the single node. compatible_mode and
+// collect_all both default to true in Alloy and are set explicitly here so the
+// config is self-documenting:
+//   - compatible_mode emits the legacy metric names (e.g.
+//     mongodb_op_counters_total, mongodb_connections) alongside the modern
+//     mongodb_ss_* names.
+//   - collect_all enables every collector, including replica-set status, which
+//     produces the replication metrics (mongodb_mongod_replset_*). These only
+//     appear when MongoDB runs as a replica set, not as a standalone node.
+prometheus.exporter.mongodb "default" {
+	mongodb_uri     = "mongodb://mongo:27017/"
+	direct_connect  = true
+	compatible_mode = true
+	collect_all     = true
+}
+
+// Scrape the MongoDB exporter targets every 15 seconds.
+prometheus.scrape "mongodb" {
+	targets    = prometheus.exporter.mongodb.default.targets
+	forward_to = [prometheus.remote_write.default.receiver]
+
+	scrape_interval = "15s"
+}
+
+// Send the scraped metrics to the local Prometheus instance via remote write.
+prometheus.remote_write "default" {
+	endpoint {
+		url = "http://prometheus:9090/api/v1/write"
+	}
+}

--- a/mongodb-monitoring/docker-compose.coda.yml
+++ b/mongodb-monitoring/docker-compose.coda.yml
@@ -1,0 +1,51 @@
+services:
+  mongo:
+    image: mongo:8@sha256:a706cb4e493bcd0262f345b3b0c78732ca0e54301f0d7bbe2b66f26313ce7ccb
+    hostname: mongo
+    command: ["mongod", "--replSet", "rs0", "--bind_ip_all"]
+    ports:
+      - "27017:27017"
+    healthcheck:
+      test: ["CMD", "mongosh", "--quiet", "--eval", "db.runCommand({ ping: 1 }).ok"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 20s
+
+  # Initiates a single-node replica set (so replication/oplog metrics are
+  # exposed), then continuously inserts documents so the op-counters
+  # (mongodb_op_counters_total{type="insert"}) keep incrementing.
+  mongo-load:
+    image: mongo:8@sha256:a706cb4e493bcd0262f345b3b0c78732ca0e54301f0d7bbe2b66f26313ce7ccb
+    depends_on:
+      mongo:
+        condition: service_healthy
+    restart: unless-stopped
+    entrypoint:
+      - bash
+      - -c
+      - |
+        # Initiate the replica set once. Idempotent: a re-run after a restart
+        # simply logs "already initialized" and continues.
+        mongosh --host mongo --quiet --eval '
+          try {
+            rs.initiate({ _id: "rs0", members: [{ _id: 0, host: "mongo:27017" }] })
+          } catch (e) {
+            print("replica set already initiated: " + e.codeName)
+          }
+        '
+        # Wait until this node has been elected the writable primary.
+        until mongosh --host mongo --quiet --eval 'db.hello().isWritablePrimary' | grep -q true; do
+          echo "waiting for primary..."
+          sleep 1
+        done
+        echo "primary ready - generating insert load"
+        # Insert a document every second into alloy.events. This loop must run
+        # for the life of the container: it drives the op-counters AND keeps the
+        # container alive (an exit would trip CI's no-exited-containers check).
+        while true; do
+          mongosh --host mongo --quiet alloy --eval '
+            db.events.insertOne({ at: new Date(), value: Math.random(), source: "alloy-demo" })
+          ' >/dev/null
+          sleep 1
+        done

--- a/mongodb-monitoring/docker-compose.yml
+++ b/mongodb-monitoring/docker-compose.yml
@@ -1,0 +1,99 @@
+services:
+  mongo:
+    image: mongo:8@sha256:a706cb4e493bcd0262f345b3b0c78732ca0e54301f0d7bbe2b66f26313ce7ccb
+    hostname: mongo
+    command: ["mongod", "--replSet", "rs0", "--bind_ip_all"]
+    ports:
+      - "27017:27017"
+    healthcheck:
+      test: ["CMD", "mongosh", "--quiet", "--eval", "db.runCommand({ ping: 1 }).ok"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 20s
+
+  # Initiates a single-node replica set (so replication/oplog metrics are
+  # exposed), then continuously inserts documents so the op-counters
+  # (mongodb_op_counters_total{type="insert"}) keep incrementing.
+  mongo-load:
+    image: mongo:8@sha256:a706cb4e493bcd0262f345b3b0c78732ca0e54301f0d7bbe2b66f26313ce7ccb
+    depends_on:
+      mongo:
+        condition: service_healthy
+    restart: unless-stopped
+    entrypoint:
+      - bash
+      - -c
+      - |
+        # Initiate the replica set once. Idempotent: a re-run after a restart
+        # simply logs "already initialized" and continues.
+        mongosh --host mongo --quiet --eval '
+          try {
+            rs.initiate({ _id: "rs0", members: [{ _id: 0, host: "mongo:27017" }] })
+          } catch (e) {
+            print("replica set already initiated: " + e.codeName)
+          }
+        '
+        # Wait until this node has been elected the writable primary.
+        until mongosh --host mongo --quiet --eval 'db.hello().isWritablePrimary' | grep -q true; do
+          echo "waiting for primary..."
+          sleep 1
+        done
+        echo "primary ready - generating insert load"
+        # Insert a document every second into alloy.events. This loop must run
+        # for the life of the container: it drives the op-counters AND keeps the
+        # container alive (an exit would trip CI's no-exited-containers check).
+        while true; do
+          mongosh --host mongo --quiet alloy --eval '
+            db.events.insertOne({ at: new Date(), value: Math.random(), source: "alloy-demo" })
+          ' >/dev/null
+          sleep 1
+        done
+
+  prometheus:
+    image: prom/prometheus:${PROMETHEUS_VERSION:-v3.11.3}
+    command:
+      - --web.enable-remote-write-receiver
+      - --config.file=/etc/prometheus/prometheus.yml
+    volumes:
+      - ./prom-config.yaml:/etc/prometheus/prometheus.yml
+    ports:
+      - "9090:9090"
+
+  grafana:
+    image: grafana/grafana:${GRAFANA_VERSION:-13.0.1}
+    environment:
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_BASIC_ENABLED=false
+    ports:
+      - 3000:3000/tcp
+    entrypoint:
+      - sh
+      - -euc
+      - |
+        mkdir -p /etc/grafana/provisioning/datasources
+        cat <<EOF > /etc/grafana/provisioning/datasources/ds.yaml
+        apiVersion: 1
+        datasources:
+        - name: Prometheus
+          type: prometheus
+          orgId: 1
+          url: http://prometheus:9090
+          basicAuth: false
+          isDefault: true
+          version: 1
+          editable: false
+        EOF
+        /run.sh
+
+  alloy:
+    image: grafana/alloy:${GRAFANA_ALLOY_VERSION:-v1.16.1}
+    ports:
+      - 12345:12345
+    volumes:
+      - ./config.alloy:/etc/alloy/config.alloy
+    command: run --server.http.listen-addr=0.0.0.0:12345 --storage.path=/var/lib/alloy/data /etc/alloy/config.alloy
+    depends_on:
+      mongo:
+        condition: service_healthy

--- a/mongodb-monitoring/prom-config.yaml
+++ b/mongodb-monitoring/prom-config.yaml
@@ -1,0 +1,3 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s


### PR DESCRIPTION
Closes #96. Adds a self-contained `mongodb-monitoring` scenario, rounding out the database lineup alongside Postgres/MySQL/Redis/Memcached.

## What it does

Alloy scrapes a MongoDB instance with the built-in `prometheus.exporter.mongodb` component and remote-writes the metrics to Prometheus, which Grafana queries via Explore.

```
prometheus.exporter.mongodb  →  prometheus.scrape  →  prometheus.remote_write
```

MongoDB runs as a **single-node replica set** so the replication/oplog metric family is exposed alongside the op-counter and connection metrics. A small `mongo-load` service (official `mongo` image) initiates the replica set and inserts a document every second so the op-counters keep climbing.

## Files

| File | Purpose |
|------|---------|
| `config.alloy` | Exporter → scrape → remote_write (43 lines, `alloy fmt`/`validate` clean) |
| `docker-compose.yml` | `mongo` + `mongo-load` + Prometheus + Grafana + Alloy |
| `docker-compose.coda.yml` | Coda app subset (`mongo` + `mongo-load`) |
| `prom-config.yaml` | Minimal Prometheus dev config |
| `README.md` | Walkthrough + Explore queries |

Also registered in the main `README.md` table and `.github/scenario-list.txt` (so `validate-scenarios.yml` boots it).

## Meets the success criteria

> Prometheus query for `mongodb_op_counters_total{type="insert"}` increments after running an insert load.

Verified on a live local run — the counter climbed **19 → 43 over 30s** (rate ≈ 0.78/s). Also confirmed present:

- **Connection pool:** `mongodb_connections{state="current"}`
- **Replica set:** `mongodb_mongod_replset_my_state`, `..._number_of_members`, oplog head/tail window

`compatible_mode` and `collect_all` (both default `true` in Alloy, which embeds percona/mongodb_exporter v0.47.2) are set explicitly so the config is self-documenting — `compatible_mode` is what emits the legacy `mongodb_op_counters_total` name the issue references.

## Notes

- **Replication lag:** the per-member `mongodb_mongod_replset_member_replication_lag` series is only emitted for **secondary** members, so it does not appear with a single member — the README documents this and how to extend the set. Replica-set metrics never appear on a standalone `mongod`.
- **Image:** `mongo:8` pinned by digest (multi-arch incl. linux/arm64 — native on Apple Silicon), matching the sibling DB scenarios' convention.
- **CI:** the insert load lives in a long-running loop (not a one-shot init container) so it never trips `validate-scenarios.yml`'s no-exited-containers gate; `${VAR:-default}` fallbacks match `image-versions.env`.

## Test plan

```bash
cd mongodb-monitoring && docker compose up -d
# Grafana → Explore → Prometheus:
#   rate(mongodb_op_counters_total{type="insert"}[1m])   # > 0 and climbing
```