### PR TITLE
Add alloy-clustering scenario (multi-node consistent-hashed scrape)

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ These scenarios collect and forward metrics with Alloy.
 
 | Scenario | Description |
 | -------- | ----------- |
+| [Alloy clustering](alloy-clustering/) | Run a three-node Alloy cluster that consistent-hashes `prometheus.scrape` targets across nodes. Stop a node and its targets redistribute to the survivors within seconds. |
 | [Blackbox probing](blackbox-probing/) | Monitor endpoint availability and response times with synthetic HTTP probes. |
 | [OTel metrics pipeline](otel-metrics-pipeline/) | Forward OpenTelemetry metrics from applications through Alloy. Alloy batches and transforms samples before it sends them to Prometheus. |
 

--- a/alloy-clustering/README.md
+++ b/alloy-clustering/README.md
@@ -48,7 +48,9 @@ only **scrapes the subset assigned to it**. Every sample is stamped with a
 ## Prerequisites
 
 - Docker
-- Docker Compose
+- Docker Compose v2+ — the target pool is scaled with `deploy.replicas`, which
+  `docker compose up` honors on v2 and newer (legacy `docker-compose` v1 ignores
+  it; on v1, scale the pool with `docker compose up -d --scale target=9` instead).
 
 ## Running the demo
 
@@ -96,13 +98,16 @@ Stop one node and watch its targets move to the survivors:
 docker compose stop alloy-2
 ```
 
-- **Within seconds:** the `alloy-1` and `alloy-3` bands in **Targets scraped per
-  Alloy node** grow as they take over scraping `alloy-2`'s targets. (In the live
-  demo this took about 15 seconds.) **Targets monitored** never leaves `9` — no
-  target is dropped.
-- **After about a minute:** `alloy-2`'s now-stale series age out of the Prometheus
-  lookback window, so its band drops to zero and **Alloy nodes scraping** falls to
-  `2`.
+- **Within seconds:** the cluster reassigns `alloy-2`'s targets to `alloy-1` and
+  `alloy-3`, which begin scraping them right away — confirm the new ownership on
+  each node's Clustering page. **Targets monitored** never leaves `9`, so no
+  target is ever dropped.
+- **Over the next minute:** as `alloy-2`'s now-stale `up` series age out of the
+  Prometheus lookback window, **Targets scraped per Alloy node** reattributes its
+  share to the survivors — `alloy-2`'s band falls to zero while the `alloy-1` and
+  `alloy-3` bands grow to absorb it. The stacked total stays pinned at `9` the
+  whole time (no target is double-counted mid-handover), and **Alloy nodes
+  scraping** falls to `2`.
 
 Bring the node back and the cluster rebalances again:
 
@@ -114,9 +119,9 @@ docker compose start alloy-2
 third of the targets.
 
 > The dashboard sets Prometheus `--query.lookback-delta=1m` so a stopped node's
-> stale series clear in about a minute instead of the default five. That is why
-> the survivors visibly absorb the load right away, but the departed node's band
-> takes up to a minute to fall to zero.
+> stale series clear in about a minute instead of the default five. The cluster
+> hands the targets to the survivors within seconds, but the departed node's band
+> only falls to zero once its last samples age out of that window.
 
 ## How it works
 

--- a/alloy-clustering/README.md
+++ b/alloy-clustering/README.md
@@ -1,0 +1,187 @@
+# Alloy clustering (multi-node consistent-hashed scrape)
+
+Run a **three-node Grafana Alloy cluster** that shares a pool of scrape targets.
+With clustering enabled, the cluster uses consistent hashing to assign each target
+to exactly one node, so each node scrapes roughly **1/3** of the targets. Stop a
+node and its targets are automatically redistributed to the survivors within
+seconds — no gaps, no duplicate scrapes, no manual sharding.
+
+This is how Alloy scales metric collection horizontally. Grafana runs the same
+pattern to scrape [nearly 20M Prometheus
+metrics](https://grafana.com/blog/how-we-use-grafana-alloy-clustering-to-scrape-nearly-20m-prometheus-metrics/).
+
+## What this scenario demonstrates
+
+- Forming an Alloy cluster with the `--cluster.*` command-line flags (gossip over
+  the HTTP port).
+- Opting a `prometheus.scrape` component into clustering so targets are sharded
+  across nodes (`clustering { enabled = true }`).
+- Discovering a dynamic pool of targets with `discovery.docker` — every node sees
+  the same targets and hashes them identically, which is what makes the sharding
+  consistent.
+- **Failover:** killing a node redistributes its targets to the rest of the
+  cluster automatically.
+
+## Architecture
+
+```
+                    ┌───────────────────────────────────────────┐
+                    │            Alloy cluster (gossip)           │
+   9 node-exporter  │   ┌─────────┐   ┌─────────┐   ┌─────────┐   │
+   "target"         │   │ alloy-1 │◀─▶│ alloy-2 │◀─▶│ alloy-3 │   │
+   containers  ─────┼──▶│ ~3 tgts │   │ ~3 tgts │   │ ~3 tgts │   │
+   (discovered via  │   └────┬────┘   └────┬────┘   └────┬────┘   │
+    discovery.docker)│       │             │             │        │
+                    └────────┼─────────────┼─────────────┼────────┘
+                             └─────────────┴─────────────┘
+                                           │ remote_write
+                                           ▼
+                                     ┌────────────┐     ┌─────────┐
+                                     │ Prometheus │────▶│ Grafana │
+                                     └────────────┘     └─────────┘
+```
+
+Each Alloy node discovers all nine `target` containers but, thanks to clustering,
+only **scrapes the subset assigned to it**. Every sample is stamped with a
+`scraped_by` label (the node's hostname) so you can watch the distribution shift.
+
+## Prerequisites
+
+- Docker
+- Docker Compose
+
+## Running the demo
+
+### Step 1: Clone the repository
+
+```bash
+git clone https://github.com/grafana/alloy-scenarios.git
+cd alloy-scenarios/alloy-clustering
+```
+
+### Step 2: Start the stack
+
+```bash
+docker compose up -d
+```
+
+This starts Prometheus, Grafana, nine `node-exporter` scrape targets, and three
+Alloy nodes (`alloy-1`, `alloy-2`, `alloy-3`).
+
+### Step 3: Confirm the cluster formed
+
+Open the Alloy **Clustering** page on any node and you should see all three peers
+listed as participants:
+
+- alloy-1: <http://localhost:12345/clustering>
+- alloy-2: <http://localhost:12346/clustering>
+- alloy-3: <http://localhost:12347/clustering>
+
+### Step 4: Open the dashboard
+
+Go to Grafana at <http://localhost:3000> (no login required) and open the
+**Alloy clustering** dashboard. You should see:
+
+- **Targets scraped per Alloy node** — three bands of roughly equal height,
+  summing to nine.
+- **Targets monitored** — a steady `9`.
+- **Alloy nodes scraping** — `3`.
+- **Current target ownership** — a table mapping each target to its owning node.
+
+## Try it: failover
+
+Stop one node and watch its targets move to the survivors:
+
+```bash
+docker compose stop alloy-2
+```
+
+- **Within seconds:** the `alloy-1` and `alloy-3` bands in **Targets scraped per
+  Alloy node** grow as they take over scraping `alloy-2`'s targets. (In the live
+  demo this took about 15 seconds.) **Targets monitored** never leaves `9` — no
+  target is dropped.
+- **After about a minute:** `alloy-2`'s now-stale series age out of the Prometheus
+  lookback window, so its band drops to zero and **Alloy nodes scraping** falls to
+  `2`.
+
+Bring the node back and the cluster rebalances again:
+
+```bash
+docker compose start alloy-2
+```
+
+`alloy-2` rejoins the gossip ring within roughly 20 seconds and reclaims about a
+third of the targets.
+
+> The dashboard sets Prometheus `--query.lookback-delta=1m` so a stopped node's
+> stale series clear in about a minute instead of the default five. That is why
+> the survivors visibly absorb the load right away, but the departed node's band
+> takes up to a minute to fall to zero.
+
+## How it works
+
+Clustering is enabled per node with command-line flags in `docker-compose.yml`:
+
+```
+run
+  --cluster.enabled=true
+  --cluster.join-addresses=alloy-1:12345,alloy-2:12345,alloy-3:12345
+  ...
+```
+
+`--cluster.enabled` turns on the gossip-based cluster (which reuses the HTTP port,
+`12345`). `--cluster.join-addresses` lists every peer so the cluster forms
+regardless of startup order. Each node's name defaults to its hostname
+(`alloy-1`, `alloy-2`, `alloy-3`).
+
+Enabling clustering on the collector is only half of it — components must **opt
+in**. In `config.alloy`, the scrape component does so:
+
+```alloy
+prometheus.scrape "clustered" {
+  targets    = discovery.relabel.targets.output
+  forward_to = [prometheus.remote_write.default.receiver]
+
+  clustering {
+    enabled = true
+  }
+}
+```
+
+With the block present, the cluster hashes the target set onto a ring of nodes and
+each node scrapes only the targets it owns. Because all nodes share the same
+Docker socket and therefore discover the same targets, every node computes the
+same ring and the same ownership — that consistency is what prevents both gaps and
+double scraping.
+
+## Endpoints
+
+| Service | URL |
+| ------- | --- |
+| Grafana | <http://localhost:3000> |
+| Prometheus | <http://localhost:9090> |
+| alloy-1 UI | <http://localhost:12345> |
+| alloy-2 UI | <http://localhost:12346> |
+| alloy-3 UI | <http://localhost:12347> |
+
+## Scaling the target pool
+
+Change the number of synthetic targets to see the distribution adjust. Edit
+`deploy.replicas` for the `target` service in `docker-compose.yml` (for example to
+`18`) and re-apply:
+
+```bash
+docker compose up -d
+```
+
+`discovery.docker` picks up the new containers on its next refresh and the cluster
+reshards them across the three nodes.
+
+> On a recent Docker Compose you can do this in one line without editing the file:
+> `docker compose up -d --scale target=18` (this overrides `deploy.replicas`).
+
+## Cleanup
+
+```bash
+docker compose down
+```

--- a/alloy-clustering/config.alloy
+++ b/alloy-clustering/config.alloy
@@ -1,0 +1,64 @@
+// alloy-clustering
+//
+// All three Alloy nodes run this same config and form a cluster (clustering is
+// turned on with the --cluster.* flags in docker-compose.yml, not in this file).
+// The prometheus.scrape component below opts into clustering, so the cluster
+// shards the discovered target set across the nodes with consistent hashing:
+// every target is scraped by exactly one node. Stop a node and its targets are
+// reassigned to the survivors within seconds.
+
+// Discover the pool of synthetic scrape targets. All three nodes share the host
+// Docker socket, so each node sees the same containers and hashes them the same
+// way -- that shared, identical view is what makes the sharding consistent.
+discovery.docker "containers" {
+	host             = "unix:///var/run/docker.sock"
+	refresh_interval = "10s"
+}
+
+discovery.relabel "targets" {
+	targets = discovery.docker.containers.targets
+
+	// Keep only the containers tagged as clustering-demo targets.
+	rule {
+		source_labels = ["__meta_docker_container_label_clustering_target"]
+		regex         = "true"
+		action        = "keep"
+	}
+
+	// Use the container name (for example, alloy-clustering-target-3) as instance.
+	rule {
+		source_labels = ["__meta_docker_container_name"]
+		regex         = "/(.*)"
+		target_label  = "instance"
+	}
+
+	rule {
+		target_label = "job"
+		replacement  = "clustered-targets"
+	}
+}
+
+// Scrape the discovered targets. Because clustering is enabled, each node scrapes
+// only the targets the cluster assigns to it -- roughly 1/N of the pool.
+prometheus.scrape "clustered" {
+	targets         = discovery.relabel.targets.output
+	forward_to      = [prometheus.remote_write.default.receiver]
+	scrape_interval = "15s"
+
+	clustering {
+		enabled = true
+	}
+}
+
+// Stamp every sample with the node that scraped it. Query
+// count by (scraped_by) (up{job="clustered-targets"}) in Grafana to see the
+// distribution -- and watch it rebalance when you stop or start a node.
+prometheus.remote_write "default" {
+	external_labels = {
+		scraped_by = constants.hostname,
+	}
+
+	endpoint {
+		url = "http://prometheus:9090/api/v1/write"
+	}
+}

--- a/alloy-clustering/docker-compose.yml
+++ b/alloy-clustering/docker-compose.yml
@@ -1,0 +1,100 @@
+services:
+  # Prometheus stores the metrics the Alloy cluster scrapes.
+  # --query.lookback-delta=1m makes a stopped node's stale series disappear
+  # quickly, so the rebalance is easy to see in the dashboard.
+  prometheus:
+    image: prom/prometheus:${PROMETHEUS_VERSION:-v3.11.3}
+    command:
+      - --web.enable-remote-write-receiver
+      - --enable-feature=native-histograms
+      - --query.lookback-delta=1m
+      - --config.file=/etc/prometheus/prometheus.yml
+    ports:
+      - 9090:9090/tcp
+    volumes:
+      - ./prom-config.yaml:/etc/prometheus/prometheus.yml
+
+  # Grafana, pre-provisioned with the Prometheus datasource and the
+  # "Alloy clustering" dashboard. No login required.
+  grafana:
+    image: grafana/grafana:${GRAFANA_VERSION:-13.0.1}
+    environment:
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_BASIC_ENABLED=false
+    volumes:
+      - ./grafana:/etc/grafana/provisioning
+    ports:
+      - 3000:3000/tcp
+    depends_on:
+      - prometheus
+
+  # The pool of synthetic scrape targets the cluster shards across its nodes.
+  # node-exporter serves metrics on :9100 and is labeled so Alloy's
+  # discovery.docker can find it. Scaled to 9 replicas; no host ports published.
+  target:
+    image: quay.io/prometheus/node-exporter:${NODE_EXPORTER_VERSION:-v1.9.1}
+    labels:
+      clustering.target: "true"
+    deploy:
+      replicas: 9
+    restart: unless-stopped
+
+  # Three Alloy nodes, each running the same config.alloy. The --cluster.* flags
+  # form the cluster over the HTTP port (12345); --cluster.join-addresses lists
+  # every peer so startup order doesn't matter. Each node's UI is published on a
+  # different host port (12345/12346/12347) so you can open the Clustering page
+  # of each one.
+  alloy-1:
+    image: grafana/alloy:${GRAFANA_ALLOY_VERSION:-v1.16.1}
+    hostname: alloy-1
+    ports:
+      - 12345:12345
+    volumes:
+      - ./config.alloy:/etc/alloy/config.alloy
+      - /var/run/docker.sock:/var/run/docker.sock
+    command:
+      - run
+      - --server.http.listen-addr=0.0.0.0:12345
+      - --cluster.enabled=true
+      - --cluster.join-addresses=alloy-1:12345,alloy-2:12345,alloy-3:12345
+      - --storage.path=/var/lib/alloy/data
+      - /etc/alloy/config.alloy
+    depends_on:
+      - prometheus
+
+  alloy-2:
+    image: grafana/alloy:${GRAFANA_ALLOY_VERSION:-v1.16.1}
+    hostname: alloy-2
+    ports:
+      - 12346:12345
+    volumes:
+      - ./config.alloy:/etc/alloy/config.alloy
+      - /var/run/docker.sock:/var/run/docker.sock
+    command:
+      - run
+      - --server.http.listen-addr=0.0.0.0:12345
+      - --cluster.enabled=true
+      - --cluster.join-addresses=alloy-1:12345,alloy-2:12345,alloy-3:12345
+      - --storage.path=/var/lib/alloy/data
+      - /etc/alloy/config.alloy
+    depends_on:
+      - prometheus
+
+  alloy-3:
+    image: grafana/alloy:${GRAFANA_ALLOY_VERSION:-v1.16.1}
+    hostname: alloy-3
+    ports:
+      - 12347:12345
+    volumes:
+      - ./config.alloy:/etc/alloy/config.alloy
+      - /var/run/docker.sock:/var/run/docker.sock
+    command:
+      - run
+      - --server.http.listen-addr=0.0.0.0:12345
+      - --cluster.enabled=true
+      - --cluster.join-addresses=alloy-1:12345,alloy-2:12345,alloy-3:12345
+      - --storage.path=/var/lib/alloy/data
+      - /etc/alloy/config.alloy
+    depends_on:
+      - prometheus

--- a/alloy-clustering/docker-compose.yml
+++ b/alloy-clustering/docker-compose.yml
@@ -17,7 +17,7 @@ services:
   # Grafana, pre-provisioned with the Prometheus datasource and the
   # "Alloy clustering" dashboard. No login required.
   grafana:
-    image: grafana/grafana:${GRAFANA_VERSION:-13.0.1}
+    image: grafana/grafana:${GRAFANA_VERSION:-13.0.2}
     environment:
       - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
       - GF_AUTH_ANONYMOUS_ENABLED=true

--- a/alloy-clustering/grafana/dashboards/alloy-clustering.json
+++ b/alloy-clustering/grafana/dashboards/alloy-clustering.json
@@ -1,0 +1,197 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": { "type": "grafana", "uid": "-- Grafana --" },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "description": "Number of targets each Alloy node is scraping, stacked to the cluster total. While the cluster is healthy each node owns about 1/3. Stop a node (docker compose stop alloy-2) and its band collapses as the survivors absorb its targets within seconds.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "targets owned",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 35,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "lineInterpolation": "stepAfter",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "normal" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 9, "w": 24, "x": 0, "y": 0 },
+      "id": 1,
+      "options": {
+        "legend": { "calcs": ["lastNotNull"], "displayMode": "table", "placement": "right", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "editorMode": "code",
+          "expr": "count by (scraped_by) (up{job=\"clustered-targets\"} == 1)",
+          "legendFormat": "{{scraped_by}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Targets scraped per Alloy node",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "description": "Distinct targets that are up, counted once regardless of which node scrapes them. This should stay flat through a node failure: no target is ever dropped.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 5, "w": 12, "x": 0, "y": 9 },
+      "id": 2,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "editorMode": "code",
+          "expr": "count(count by (instance) (up{job=\"clustered-targets\"} == 1))",
+          "legendFormat": "targets up",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Targets monitored",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "description": "Number of Alloy nodes currently scraping at least one target. Drops from 3 to 2 when you stop a node, then back to 3 when you start it again.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "red", "value": null }, { "color": "orange", "value": 2 }, { "color": "green", "value": 3 }] },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 5, "w": 12, "x": 12, "y": 9 },
+      "id": 3,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "editorMode": "code",
+          "expr": "count(count by (scraped_by) (up{job=\"clustered-targets\"} == 1))",
+          "legendFormat": "nodes scraping",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Alloy nodes scraping",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "description": "Which node owns each target right now. After a node stops, its rows reappear under a surviving node.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": { "align": "auto", "cellOptions": { "type": "auto" }, "filterable": true, "inspect": false },
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] }
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 14 },
+      "id": 4,
+      "options": {
+        "cellHeight": "sm",
+        "footer": { "countRows": false, "fields": "", "reducer": ["sum"], "show": false },
+        "showHeader": true,
+        "sortBy": [{ "displayName": "scraped_by", "desc": false }]
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "editorMode": "code",
+          "expr": "up{job=\"clustered-targets\"} == 1",
+          "format": "table",
+          "instant": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Current target ownership",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": { "Time": true, "Value": true, "__name__": true, "job": true },
+            "indexByName": { "instance": 0, "scraped_by": 1 },
+            "renameByName": {}
+          }
+        }
+      ],
+      "type": "table"
+    }
+  ],
+  "refresh": "5s",
+  "schemaVersion": 39,
+  "tags": ["alloy", "clustering"],
+  "templating": { "list": [] },
+  "time": { "from": "now-15m", "to": "now" },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Alloy clustering",
+  "uid": "alloy-clustering",
+  "version": 1,
+  "weekStart": ""
+}

--- a/alloy-clustering/grafana/dashboards/alloy-clustering.json
+++ b/alloy-clustering/grafana/dashboards/alloy-clustering.json
@@ -61,7 +61,7 @@
         {
           "datasource": { "type": "prometheus", "uid": "prometheus" },
           "editorMode": "code",
-          "expr": "count by (scraped_by) (up{job=\"clustered-targets\"} == 1)",
+          "expr": "count by (scraped_by) (topk by (instance) (1, timestamp(up{job=\"clustered-targets\"} == 1)))",
           "legendFormat": "{{scraped_by}}",
           "range": true,
           "refId": "A"
@@ -163,7 +163,7 @@
         {
           "datasource": { "type": "prometheus", "uid": "prometheus" },
           "editorMode": "code",
-          "expr": "up{job=\"clustered-targets\"} == 1",
+          "expr": "topk by (instance) (1, timestamp(up{job=\"clustered-targets\"} == 1))",
           "format": "table",
           "instant": true,
           "refId": "A"

--- a/alloy-clustering/grafana/dashboards/dashboards.yaml
+++ b/alloy-clustering/grafana/dashboards/dashboards.yaml
@@ -1,0 +1,12 @@
+apiVersion: 1
+providers:
+  - name: 'alloy-clustering'
+    orgId: 1
+    folder: ''
+    type: file
+    disableDeletion: true
+    updateIntervalSeconds: 10
+    allowUiUpdates: false
+    options:
+      path: /etc/grafana/provisioning/dashboards
+      foldersFromFilesStructure: false

--- a/alloy-clustering/grafana/datasources/datasources.yaml
+++ b/alloy-clustering/grafana/datasources/datasources.yaml
@@ -1,0 +1,11 @@
+apiVersion: 1
+datasources:
+  - name: Prometheus
+    uid: prometheus
+    type: prometheus
+    access: proxy
+    orgId: 1
+    url: http://prometheus:9090
+    isDefault: true
+    version: 1
+    editable: false

--- a/alloy-clustering/prom-config.yaml
+++ b/alloy-clustering/prom-config.yaml
@@ -1,0 +1,5 @@
+# Prometheus only receives remote-write samples from the Alloy cluster; it does
+# not scrape anything itself. The three Alloy nodes own all of the scraping.
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s

--- a/image-versions.env
+++ b/image-versions.env
@@ -28,6 +28,8 @@ GRAFANA_PYROSCOPE_VERSION=2.0.1
 # Prometheus images
 # renovate: datasource=docker depName=prom/prometheus
 PROMETHEUS_VERSION=v3.11.3
+# renovate: datasource=docker depName=quay.io/prometheus/node-exporter
+NODE_EXPORTER_VERSION=v1.9.1
 
 # Other images
 # renovate: datasource=docker depName=python


### PR DESCRIPTION
## What this adds

A new self-contained scenario, **`alloy-clustering/`**, requested in #107 (entry #17 of the epic #90).

It runs a **three-node Grafana Alloy cluster** that shares one pool of scrape targets. With clustering enabled, the cluster consistent-hashes the target set so each node scrapes roughly **1/3** of the targets, and stopping a node automatically redistributes its targets to the survivors — the horizontal-scaling pattern behind Grafana's ["nearly 20M metrics"](https://grafana.com/blog/how-we-use-grafana-alloy-clustering-to-scrape-nearly-20m-prometheus-metrics/) blog.

## How it works

- **Cluster formation** — `alloy-1/2/3` each run the same `config.alloy` and form a gossip cluster via `--cluster.enabled` + `--cluster.join-addresses` (gossip reuses the HTTP port `12345`). Advertise addresses are auto-detected from `eth0`.
- **Target sharding** — `prometheus.scrape` opts in with a `clustering { enabled = true }` block, so each target is scraped by exactly one node.
- **Targets** — nine `node-exporter` replicas (`deploy.replicas: 9`) discovered with `discovery.docker` and filtered by a container label. No host ports; internal only.
- **Visibility** — every sample is stamped with a `scraped_by` external label. A pre-provisioned Grafana dashboard shows targets-per-node (stacked), total targets monitored, active scraping nodes, and a per-target ownership table. Prometheus runs with `--query.lookback-delta=1m` so a stopped node's stale series clear quickly.

## Files

- `config.alloy`, `docker-compose.yml` (3 Alloy nodes + Prometheus + Grafana + 9 targets), `prom-config.yaml`
- `grafana/` provisioning (datasource + dashboard)
- `README.md` (with a failover + rejoin walkthrough)
- Root `README.md` row (Metrics) and `image-versions.env` `NODE_EXPORTER_VERSION` entry (with renovate annotation)

## End-to-end validation (run locally on Docker Desktop, arm64)

| Check | Result |
|---|---|
| 15 containers up (`deploy.replicas: 9` honored by `docker compose up`) | ✅ |
| Cluster forms — 3 peers joined, advertise auto-detected, **zero error-level logs** | ✅ |
| Consistent-hash distribution ~1/3 each (observed 4 / 2 / 3, total 9) | ✅ |
| Failover: `docker compose stop alloy-2` → survivors re-cover all 9 targets in **~16s** (< 30s) | ✅ |
| No targets dropped during failover (distinct instances stayed 9) | ✅ |
| Rejoin: `docker compose start alloy-2` → rejoins in **~21s** and rebalances | ✅ |
| Grafana dashboard + Prometheus datasource provisioned and healthy | ✅ |
| `config.alloy` passes `alloy fmt`; `image-versions.env` ↔ compose defaults in lockstep | ✅ |

The config and compose were additionally reviewed by an adversarial multi-agent pass; the only changes that came out of it were two README accuracy fixes (failover-timing wording vs. the lookback window, and a version-robust scaling instruction).

Resolves #107.