### PR TITLE
Fix logs-tcp simulator startup race against Alloy

### DIFF
--- a/logs-tcp/simulator.py
+++ b/logs-tcp/simulator.py
@@ -12,13 +12,31 @@ target_port = int(os.getenv('TARGET_PORT', 5140))
 # Define the endpoint path
 endpoint_path = "/loki/api/v1/raw"
 
-# Create a TCP socket
-sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-try:
-    sock.connect((target_host, target_port))
-except socket.error as e:
-    print(f"Failed to connect to {target_host}:{target_port} - {e}")
-    exit(1)
+
+def connect_with_retry():
+    """Open a TCP connection to Alloy, retrying until it is ready.
+
+    `depends_on` in docker-compose only waits for the Alloy container to
+    start, not for its loki.source.api listener to bind port 9999. Without
+    a retry the simulator races Alloy on boot, hits "Connection refused",
+    and exits — so retry with backoff until the listener is up.
+    """
+    delay = 1
+    while True:
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        try:
+            sock.connect((target_host, target_port))
+            print(f"Connected to {target_host}:{target_port}")
+            return sock
+        except socket.error as e:
+            sock.close()
+            print(f"Waiting for {target_host}:{target_port} - {e}; retrying in {delay}s")
+            time.sleep(delay)
+            delay = min(delay * 2, 10)  # exponential backoff, capped at 10s
+
+
+# Create a TCP socket, waiting for Alloy to become available
+sock = connect_with_retry()
 
 # Define log levels and messages
 log_levels = ["INFO", "WARNING", "ERROR", "DEBUG", "CRITICAL"]
@@ -81,8 +99,12 @@ while True:
         sock.sendall(http_request.encode())
         print(f"Sent JSON log message to {target_host}:{target_port} - {log_json}")
     except socket.error as e:
-        print(f"Failed to send log message - {e}")
-        break
+        # The connection dropped (e.g. Alloy restarted or reloaded its
+        # config). Reconnect and keep going rather than exiting.
+        print(f"Failed to send log message - {e}; reconnecting")
+        sock.close()
+        sock = connect_with_retry()
+        continue
 
     # Wait for a few seconds before sending the next message
     time.sleep(random.randint(3, 8))  # Send a message every 3-8 seconds


### PR DESCRIPTION
## What

The `logs-tcp` smoke test fails intermittently on `validate-scenarios` (seen on [PR #177's run](https://github.com/grafana/alloy-scenarios/actions/runs/27136679730/job/80090968161?pr=177)). The failing step is **Verify no exited containers**, and the cause is the `simulator` container exiting with:

```
simulator | Failed to connect to alloy:9999 - [Errno 111] Connection refused
```

## Root cause

`logs-tcp/simulator.py` opened a single TCP connection to `alloy:9999` at startup and called `exit(1)` on failure. In docker-compose, `depends_on: alloy` only waits for the Alloy *container* to start — not for its `loki.source.api` listener to bind port `9999`. So the simulator can win the boot race, get `Connection refused`, and exit. The smoke test's `docker compose ps --status exited` check then trips.

This is a pre-existing race, not caused by the Renovate alloy bump in #177 — that PR just happened to trigger this scenario's validation and lose the race. Opening this as a standalone fix off `main`; once merged, #177 (and any future scenario PR) can be re-run and will pass.

## Fix

- **Retry the initial connection** with exponential backoff (1s → 2s → … capped at 10s) until Alloy's listener is up, instead of exiting on first failure.
- **Reconnect on send failure** rather than `break`ing out of the loop, so the simulator also survives an Alloy restart / config reload (which would otherwise leave the container `exited` and trip the same check).

## Verification

- Isolated test: started the simulator against a closed port, opened a listener after a delay — it retried (`1s`, `2s`, `4s`), connected once listening, and delivered an HTTP POST.
- Full scenario boot (`./run-example.sh logs-tcp`): Grafana health probe returns `200`, all four containers (`alloy`, `grafana`, `loki`, `simulator`) stay `running`, and `docker compose ps --status exited` is empty — the exact assertion the smoke test makes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)