### PR TITLE
Fix kafka scenario: migrate from removed bitnami/kafka to apache/kafka

### DIFF
--- a/kafka/README.md
+++ b/kafka/README.md
@@ -23,7 +23,7 @@ Ensure you have the following:
 ```
 
 - **Kafka producer**: The `kafka-producer` service runs `gen_log.sh` and publishes JSON log entries to the `alloy-logs` topic every two seconds.
-- **Kafka**: A single-node KRaft broker that runs the `bitnami/kafka:3.8` image and stores messages in the `alloy-logs` topic.
+- **Kafka**: A single-node KRaft broker that runs the official `apache/kafka` image and stores messages in the `alloy-logs` topic.
 - **Alloy**: Consumes messages from the Kafka topic, parses and restructures the JSON payload, and forwards processed entries to Loki.
 - **Loki**: Stores the processed log entries.
 - **Grafana**: Visualizes the logs.

--- a/kafka/config.alloy
+++ b/kafka/config.alloy
@@ -22,7 +22,7 @@ loki.process "log_data" {
 
 
   stage.json {
-    drop_malformed = true,
+    drop_malformed = true
     expressions = {
       level = "",
       msg   = "",

--- a/kafka/docker-compose.coda.yml
+++ b/kafka/docker-compose.coda.yml
@@ -1,31 +1,36 @@
 services:
   kafka:
-    image: 'bitnami/kafka:3.8'
+    image: apache/kafka:4.2.0@sha256:9516fb7634bad307d17c33b589fde9023003b0cb761374f500002b980a3149b9
     ports:
       - "9092:9092"
     volumes:
-      - kafka_data:/bitnami/kafka
+      - kafka_data:/var/lib/kafka
     environment:
-       #KRaft must
-      - KAFKA_CFG_NODE_ID=0
-      - KAFKA_CFG_PROCESS_ROLES=controller,broker
-      - KAFKA_CFG_CONTROLLER_QUORUM_VOTERS=0@kafka:9093
-      - KAFKA_CFG_LISTENERS=PLAINTEXT://:9092,CONTROLLER://:9093
-      - KAFKA_CFG_ADVERTISED_LISTENERS=PLAINTEXT://kafka:9092
-      - KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP=CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT
-      - KAFKA_CFG_CONTROLLER_LISTENER_NAMES=CONTROLLER
+       # KRaft single-node combined broker + controller
+      - KAFKA_NODE_ID=0
+      - KAFKA_PROCESS_ROLES=broker,controller
+      - KAFKA_CONTROLLER_QUORUM_VOTERS=0@kafka:9093
+      - KAFKA_LISTENERS=PLAINTEXT://:9092,CONTROLLER://:9093
+      - KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://kafka:9092
+      - KAFKA_LISTENER_SECURITY_PROTOCOL_MAP=CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT
+      - KAFKA_CONTROLLER_LISTENER_NAMES=CONTROLLER
+      - KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=1
+      - KAFKA_LOG_DIRS=/var/lib/kafka/data
+      - CLUSTER_ID=alloy-kafka-logs-cluster-001
     healthcheck:
-      test: ["CMD", "kafka-topics.sh", "--bootstrap-server", "localhost:9092", "--version"]
+      test: ["CMD", "/opt/kafka/bin/kafka-topics.sh", "--bootstrap-server", "localhost:9092", "--list"]
       interval: 10s
       timeout: 10s
       retries: 5
 
   kafka-producer:
-    image: 'bitnami/kafka:3.8'
+    image: apache/kafka:4.2.0@sha256:9516fb7634bad307d17c33b589fde9023003b0cb761374f500002b980a3149b9
     volumes:
       - ./gen_log.sh:/bin/gen_log.sh
-      - kafka_data:/bitnami/kafka
     entrypoint: ["sh", "-c", "/bin/gen_log.sh"]
+    depends_on:
+      kafka:
+        condition: service_healthy
 
 volumes:
   kafka_data:

--- a/kafka/docker-compose.yml
+++ b/kafka/docker-compose.yml
@@ -48,7 +48,12 @@ services:
       - ./logs:/temp/logs
     command: run --server.http.listen-addr=0.0.0.0:12345 --stability.level=experimental  --storage.path=/var/lib/alloy/data /etc/alloy/config.alloy
     depends_on:
-      - loki
+      loki:
+        condition: service_started
+      # loki.source.kafka builds its client at config-load time, so the broker
+      # must be reachable before Alloy starts or the initial load fails fatally.
+      kafka:
+        condition: service_healthy
 
   loki:
     image: grafana/loki:${GRAFANA_LOKI_VERSION:-3.6.10}

--- a/kafka/docker-compose.yml
+++ b/kafka/docker-compose.yml
@@ -3,33 +3,37 @@ version: '3.8'
 services:
   # kafka server instance
   kafka:
-    image: 'bitnami/kafka:3.8'
+    image: apache/kafka:4.2.0@sha256:9516fb7634bad307d17c33b589fde9023003b0cb761374f500002b980a3149b9
     ports:
       - "9092:9092"
     volumes:
-      - kafka_data:/bitnami/kafka
+      - kafka_data:/var/lib/kafka
 
     environment:
-       #KRaft must
-      - KAFKA_CFG_NODE_ID=0
-      - KAFKA_CFG_PROCESS_ROLES=controller,broker
-      - KAFKA_CFG_CONTROLLER_QUORUM_VOTERS=0@kafka:9093
-      - KAFKA_CFG_LISTENERS=PLAINTEXT://:9092,CONTROLLER://:9093
-      - KAFKA_CFG_ADVERTISED_LISTENERS=PLAINTEXT://kafka:9092
-      - KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP=CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT
-      - KAFKA_CFG_CONTROLLER_LISTENER_NAMES=CONTROLLER
+       # KRaft single-node combined broker + controller
+      - KAFKA_NODE_ID=0
+      - KAFKA_PROCESS_ROLES=broker,controller
+      - KAFKA_CONTROLLER_QUORUM_VOTERS=0@kafka:9093
+      - KAFKA_LISTENERS=PLAINTEXT://:9092,CONTROLLER://:9093
+      - KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://kafka:9092
+      - KAFKA_LISTENER_SECURITY_PROTOCOL_MAP=CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT
+      - KAFKA_CONTROLLER_LISTENER_NAMES=CONTROLLER
+      - KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR=1
+      - KAFKA_LOG_DIRS=/var/lib/kafka/data
+      - CLUSTER_ID=alloy-kafka-logs-cluster-001
     healthcheck:
-      test: ["CMD", "kafka-topics.sh", "--bootstrap-server", "localhost:9092", "--version"]
+      test: ["CMD", "/opt/kafka/bin/kafka-topics.sh", "--bootstrap-server", "localhost:9092", "--list"]
       interval: 10s
       timeout: 10s
       retries: 5
   kafka-producer:
-    image: 'bitnami/kafka:3.8'
+    image: apache/kafka:4.2.0@sha256:9516fb7634bad307d17c33b589fde9023003b0cb761374f500002b980a3149b9
     volumes:
       - ./gen_log.sh:/bin/gen_log.sh
-      - kafka_data:/bitnami/kafka
-    # change cmd 
     entrypoint: ["sh", "-c", "/bin/gen_log.sh"]
+    depends_on:
+      kafka:
+        condition: service_healthy
 
     
 

--- a/kafka/gen_log.sh
+++ b/kafka/gen_log.sh
@@ -24,6 +24,6 @@ while true; do
   printf '{"level":"%s","msg":"%s","app":{"name":"%s","version":"%s"}}\n' \
     "$level" "$msg" "$app" "$version"
   sleep 2
-done | kafka-console-producer.sh \
+done | /opt/kafka/bin/kafka-console-producer.sh \
     --bootstrap-server kafka:9092 \
     --topic alloy-logs


### PR DESCRIPTION
## Why

CI fails on the `kafka` scenario with:

```
Error response from daemon: manifest for bitnami/kafka:3.8 not found: manifest unknown
```

Broadcom **retired the public `bitnami/*` Docker Hub catalog**, so `bitnami/kafka:3.8` no longer resolves. This is the *same* break that PR #39 fixed for `otel-examples/kafka-buffer` by moving to the official `apache/kafka` image — but the top-level **`kafka` scenario was never migrated**, so it still pointed at the dead image. That's why it looked "already fixed" but wasn't.

## What

Migrate both `kafka` and `kafka-producer` to `apache/kafka:4.2.0` (identical pin to kafka-buffer, so renovate bumps all occurrences together) and adapt the config for the official image:

- `KAFKA_CFG_*` → `KAFKA_*` env vars (apache drops the `_CFG_` infix); add `KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR`, `KAFKA_LOG_DIRS`, `CLUSTER_ID`.
- Mount `kafka_data` at `/var/lib/kafka` (appuser-owned in the image — avoids the root-owned-volume permission trap) instead of bitnami's `/bitnami/kafka`.
- Call CLI tools by full path (`/opt/kafka/bin/...`) in the healthcheck and `gen_log.sh` — apache/kafka doesn't put them on `PATH`.
- Healthcheck is now a real readiness probe (`--list`), and `kafka-producer` waits on `kafka` being `service_healthy`.

### Also: a second, masked bug

The image-pull failure was hiding a **pre-existing `config.alloy` syntax error** — a trailing comma after `drop_malformed = true` inside the `stage.json` block (commas only separate map-literal entries, not block attributes) crashes Alloy on load. Without fixing it, the CI smoke test's **"no exited containers"** gate would still fail once the image pulls, because Alloy would exit. Fixed here too.

## Testing

Docker-tested end-to-end locally (Docker 29.5.3, arm64):

- `kafka` reaches **healthy**; `kafka-producer` starts only after that and publishes to `alloy-logs`.
- Alloy loads `config.alloy` cleanly (no errors) and its two-pass JSON pipeline delivers restructured lines into Loki:
  ```
  {"level":"error","msg":"High memory usage detected ...","app_name":"auth","app_version":"0.0.51"}
  ```
- Both CI gates pass locally: **no exited containers**, and `docker compose config --images` resolves every image to a real, pullable reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)