### PR TITLE
Fix mongodb-monitoring Grafana version drift

### DIFF
--- a/mongodb-monitoring/docker-compose.yml
+++ b/mongodb-monitoring/docker-compose.yml
@@ -61,7 +61,7 @@ services:
       - "9090:9090"
 
   grafana:
-    image: grafana/grafana:${GRAFANA_VERSION:-13.0.1}
+    image: grafana/grafana:${GRAFANA_VERSION:-13.0.2}
     environment:
       - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
       - GF_AUTH_ANONYMOUS_ENABLED=true


### PR DESCRIPTION
## What

Bump the Grafana image fallback in `mongodb-monitoring/docker-compose.yml` from `13.0.1` to `13.0.2` to match `image-versions.env`.

## Why

`check-image-versions` has been **failing on `main`** since #173 merged. That PR added `mongodb-monitoring/docker-compose.yml` with `${GRAFANA_VERSION:-13.0.1}`, but renovate had already bumped `GRAFANA_VERSION=13.0.2` in `image-versions.env` and in every other compose file — so this lone fallback drifted out of lockstep.

The failing run on `main` ([b83f56f](https://github.com/grafana/alloy-scenarios/actions/runs/27221118391)) reports exactly one drift:

```
${GRAFANA_VERSION:-13.0.1} should be ${GRAFANA_VERSION:-13.0.2}
```

Because the check runs against the PR *merge* commit, this also turns every open PR red (e.g. #179). This one-line fix restores lockstep and greens `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)