### PR TITLE
game-of-tracing: harden game logic, deepen OTel curriculum, sync UI to server state

### DIFF
--- a/game-of-tracing/AGENTS.md
+++ b/game-of-tracing/AGENTS.md
@@ -124,17 +124,25 @@ Incoming requests extract W3C trace context from headers; outgoing requests inje
 ctx = extract(request.headers)
 with tracer.start_as_current_span("name", context=ctx, ...) as span:
 
-# Outgoing (canonical helper at app/location_server.py:327-352):
+# Outgoing (canonical helper at app/location_server.py:762-820):
 inject(headers)
-requests.post(url, headers=headers, ...)
+requests.post(url, headers=headers, timeout=(3, 10), ...)
 ```
+
+The HTTP client helpers (`_make_request_with_trace` in `app/`, `make_api_request` in `war_map/` and `ai_opponent/`) use the **OTel HTTP semantic conventions** for attribute names — `url.full`, `http.request.method`, `http.response.status_code` — so convention-aware tooling (Tempo service-graph details, Grafana drilldowns) works without custom mapping. `_make_request_with_trace` also retries transport errors exactly once (2 s backoff, `retry_attempted` span event); duplicate deliveries are absorbed by `/receive_army`'s movement-id idempotency cache (see "Game-state integrity" below).
+
+### Baggage carries game context across every hop
+
+The services propagate **W3C Baggage** alongside the trace context. `war_map` sets `game.session.id`, `player.faction`, and `game.actor` via the `game_baggage()` context manager (`war_map/app.py:45`) before starting each player-action span; the AI sets `game.actor="ai"` + its faction per decision cycle. The default propagator injects/extracts the `baggage` HTTP header automatically — no per-service code.
+
+Baggage is *not* written to spans by itself. Each service's `telemetry.py` registers a small `BaggageSpanProcessor` that copies an **allow-list** of baggage keys onto every span at start (mirrors the contrib `opentelemetry-processor-baggage`; reimplemented inline so the demo carries no extra dependency). Net effect: TraceQL like `{span.game.session.id="<id>"}` matches a player action's entire downstream cascade — including the 5 s-delayed background-thread spans, because `get_current()` captures baggage too. The allow-list matters: in an internet-facing system the baggage header is caller-controlled, so copying it wholesale would let clients inject attributes into your telemetry.
 
 ### Background threads MUST capture context explicitly
 
 Python threads do not inherit OpenTelemetry context. The scenario's canonical pattern is to capture before spawning and attach inside the thread:
 
 ```python
-# app/location_server.py:209-271 (_continue_army_movement) — canonical example:
+# app/location_server.py:562-660 (_continue_army_movement) — canonical example:
 ctx = get_current()
 
 def move():
@@ -148,7 +156,23 @@ def move():
 Thread(target=move).start()
 ```
 
-The same pattern appears in `_transfer_resources_along_path` at `app/location_server.py:273-325`. If a background span shows up with a missing or different `trace_id`, the `get_current()` / `attach` / `detach` pair is the first thing to check.
+The same pattern appears in `_forward_resources` at `app/location_server.py:662-760`. If a background span shows up with a missing or different `trace_id`, the `get_current()` / `attach` / `detach` pair is the first thing to check.
+
+### Span events mark points in time inside a span
+
+Battle resolution in `/receive_army` emits timestamped **span events** — `battle_started`, `casualties_calculated`, `territory_captured` — visible on the Tempo trace timeline. Events differ from attributes: an attribute is a span-wide fact; an event is a point-in-time annotation with its own timestamp. Compensation paths emit `army_returned` / `resources_returned` events, and failed operations call `span.record_exception(e)` (full stack trace as an `exception` event) in addition to `set_status(ERROR)`.
+
+## Game-state integrity (movement, transfers, caps)
+
+The army/resource flows are deliberately written as a miniature distributed-transactions lesson:
+
+- **Debit-at-send.** `/move_army`, `/all_out_attack`, and resource sends debit the source *before* the 5 s in-flight delay, using guarded SQL (`UPDATE ... WHERE army = ?` / `WHERE resources >= ?`) so two concurrent requests can't dispatch the same units twice (optimistic concurrency; conflicting request gets a 409).
+- **Compensation.** If delivery fails at the *transport* level, the in-flight units are credited back (additively, so refunds compose with reinforcements) with an `army_returned` / `resources_returned` span event. A *lost battle* or a *captured caravan* is a game outcome, not a delivery failure — no refund (the `captured` response flag distinguishes the two).
+- **Idempotency.** Every movement carries a `movement_id` (UUID, also the `game.movement.id` span attribute); `/receive_army` keeps a short-lived per-process dedupe cache so a transport retry can never fight the same battle twice.
+- **Input validation.** `/receive_army` and `/receive_resources` reject non-integer/out-of-range amounts, unknown factions, and non-adjacent `source_location`s (armies only ever arrive from neighbours).
+- **Economy caps.** `rules["max_resources"]` (1000), `rules["max_army"]` (50), `rules["max_corpses"]` (200) in `app/game_config.py`, clamped centrally in `_update_location_state` / `_credit_*` — an idle game can't bank unbounded passive income.
+- **Game-over enforcement.** `war_map` rejects the five player-action endpoints with 409 once a winner is declared (`_reject_if_game_over`, `war_map/app.py:850`) and POSTs `/deactivate` to the AI exactly once (`_deactivate_ai_once`). Location servers stay permissive by design — in-flight movements should still resolve.
+- **Thread resilience.** All passive loops (village generation, barbarian growth, corpse tick, NW capital tick) wrap each iteration in try/except so a transient SQLite error can't kill the economy; `/health` on every location reports per-thread liveness.
 
 ## Span links — the headline feature
 
@@ -157,8 +181,8 @@ Span links are the mechanism that turns a sequence of discrete player actions in
 **Flow:**
 1. Player selects a faction → `war_map/app.py` creates a `game_session_id` (UUID).
 2. Every action handler (`/api/collect_resources`, `/api/create_army`, `/api/move_army`) does:
-   - Looks up the previous action for this session via `get_previous_action_context()` at `war_map/app.py:130-170`. That function reads `trace_id` and `span_id` from the `game_actions` SQLite table and rebuilds a `trace.SpanContext(..., is_remote=True, trace_flags=TraceFlags.SAMPLED)`.
-   - Wraps the context in a link via `create_span_link_from_context()` at `war_map/app.py:172-189`, attaching `link.type="game_sequence"`, `link.relation="follows"`, `game.sequence="true"`.
+   - Looks up the previous action for this session via `get_previous_action_context()` at `war_map/app.py:343`. That function reads `trace_id` and `span_id` from the `game_actions` SQLite table and rebuilds a `trace.SpanContext(..., is_remote=True, trace_flags=TraceFlags.SAMPLED)`.
+   - Wraps the context in a link via `create_span_link_from_context()` at `war_map/app.py:385`, attaching `link.type="game_sequence"`, `link.relation="follows"`, `game.sequence="true"`.
    - Starts its own action span with that link, then calls `store_game_action()` to record its own `trace_id`/`span_id` for the next action to link back to.
 3. The AI opponent uses the same primitive with a different link type — `link.type="ai_decision_trigger"` — to link its decision span to the action execution span it spawns (see `ai_opponent/ai_server.py`).
 4. The replay UI queries Tempo:
@@ -187,11 +211,18 @@ Span links are the mechanism that turns a sequence of discrete player actions in
 | `ai.territory_count` | observable gauge | `faction` |
 | `ai.total_army` | observable gauge | `faction` |
 
-### Span attributes used by the provisioned Grafana dashboard
-Preserve these when adding new spans — the dashboard's TraceQL filters depend on them:
-- `span.resource.movement = true`
-- `span.battle.occurred = true`
-- `span.player.action = true`
+### Span attributes that feed TraceQL queries
+Preserve these when adding or modifying spans — dashboards and the README's example queries depend on them. (TraceQL prefixes span attributes with `span.`; the Python code sets the un-prefixed name.)
+
+| Attribute | Set on | TraceQL |
+|---|---|---|
+| `battle.occurred = true` | every `/receive_army` span that resolves a battle | `{span.battle.occurred=true}` |
+| `player.action = true` | the five war_map player-action SERVER spans | `{span.player.action=true}` |
+| `resource.movement = true` | `resource_movement`, `/receive_resources`, `/send_resources_to_capital` spans | `{span.resource.movement=true}` |
+| `game.session.id` | every span in a player session (stamped from baggage) | `{span.game.session.id="<uuid>"}` |
+| `game.actor` | `"ai"` on every span in an AI decision cascade (from baggage) | `{span.game.actor="ai"}` |
+| `game.movement.id` | every hop/battle span of one army's journey | `{span.game.movement.id="<uuid>"}` |
+| `wall.battle = true` | battles at `wall`-type locations (WWA) | `{span.wall.battle=true}` |
 
 ## Common tasks
 
@@ -226,7 +257,8 @@ docker compose -f docker-compose.yml -f docker-compose-otel.yml up -d
 - **Grafana is auto-provisioned** via `grafana/datasources/defaults.yml`. Tempo is the default datasource; service map, traces-to-logs (Loki `trace_id` label), traces-to-metrics, and exemplars are pre-wired. Do not add datasources via UI — edit the YAML.
 - **Tempo metrics generator is enabled** in `tempo-config.yaml` with processors `service-graphs`, `span-metrics`, `local-blocks`, writing to `prometheus:9090/api/v1/write`. Ingester `max_block_duration: 5m` and 720h compactor retention are demo-tuned, not production values.
 - **`grafana-traces-app` plugin** is installed via `GF_INSTALL_PLUGINS` at container start. If Grafana is slow on first boot, that is why.
-- **`war-map` strips `X-Frame-Options`** in an `@app.after_request` hook (`war_map/app.py:191-194`) so the UI can be embedded in Grafana iframes. Intentional — do not remove.
+- **`war-map` strips `X-Frame-Options`** in an `@app.after_request` hook (`war_map/app.py:404-407`) so the UI can be embedded in Grafana iframes. Intentional — do not remove.
+- **`config.alloy` is a plain pass-through pipeline** (receiver → batch → exporters, no sampling). The `battle.occurred` / `player.action` / `resource.movement` attributes were designed so a tail-sampling policy can be layered in as an exercise — see the README's teaching notes.
 
 ## Keep docs current
 

--- a/game-of-tracing/CLAUDE.md
+++ b/game-of-tracing/CLAUDE.md
@@ -27,9 +27,9 @@ The sub-agent is read-only (no Write/Edit tools) — it reports; the parent agen
 ## Tool preferences
 
 - **Use `Read`, not `cat`**, for the large files in this scenario. Use `offset` / `limit` to target line ranges rather than reading the whole file:
-  - `app/location_server.py` (~52 KB, ~1200 lines)
-  - `ai_opponent/ai_server.py` (~46 KB)
-  - `war_map/app.py` (~64 KB)
+  - `app/location_server.py` (~80 KB, ~1950 lines)
+  - `ai_opponent/ai_server.py` (~48 KB)
+  - `war_map/app.py` (~90 KB)
   - `war_map/templates/map.html` (~50 KB)
   - `war_map/templates/replay_session.html` (~28 KB)
   - `SPAN_LINKS.md` (~17 KB)
@@ -44,7 +44,7 @@ Before editing any service, open these files to ground yourself:
 |---|---|
 | Location server behavior | `app/telemetry.py`, relevant route handler in `app/location_server.py`, `app/game_config.py`, the service block in `docker-compose.yml` |
 | AI decision logic | `ai_opponent/telemetry.py`, `ai_opponent/ai_server.py`, `ai_opponent/README.md` |
-| UI, sessions, or replay | `war_map/telemetry.py`, `war_map/app.py` (especially `:130-189` for span-link plumbing), relevant template under `war_map/templates/` |
+| UI, sessions, or replay | `war_map/telemetry.py`, `war_map/app.py` (especially `:258-402` for span-link plumbing and `:45` for the baggage helper), relevant template under `war_map/templates/` |
 | Telemetry pipeline | `config.alloy` (default) or `config-otel.yaml` (OTel variant), `tempo-config.yaml`, `loki-config.yaml`, `prom-config.yaml` |
 | Datasources / dashboards | `grafana/datasources/defaults.yml`, `grafana/dashboards/*.json` |
 | Image versions | `../image-versions.env` |

--- a/game-of-tracing/README.md
+++ b/game-of-tracing/README.md
@@ -40,9 +40,12 @@ This game teaches several key concepts in distributed tracing:
 
 2. **OpenTelemetry Concepts**
    - Trace context propagation
-   - Span creation and attributes
+   - W3C Baggage (cross-service game context on every span)
+   - Span creation, attributes, and span events
+   - HTTP semantic conventions
    - Service naming and resource attributes
    - Manual instrumentation techniques
+   - Metric exemplars linking metrics to traces
 
 3. **Observability Patterns**
    - Trace sampling strategies
@@ -188,6 +191,29 @@ Learn how services interact:
 - Army movement paths
 - Battle resolution chains
 
+### 3. Baggage: Context That Travels With the Trace
+Trace context tells you *which* trace a span belongs to; **W3C Baggage** lets you carry your own key/values along the same ride. When you click an action, `war-map` sets `game.session.id`, `player.faction`, and `game.actor` as baggage. The default propagator serializes it into the `baggage` HTTP header next to `traceparent` — every downstream location service receives it with zero extra code.
+
+Baggage is not written to spans automatically, though. Each service's `telemetry.py` registers a tiny `BaggageSpanProcessor` that copies an **allow-list** of baggage keys onto every span at start (the same idea as the contrib `opentelemetry-processor-baggage` package). Two details worth teaching:
+
+- It works for the 5-second-delayed background spans too — `get_current()` captures baggage along with the active span, so an `army_movement` span created in a thread still knows its session.
+- The allow-list is deliberate. Baggage headers are caller-controlled; copying them wholesale onto spans would let any client inject attributes into your telemetry.
+
+Try it in Grafana → Explore → Tempo:
+```console
+{span.game.session.id="<your session id>"}
+```
+You'll get the *entire* downstream cascade of your actions — not just the spans `war-map` created. The AI opponent uses the same mechanism with `game.actor="ai"`:
+```console
+{span.game.actor="ai"}
+```
+
+### 4. Span Events: Points in Time Inside a Span
+An attribute describes the whole span; a **span event** is a timestamped annotation inside it. Open any battle trace and look at the `receive_army` span — you'll see `battle_started`, `casualties_calculated`, and (when a location changes hands) `territory_captured` events on the timeline, each with its own attributes. Failure paths use the same mechanism: failed deliveries record the exception (`span.record_exception()` produces an `exception` event with a stack trace) plus an `army_returned` / `resources_returned` event when the game refunds in-flight units.
+
+### 5. Semantic Conventions
+The HTTP client spans use the OpenTelemetry **HTTP semantic conventions** — `url.full`, `http.request.method`, `http.response.status_code` — instead of invented names. Conventions are what let convention-aware tooling (Tempo service-graph details, Grafana drilldowns, vendor dashboards) work on your data without per-app configuration. Game-domain attributes (`battle.occurred`, `game.session.id`, …) are namespaced custom attributes, which is exactly how the conventions intend you to mix standard and domain data.
+
 ## Observability Features
 
 ### 1. Resource Movement Tracing
@@ -207,6 +233,15 @@ Analyze combat events, outcomes, and participating forces.
 {span.player.action = true}
 ```
 Monitor player interactions and their impact on the game state.
+
+### 4. Follow One Army Across Hops
+```console
+{span.game.movement.id = "<uuid>"}
+```
+Every move or all-out attack mints a `movement_id` that is stamped on each hop's movement and battle spans — copy it from any movement span to follow the army's whole journey, including compensation events when a delivery fails and the army marches home.
+
+### 5. Metrics → Trace Exemplars
+The Python services configure a `TraceBasedExemplarFilter`, Prometheus runs with `--enable-feature=exemplar-storage`, and the dashboard panels have exemplars enabled — so metric samples recorded inside a sampled span carry that span's trace ID. On the dashboard, look for the small diamond dots on the battle/army panels: click one → **Query with Tempo** jumps straight from the metric sample to the exact trace that produced it. This closes the loop between the metrics and traces you've been exploring separately.
 
 <!-- INTERACTIVE page step3.md END -->
 

--- a/game-of-tracing/SPAN_LINKS.md
+++ b/game-of-tracing/SPAN_LINKS.md
@@ -239,6 +239,18 @@ Game Start → Collect Resources → Create Army → Move Army → Battle → Vi
 {span.battle.occurred=true}
 ```
 
+#### 7. Follow One Army Across Every Hop
+Every `/move_army` / `/all_out_attack` generates a `movement_id` that is stamped (as `game.movement.id`) on each hop's movement and battle spans:
+```traceql
+{span.game.movement.id="<uuid>"}
+```
+
+#### 8. Separate AI Activity from Human Play
+The AI's decision cycles propagate `game.actor="ai"` via W3C Baggage, stamped onto every downstream span:
+```traceql
+{span.game.actor="ai"}
+```
+
 ### Tempo API Integration
 
 The replay system uses Tempo's HTTP API:

--- a/game-of-tracing/ai_opponent/CLAUDE.md
+++ b/game-of-tracing/ai_opponent/CLAUDE.md
@@ -96,6 +96,12 @@ The AI opponent instruments its own causal chain **inside a single decision cycl
 
 The linking logic lives around `ai_server.py:888-901`. The AI does **not** participate in the cross-session `game_sequence` chain that `war_map` builds — that is player-only.
 
+## Baggage + HTTP client conventions
+
+Each `ai_decision_cycle` sets real W3C Baggage — `game.actor="ai"` and `player.faction=<ai faction>` — at the top of the cycle (`ai_decision_loop` in `ai_server.py`). The `BaggageSpanProcessor` in `telemetry.py` stamps these onto every span of the cycle, *including* spans created by the location services the AI calls (the propagator carries the `baggage` header automatically). TraceQL `{span.game.actor="ai"}` therefore isolates AI activity end-to-end. (Historically this line set a meaningless `context=parent` baggage entry used purely as a context handle — don't reintroduce that.)
+
+`make_api_request` uses OTel HTTP semantic-convention attributes (`url.full`, `http.request.method`, `http.response.status_code`) and a `(3, 10)` connect/read timeout so a hung location server can't freeze the decision loop.
+
 ## Environment
 
 | Var | Default | Purpose |

--- a/game-of-tracing/ai_opponent/ai_server.py
+++ b/game-of-tracing/ai_opponent/ai_server.py
@@ -10,6 +10,7 @@ from telemetry import AITelemetry
 from opentelemetry import trace, baggage
 from opentelemetry.trace import SpanKind, Link
 from opentelemetry.propagate import inject
+from opentelemetry.context import attach, detach, get_current
 from datetime import datetime, timedelta
 from enum import Enum
 
@@ -1269,8 +1270,18 @@ def fetch_faction_corpses(faction):
     except Exception:
         return 0
 
+# (connect, read) timeouts — a hung location server must never freeze the
+# AI decision loop indefinitely.
+REQUEST_TIMEOUT = (3, 10)
+
+
 def make_api_request(location_id, endpoint, method='GET', data=None):
-    """Make an API request to a location server with trace context"""
+    """Make an API request to a location server with trace context.
+
+    Attribute names follow the OTel HTTP semantic conventions (url.full,
+    http.request.method, http.response.status_code) so convention-aware
+    tooling works without custom mapping.
+    """
     url = f"{get_location_url(location_id)}/{endpoint}"
     headers = {"Content-Type": "application/json"}
 
@@ -1280,18 +1291,19 @@ def make_api_request(location_id, endpoint, method='GET', data=None):
         attributes={
             "location.id": location_id,
             "location.endpoint": endpoint,
-            "http.method": method
+            "url.full": url,
+            "http.request.method": method
         }
     ) as span:
         inject(headers)  # Inject trace context
 
         try:
             if method == 'GET':
-                response = requests.get(url, headers=headers)
+                response = requests.get(url, headers=headers, timeout=REQUEST_TIMEOUT)
             else:  # POST
-                response = requests.post(url, json=data, headers=headers)
+                response = requests.post(url, json=data, headers=headers, timeout=REQUEST_TIMEOUT)
 
-            span.set_attribute("http.status_code", response.status_code)
+            span.set_attribute("http.response.status_code", response.status_code)
             response.raise_for_status()
             result = response.json()
 
@@ -1443,6 +1455,17 @@ def ai_decision_loop():
 
     decision_count = 0
 
+    # Attach the AI's identity as W3C Baggage for the lifetime of the loop.
+    # Attaching (not just creating) the context matters: outbound inject()
+    # calls and child spans read the *current* context, so this is what
+    # makes every span in the cascade — including the ones created by the
+    # location services the AI calls — carry game.actor="ai".
+    loop_ctx = baggage.set_baggage("game.actor", "ai")
+    loop_ctx = baggage.set_baggage(
+        "player.faction", ai_state.faction or "unknown", context=loop_ctx
+    )
+    loop_token = attach(loop_ctx)
+
     while ai_state.active and not ai_state.stop_flag.is_set():
         decision_count += 1
 
@@ -1457,7 +1480,12 @@ def ai_decision_loop():
                 "session_start": ai_state.game_start_time.isoformat() if ai_state.game_start_time else None
             }
         ) as cycle_span:
-            parent_ctx = baggage.set_baggage("context", "parent")
+            # Current context = loop baggage (attached above) + the active
+            # cycle span; children created from it parent correctly *and*
+            # get stamped with the AI baggage by the BaggageSpanProcessor.
+            # (This previously set a meaningless `context=parent` baggage
+            # entry that was used purely as a context handle.)
+            parent_ctx = get_current()
             cycle_start_time = time.time()
             try:
                 # Get current game state
@@ -1532,6 +1560,8 @@ def ai_decision_loop():
                 cycle_span.set_status(trace.StatusCode.ERROR, str(e))
                 logger.error("Error in AI decision cycle", extra={"error": str(e), "cycle_number": decision_count})
                 time.sleep(5)
+
+    detach(loop_token)
 
 # ─── Flask Endpoints ───────────────────────────────────────────────────────────
 

--- a/game-of-tracing/ai_opponent/telemetry.py
+++ b/game-of-tracing/ai_opponent/telemetry.py
@@ -1,9 +1,10 @@
 import os
 
 from opentelemetry.sdk.resources import SERVICE_NAME, Resource
-from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace import TracerProvider, SpanProcessor
 from opentelemetry.sdk.trace.export import BatchSpanProcessor
 from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+from opentelemetry import baggage as otel_baggage
 from opentelemetry import trace
 
 # Logging setup
@@ -25,6 +26,32 @@ from typing import Iterable
 # Profiling setup (Pyroscope v2 + OTel span-profile linking)
 import pyroscope
 from pyroscope.otel import PyroscopeSpanProcessor
+
+
+class BaggageSpanProcessor(SpanProcessor):
+    """Copy selected W3C Baggage entries onto every span at start.
+
+    Baggage rides along with the trace context (the default propagator
+    injects/extracts the ``baggage`` HTTP header automatically), but it is
+    **not** written to spans by itself — without this processor the values
+    would cross every service boundary and still be invisible in Tempo.
+    Mirrors the contrib package ``opentelemetry-processor-baggage``;
+    reimplemented in a few lines so the demo carries no extra dependency.
+    Identical copies live in app/, war_map/, and ai_opponent/ telemetry.py
+    (each service is its own Docker build context).
+    """
+
+    # Allow-list, never copy-everything: baggage is caller-controlled in
+    # internet-facing systems, so stamping arbitrary entries onto spans
+    # would let clients inject attributes into your telemetry.
+    ALLOWED_KEYS = ("game.session.id", "player.faction", "game.actor")
+
+    def on_start(self, span, parent_context=None):
+        for key in self.ALLOWED_KEYS:
+            value = otel_baggage.get_baggage(key, parent_context)
+            if value is not None:
+                span.set_attribute(key, str(value))
+
 
 class AITelemetry:
     def __init__(self, service_name="ai-opponent", logging_endpoint="http://alloy:4318", tracing_endpoint="http://alloy:4317", metrics_endpoint="http://alloy:4318"):
@@ -86,6 +113,9 @@ class AITelemetry:
         )
         
         trace.get_tracer_provider().add_span_processor(span_processor)
+        # Stamp allow-listed baggage entries onto every span — see
+        # BaggageSpanProcessor docstring.
+        trace.get_tracer_provider().add_span_processor(BaggageSpanProcessor())
         self.tracer = trace.get_tracer(__name__)
 
     def _setup_profiling(self):

--- a/game-of-tracing/app/CLAUDE.md
+++ b/game-of-tracing/app/CLAUDE.md
@@ -31,9 +31,9 @@ Service names (hyphenated) match the `SERVICE_NAME` resource attribute used in t
 
 | File | Size | Purpose |
 |---|---|---|
-| `game_config.py` | ~3 KB | `LOCATIONS` dict: coordinates, connections, initial resources/army/faction, passive-rate, costs. |
-| `telemetry.py` | ~11 KB | `GameTelemetry` class — traces, logs, metrics (5 observable gauges + 1 counter for game state), plus Pyroscope profiling with OTel span-profile linkage. |
-| `location_server.py` | ~52 KB (~1200 lines) | `LocationServer` class — Flask app, routes, DB access, pathfinding, battle resolution, background-thread movement. |
+| `game_config.py` | ~12 KB | `MAPS` dict: coordinates, connections, initial resources/army/faction, passive-rate, costs, economy caps (`max_resources`/`max_army`/`max_corpses`). |
+| `telemetry.py` | ~13 KB | `GameTelemetry` class — traces, logs, metrics (5 observable gauges + 1 counter for game state), `BaggageSpanProcessor` (stamps allow-listed baggage keys onto every span), plus Pyroscope profiling with OTel span-profile linkage. |
+| `location_server.py` | ~80 KB (~1950 lines) | `LocationServer` class — Flask app, routes, DB access, pathfinding, battle resolution, background-thread movement with debit-at-send + compensation semantics. |
 | `run_game.py` | — | CLI to run all 8 services as separate local processes (non-Docker). |
 | `Dockerfile` | small | `python:3.11-slim`, `pip install -r requirements.txt`, runs `python location_server.py`. |
 | `requirements.txt` | small | Flask 3.1.3, requests 2.33.1, OpenTelemetry SDK/API + OTLP gRPC/HTTP exporters, `pyroscope-io` + `pyroscope-otel` for profiling. |
@@ -45,18 +45,18 @@ Service names (hyphenated) match the `SERVICE_NAME` resource attribute used in t
 | `GET` | `/` | `get_location_info` | Location state + optional cooldown |
 | `POST` | `/collect_resources` | `collect_resources` | Capital-only; 5 s cooldown; +20 resources |
 | `POST` | `/create_army` | `create_army` | Capital-only; costs 30 resources → +1 army unit |
-| `POST` | `/move_army` | `move_army_request` | Move army to adjacent location; spawns background movement thread |
-| `POST` | `/all_out_attack` | `all_out_attack` | Capital-to-capital attack via `_find_path(target, ATTACK)` |
-| `POST` | `/receive_army` | `receive_army` | Target of `_continue_army_movement`; resolves battle via `_handle_battle` |
-| `POST` | `/receive_resources` | `receive_resources` | Target of `_transfer_resources_along_path` |
-| `GET` | `/health` | — | Docker health check; returns `{"status":"ok"}` |
-| `POST` | `/send_resources_to_capital` | — | Village → friendly capital resource forwarding (used by AI) |
+| `POST` | `/move_army` | `move_army_request` | Atomic army debit (409 on conflict); spawns background movement thread with a fresh `movement_id` |
+| `POST` | `/all_out_attack` | `all_out_attack` | Capital-to-capital attack via `_find_path(target, ATTACK)`; same atomic debit + `movement_id` |
+| `POST` | `/receive_army` | `receive_army` | Target of `_continue_army_movement`; validates payload, dedupes by `movement_id`, resolves battle via `_handle_battle` with span events |
+| `POST` | `/receive_resources` | `receive_resources` | Target of `_forward_resources`; validates payload; banks at destination, relays at intermediate hops (no banking), `captured: true` on faction mismatch |
+| `GET` | `/health` | — | Docker health check; returns `{"status": "ok"\|"degraded", "threads": {name: alive}}` with passive-thread liveness |
+| `POST` | `/send_resources_to_capital` | — | Village → friendly capital; guarded debit-at-send, then `_forward_resources` |
 | `POST` | `/reload` | — | Re-read `active_map_id` + rebind slot identity in place (war_map calls this after `/select_map`) |
 | `GET` | `/faction_economy?faction=...` | — | Read a faction's corpse pool (AI uses it) |
 
 ## Key algorithms
 
-### Dijkstra pathfinding — `_find_path()` at `location_server.py:128-182`
+### Dijkstra pathfinding — `_find_path()` at `location_server.py:454`
 
 Faction-aware edge weights:
 
@@ -65,9 +65,11 @@ Faction-aware edge weights:
 | `PathType.RESOURCE` | 1 | 2 | ∞ (unreachable) |
 | `PathType.ATTACK` | 1 | 2 | 3 |
 
-Resource routing only returns a path if the source is a capital of a known faction. Attack routing allows crossing enemy terrain at a cost.
+Resource routing only returns a path for factions with a resource economy. Attack routing allows crossing enemy terrain at a cost.
 
-### Battle resolution — `_handle_battle()` at `location_server.py:184-207`
+**Path convention:** every payload's `remaining_path` holds the hops *after* the receiving location for armies (`remaining_path[0]` is the hop after the receiver), and the receiver-first slice for resources (`remaining_path[0]` is the receiver itself). Both `/all_out_attack` and the `/receive_army` continuation use the army convention — keep them in sync or hops will self-deliver.
+
+### Battle resolution — `_handle_battle()` at `location_server.py:514`
 
 | Case | Outcome | New army | New faction |
 |---|---|---|---|
@@ -76,24 +78,31 @@ Resource routing only returns a path if the source is a capital of a known facti
 | `defending > attacking` | `defender_victory` | `defending - attacking` | defender's |
 | equal | `stalemate` | `0` | defender's (territory held by default) |
 
-Every outcome calls `telemetry.record_battle(attacker_faction, defender_faction, result)`, which increments the `game.battles` counter and force-flushes metrics.
+Every outcome calls `telemetry.record_battle(attacker_faction, defender_faction, result)`, which increments the `game.battles` counter and force-flushes metrics. The `/receive_army` battle span sets `battle.occurred=true` and emits `battle_started` / `casualties_calculated` / `territory_captured` span events around the resolution.
 
-### Atomic state updates — `_update_location_state()`
+### State updates, caps, and guarded debits
 
-Forces metric collection at `location_server.py:124` on important changes (`faction`, `resources`, or `army` mutated), so the dashboard reflects state within ~1 s of the mutating request instead of waiting for the 10 s `PeriodicExportingMetricReader` cycle.
+- `_update_location_state()` (`location_server.py:339`) is the central write path: it clamps `resources`/`army` to the per-map caps (`rules["max_resources"]`, `rules["max_army"]`) and forces metric collection on every mutation, so the dashboard reflects state within ~1 s instead of waiting for the 10 s `PeriodicExportingMetricReader` cycle.
+- `_take_all_army()` (`:384`) — optimistic-concurrency debit (`UPDATE ... WHERE army = ?`); the loser of a race gets a 409.
+- `_credit_army()` / `_credit_resources()` (`:405` / `:440`) — *additive*, capped credits used by delivery and compensation paths, so refunds compose with reinforcements that arrived in the meantime.
+- `_debit_resources()` (`:423`) — guarded debit (`WHERE resources >= ?`) for debit-at-send transfers.
+
+### Movement integrity — debit-at-send, compensation, idempotency
+
+Armies and resources are debited from the source *before* the 5 s in-flight delay. If delivery fails at the transport level, the background thread credits them back (`army_returned` / `resources_returned` span events + span status ERROR). A lost battle or a captured caravan is a **game outcome** — no refund (`/receive_resources` returns `captured: true` so the sender can tell the difference). Every movement carries a `movement_id` (UUID, stamped as `game.movement.id` on every hop's spans); `/receive_army` keeps a 120 s in-memory dedupe cache (`_check_duplicate_movement` at `:885`) so the transport retry in `_make_request_with_trace` can never fight the same battle twice. Inbound payloads are validated by `_validate_inbound_payload` (`:856`): integer bounds, known faction, and `source_location` adjacent to this location.
 
 ## OpenTelemetry patterns specific to `app/`
 
 ### HTTP clients go through one helper
 
-`_make_request_with_trace()` at `location_server.py:327-352` is the only place outbound HTTP happens. It wraps every call in a CLIENT span, sets `http.url` and `http.status_code` attributes, and calls `inject(headers)` to propagate W3C trace context downstream. If you add a new outbound call, use this helper — do not call `requests.post` directly.
+`_make_request_with_trace()` at `location_server.py:762-820` is the only place outbound HTTP happens. It wraps every call in a CLIENT span with **OTel HTTP semantic-convention** attribute names (`url.full`, `http.request.method`, `http.response.status_code`), calls `inject(headers)` to propagate W3C trace context (and baggage) downstream, applies a `(3, 10)` connect/read timeout, and retries transport errors exactly once (2 s backoff, `retry_attempted` span event — safe because `/receive_army` is idempotent on `movement_id`). HTTP 4xx/5xx are not retried. If you add a new outbound call, use this helper — do not call `requests.post` directly.
 
 ### Background threads capture context explicitly
 
 Two methods spawn background threads for delayed operations:
 
-- `_continue_army_movement()` at `location_server.py:209-271` — 5 s delay before the army arrives at the next location.
-- `_transfer_resources_along_path()` at `location_server.py:273-325` — 5 s delay before the resources arrive.
+- `_continue_army_movement()` at `location_server.py:562-660` — 5 s delay before the army arrives; credits the army back to the source on transport failure.
+- `_forward_resources()` at `location_server.py:662-760` — 5 s delay before the resources arrive; credits back on transport failure, but **not** when the response says `captured` (the capturing faction keeps the caravan).
 
 Both follow the canonical pattern:
 
@@ -111,15 +120,21 @@ def work():
 Thread(target=work).start()
 ```
 
-If you add a new background thread, replicate this pattern. Python threads will **not** inherit OTel context on their own — the span will be orphaned with a fresh trace_id.
+If you add a new background thread, replicate this pattern. Python threads will **not** inherit OTel context on their own — the span will be orphaned with a fresh trace_id. Note that `get_current()` captures *baggage* too, which is why delayed movement spans still carry `game.session.id`.
 
-### Span attributes that feed the Grafana dashboard
+### Baggage → span attributes
 
-Preserve these when adding or modifying spans (the provisioned dashboard's TraceQL filters depend on them):
+`telemetry.py` registers a `BaggageSpanProcessor` (`telemetry.py:31`) that copies the allow-listed baggage keys (`game.session.id`, `player.faction`, `game.actor`) onto every span at start. war_map and the AI set the baggage; this service only needs the processor — propagation is automatic via `extract`/`inject`.
 
-- `span.resource.movement = true` — any resource transfer span
-- `span.battle.occurred = true` — any span that triggers `_handle_battle`
-- `span.player.action = true` — any span caused by a human player action
+### Span attributes that feed TraceQL queries
+
+Preserve these when adding or modifying spans (dashboards and the README's example queries depend on them; the Python code sets the un-prefixed name, TraceQL adds the `span.` prefix):
+
+- `resource.movement = true` — any resource transfer span (`resource_movement`, `/receive_resources`, `/send_resources_to_capital`)
+- `battle.occurred = true` — any span that triggers `_handle_battle`
+- `player.action = true` — set by war_map on player-action spans (not by this service)
+- `game.movement.id` — every hop/battle span of one army's journey
+- `wall.battle = true` — battles at `wall`-type locations (WWA)
 
 ## Custom metrics — `telemetry.py`
 
@@ -127,11 +142,11 @@ See `AGENTS.md` for the full cross-service metrics table. `app/`-specific:
 
 | Metric | Type | Callback location in `telemetry.py` |
 |---|---|---|
-| `game.resources` | observable gauge | `_observe_resources` at `:176-193` |
-| `game.army_size` | observable gauge | `_observe_army_size` at `:195-213` |
-| `game.battles` | counter | `record_battle` at `:274-290` |
-| `game.resource_transfer_cooldown` | observable gauge | `_observe_resource_cooldown` at `:215-233` |
-| `game.location_control` | observable gauge | `_observe_location_control` at `:235-260` (values: `northern=1`, `southern=2`, `neutral=0`, unknown=`-1`) |
+| `game.resources` | observable gauge | `_observe_resources` at `:236` |
+| `game.army_size` | observable gauge | `_observe_army_size` at `:254` |
+| `game.battles` | counter | `record_battle` at `:327` |
+| `game.resource_transfer_cooldown` | observable gauge | `_observe_resource_cooldown` at `:273` |
+| `game.location_control` | observable gauge | `_observe_location_control` at `:293` (values: `northern=1`, `southern=2`, `neutral=0`, unknown=`-1`) |
 
 The gauge callbacks read from live server state via `_get_location_state()`, which the `LocationServer` registers on the telemetry instance at construction time.
 
@@ -145,6 +160,9 @@ All defined in `app/game_config.py`'s `MAPS["white_walkers_attack"]["rules"]`. A
 - **Captured-camp resource generation** — `_start_passive_generation()` is launched for *every* `type == "village"` slot at boot (including barbarian Free Folk camps). The per-iteration `faction != "barbarian"` guard keeps it a no-op while the camp is still barbarian, then it starts producing the standard village amount the moment the player captures it. Without this fallthrough, captured camps stayed unproductive because the thread was never started on barbarian slots.
 - **White Walker passive corpses** — `_start_white_walker_corpse_tick(interval_s)` runs at the WW fortress, +1 corpse every `rules["white_walker_passive_corpse_interval_s"]` (15 s).
 - **Night's Watch passive resources** — `_start_nights_watch_capital_resource_tick(interval_s, amount)` runs at Castle Black on WWA (`faction == "nights_watch"`, `loc_type == "capital"`), adding `rules["nights_watch_capital_passive_amount"]` resources every `rules["nights_watch_capital_passive_interval_s"]` (5 per 10 s). Manual `/collect_resources` (+20, 5 s cooldown) still works alongside.
+- **Economy caps** — `rules["max_resources"]` (1000), `rules["max_army"]` (50), `rules["max_corpses"]` (200) on *both* maps; clamped centrally in `_update_location_state` / `_credit_*` / `_add_corpses` so AFK passive income can't break the late game.
+- **Thread resilience** — every passive loop wraps its iteration in try/except (a transient SQLite busy error must not kill the economy permanently), registers itself in `self._passive_threads`, and is surfaced via `/health`'s `threads` map.
+- **Corpse pool seeding** — `reset_database()` (`location_server.py:1095`) re-reads the active map *before* repopulating (war_map writes the new `active_map_id` first, then calls `/reset`) and seeds a zero-corpse `faction_economy` row for every corpse-currency faction, so the AI's `/faction_economy` reads work from t=0.
 
 ## DB additions (live in `game_state.db`)
 
@@ -176,8 +194,9 @@ All defined in `app/game_config.py`'s `MAPS["white_walkers_attack"]["rules"]`. A
 
 **Add a new route.**
 1. Wrap the handler in `tracer.start_as_current_span(..., context=extract(request.headers), ...)`.
-2. Add `"span.player.action": True` (if triggered by a player) so the dashboard picks it up.
-3. If the route spawns a background thread, follow the `get_current()` / `attach` / `detach` pattern from `:209-271`.
+2. Add the relevant TraceQL attribute (`battle.occurred`, `resource.movement`, …) so dashboards pick it up; `player.action` is set by war_map, not here.
+3. If the route spawns a background thread, follow the `get_current()` / `attach` / `detach` pattern from `:562-660`.
+4. If the route accepts state-changing input from a peer, validate it with `_validate_inbound_payload` (or equivalent bounds/faction/adjacency checks).
 
 ## Keep this doc current
 

--- a/game-of-tracing/app/game_config.py
+++ b/game-of-tracing/app/game_config.py
@@ -134,6 +134,13 @@ MAPS = {
             "white_walker_passive_corpse_interval_s": 0,
             "tick_interval_s": 0,
             "win_hold_ticks": 0,
+            # Economy caps — passive generation runs forever, so an idle
+            # game must not bank unbounded resources/armies. Enforced
+            # centrally in location_server's _update_location_state /
+            # _credit_* helpers.
+            "max_resources": 1000,
+            "max_army": 50,
+            "max_corpses": 200,
         },
     },
     "white_walkers_attack": {
@@ -287,6 +294,10 @@ MAPS = {
             "nights_watch_capital_passive_interval_s": 10,
             "tick_interval_s": 30,
             "win_hold_ticks": 5,
+            # Economy caps (see war_of_kingdoms rules for rationale).
+            "max_resources": 1000,
+            "max_army": 50,
+            "max_corpses": 200,
         },
     },
 }

--- a/game-of-tracing/app/location_server.py
+++ b/game-of-tracing/app/location_server.py
@@ -10,10 +10,10 @@ The per-container SERVICE_NAME (used by Grafana dashboards) stays stable
 regardless of map — it's derived from ``LOCATION_NAME`` env / slot id, not
 from the logical location id.
 """
-import os, sqlite3, requests, random, time, threading, atexit
+import os, sqlite3, requests, random, time, threading, atexit, uuid
 from threading import Thread, Lock
 from datetime import datetime, timedelta
-from flask import Flask, jsonify, request
+from flask import Flask, g, jsonify, request
 from game_config import (
     MAPS,
     COSTS,
@@ -63,6 +63,15 @@ class LocationServer:
         self.last_resource_collection = {}
         self.resource_cooldown = {}
         self.lock = Lock()
+        # Idempotency cache for /receive_army: movement_id → (timestamp,
+        # response). Deliveries are retried on transport errors, so the same
+        # army could otherwise arrive (and fight) twice. Per-process and
+        # time-pruned — fine for a demo; a real system would use a durable
+        # idempotency store.
+        self._processed_movements = {}
+        # Passive background threads by name, surfaced via /health so a dead
+        # economy loop is visible instead of silently starving the game.
+        self._passive_threads = {}
 
         # SERVICE_NAME must stay stable across map switches so Grafana
         # dashboards keep their series. Prefer the explicit LOCATION_NAME env
@@ -219,12 +228,15 @@ class LocationServer:
     def _add_corpses(self, delta: int, faction: str = "white_walkers"):
         if delta <= 0:
             return
+        # Cap the pool: the passive tick runs forever, so an idle game must
+        # not bank an unbounded corpse economy (see rules["max_corpses"]).
+        cap = self._current_rules().get("max_corpses") or 10**9
         conn = self._get_db_connection()
         try:
             conn.execute(
                 "INSERT INTO faction_economy (faction, corpses) VALUES (?, ?) "
-                "ON CONFLICT(faction) DO UPDATE SET corpses = corpses + excluded.corpses",
-                (faction, delta),
+                "ON CONFLICT(faction) DO UPDATE SET corpses = MIN(corpses + excluded.corpses, ?)",
+                (faction, min(delta, cap), cap),
             )
             conn.commit()
         finally:
@@ -325,9 +337,20 @@ class LocationServer:
         return state
 
     def _update_location_state(self, location_id, resources=None, army=None, faction=None):
+        # Central clamp: every write path (passive ticks, battles, refunds)
+        # funnels through here, so the per-map economy caps are enforced in
+        # exactly one place. See rules["max_resources"] / rules["max_army"].
+        rules = self._current_rules()
+        max_resources = rules.get("max_resources")
+        max_army = rules.get("max_army")
+        if resources is not None and max_resources:
+            resources = min(resources, max_resources)
+        if army is not None and max_army:
+            army = min(army, max_army)
+
         set_clauses = []
         params = []
-        
+
         if resources is not None:
             set_clauses.append("resources = ?")
             params.append(resources)
@@ -355,8 +378,78 @@ class LocationServer:
         # Force metric collection on important state changes
         if faction is not None or resources is not None or army is not None:
             self.telemetry.collect_metrics()
-            
+
         return True
+
+    def _take_all_army(self, expected_army: int) -> bool:
+        """Optimistic-concurrency debit of this location's whole army.
+
+        Two near-simultaneous /move_army requests both read the same army
+        count; the guarded UPDATE only matches for the first one, so the
+        same troops can never march twice. Callers retry/409 on False.
+        """
+        conn = self._get_db_connection()
+        try:
+            cursor = conn.execute(
+                "UPDATE locations SET army = 0 WHERE id = ? AND army = ?",
+                (self.location_id, expected_army),
+            )
+            conn.commit()
+            taken = cursor.rowcount > 0
+        finally:
+            conn.close()
+        if taken:
+            self.telemetry.collect_metrics()
+        return taken
+
+    def _credit_army(self, location_id: str, amount: int):
+        """Additive army credit (refund/compensation path).
+
+        Additive UPDATE — not a read-then-write — so it composes with any
+        reinforcements that arrived while the refunded army was in flight.
+        """
+        cap = self._current_rules().get("max_army") or 10**9
+        conn = self._get_db_connection()
+        try:
+            conn.execute(
+                "UPDATE locations SET army = MIN(army + ?, ?) WHERE id = ?",
+                (amount, cap, location_id),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+        self.telemetry.collect_metrics()
+
+    def _debit_resources(self, location_id: str, amount: int) -> bool:
+        """Guarded resource debit; False if the balance no longer covers it."""
+        conn = self._get_db_connection()
+        try:
+            cursor = conn.execute(
+                "UPDATE locations SET resources = resources - ? "
+                "WHERE id = ? AND resources >= ?",
+                (amount, location_id, amount),
+            )
+            conn.commit()
+            debited = cursor.rowcount > 0
+        finally:
+            conn.close()
+        if debited:
+            self.telemetry.collect_metrics()
+        return debited
+
+    def _credit_resources(self, location_id: str, amount: int):
+        """Additive resource credit (delivery or refund), capped per map rules."""
+        cap = self._current_rules().get("max_resources") or 10**9
+        conn = self._get_db_connection()
+        try:
+            conn.execute(
+                "UPDATE locations SET resources = MIN(resources + ?, ?) WHERE id = ?",
+                (amount, cap, location_id),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+        self.telemetry.collect_metrics()
 
     def _find_path(self, target: str, path_type: PathType) -> Optional[List[str]]:
         """Unified pathfinding for both resources and armies on the active map."""
@@ -467,13 +560,22 @@ class LocationServer:
             return "stalemate", 0, defending_faction
 
     def _continue_army_movement(self, army_size: int, faction: str, current_loc: str,
-                              next_loc: str, remaining_path: List[str], is_attack_move: bool = False) -> Dict:
-        """Continue army movement to next location."""
+                              next_loc: str, remaining_path: List[str], is_attack_move: bool = False,
+                              movement_id: Optional[str] = None) -> Dict:
+        """Continue army movement to next location.
+
+        The caller has already debited the source (debit-at-send), so while
+        the thread sleeps the army exists only "in flight". If delivery
+        fails at the transport level the army marches home (compensation);
+        a *lost battle* is a game outcome, not a delivery failure — those
+        troops are dead, not refunded.
+        """
         # Capture the full context before spawning the thread
         ctx = get_current()
 
         def move():
             token = attach(ctx)
+            refunded = False
             try:
                 time.sleep(5)  # Wait 5 seconds before moving
 
@@ -484,45 +586,72 @@ class LocationServer:
                             "source_location": current_loc,
                             "target_location": next_loc,
                             "army_size": army_size,
-                            "is_attack_move": is_attack_move
+                            "is_attack_move": is_attack_move,
+                            "game.movement.id": movement_id or "",
                         }
                     ) as movement_span:
                         target_url = f"{self.get_location_url(next_loc)}/receive_army"
                         self.logger.info(f"Moving army from {current_loc} to {next_loc}")
-                        
-                        result = self._make_request_with_trace(
-                            'post',
-                            target_url,
-                            {
+
+                        try:
+                            result = self._make_request_with_trace(
+                                'post',
+                                target_url,
+                                {
+                                    "army_size": army_size,
+                                    "faction": faction,
+                                    "source_location": current_loc,
+                                    "remaining_path": remaining_path,
+                                    "is_attack_move": is_attack_move,
+                                    "movement_id": movement_id,
+                                },
+                                span_name="http_request.move_army"
+                            )
+                        except requests.RequestException as e:
+                            # Transport failure (or downstream rejection) —
+                            # the army never fought anywhere. March it home.
+                            self._credit_army(current_loc, army_size)
+                            refunded = True
+                            movement_span.record_exception(e)
+                            movement_span.add_event("army_returned", {
                                 "army_size": army_size,
-                                "faction": faction,
-                                "source_location": current_loc,
-                                "remaining_path": remaining_path,
-                                "is_attack_move": is_attack_move
-                            },
-                            span_name="http_request.move_army"
-                        )
-                        
+                                "returned_to": current_loc,
+                                "reason": "delivery_failed",
+                            })
+                            movement_span.set_status(
+                                trace.StatusCode.ERROR,
+                                f"Delivery to {next_loc} failed; army returned to {current_loc}",
+                            )
+                            self.logger.error(
+                                f"Army delivery to {next_loc} failed ({e}); "
+                                f"{army_size} units returned to {current_loc}"
+                            )
+                            return
+
                         if not result.get("success", False):
+                            # A lost battle is a game outcome, not a transport
+                            # failure — those troops are dead, not refunded.
                             movement_span.set_status(trace.StatusCode.ERROR, "Army movement failed")
                             movement_span.set_attribute("error", result.get("message", "Unknown error"))
                             self.logger.error(f"Army movement failed: {result.get('message', 'Unknown error')}")
                         else:
                             # Force metric collection after successful army movement
                             self.telemetry.collect_metrics()
-                
+
             except Exception as e:
-                self.logger.error(f"Failed to move army to {next_loc}: {str(e)}")
-                raise
+                # Never let an unexpected error evaporate the army silently.
+                if not refunded:
+                    self._credit_army(current_loc, army_size)
+                self.logger.error(f"Failed to move army to {next_loc}: {str(e)}; army returned")
             finally:
                 detach(token)
 
         # Start movement in background thread
         Thread(target=move).start()
-        
+
         # Force metric collection at the start of movement
         self.telemetry.collect_metrics()
-        
+
         # Return immediate response indicating movement has started
         return {
             "success": True,
@@ -530,19 +659,29 @@ class LocationServer:
             "is_attack_move": is_attack_move
         }
 
-    def _transfer_resources_along_path(self, resources: int, path: List[str]) -> bool:
-        """Transfer resources along a path with delays."""
-        if not path or len(path) < 2:
-            return False
-            
+    def _forward_resources(self, amount: int, faction: str, next_loc: str,
+                           payload_path: List[str]) -> None:
+        """Deliver ``amount`` resources to ``next_loc`` after the 5 s march delay.
+
+        Debit-at-send: the caller has already debited this location's row,
+        so while the thread sleeps the resources exist only "in flight".
+        Compensation rules:
+
+        - transport failure / downstream rejection → refund here
+          (``resources_returned`` span event);
+        - caravan captured by another faction → the new owner keeps it,
+          no refund (a game outcome, not a delivery failure).
+
+        ``faction`` is captured at call time, *not* re-read after the delay —
+        if this location changes hands mid-flight the caravan still belongs
+        to whoever dispatched it.
+        """
         # Capture the full context before spawning the thread
         ctx = get_current()
 
         def transfer():
-            current_loc = path[0]
-            next_loc = path[1]
-
             token = attach(ctx)
+            refunded = False
             try:
                 time.sleep(5)  # Wait before starting transfer
 
@@ -550,66 +689,131 @@ class LocationServer:
                     "resource_movement",
                     kind=SpanKind.SERVER,
                     attributes={
-                        "source_location": current_loc,
+                        "source_location": self.location_id,
                         "target_location": next_loc,
-                        "resources_amount": resources
+                        "resources_amount": amount,
+                        "faction": faction,
+                        "resource.movement": True,
                     }
                 ) as movement_span:
                     target_url = f"{self.get_location_url(next_loc)}/receive_resources"
-                    result = self._make_request_with_trace(
-                        'post',
-                        target_url,
-                        {
-                            "resources": resources,
-                            "source_location": current_loc,
-                            "remaining_path": path[1:],
-                            "faction": self._get_location_state(self.location_id)["faction"]
-                        },
-                        span_name="http_request.transfer_resources"
-                    )
+                    try:
+                        result = self._make_request_with_trace(
+                            'post',
+                            target_url,
+                            {
+                                "resources": amount,
+                                "source_location": self.location_id,
+                                "remaining_path": payload_path,
+                                "faction": faction,
+                            },
+                            span_name="http_request.transfer_resources"
+                        )
+                    except requests.RequestException as e:
+                        self._credit_resources(self.location_id, amount)
+                        refunded = True
+                        movement_span.record_exception(e)
+                        movement_span.add_event("resources_returned", {
+                            "resources_amount": amount,
+                            "reason": "delivery_failed",
+                        })
+                        movement_span.set_status(
+                            trace.StatusCode.ERROR,
+                            f"Delivery to {next_loc} failed; resources returned",
+                        )
+                        self.logger.error(
+                            f"Resource delivery to {next_loc} failed ({e}); "
+                            f"{amount} returned to {self.location_id}"
+                        )
+                        return
 
-                    if result.get("success", False):
-                        current_loc_resources = self._get_location_state(current_loc)['resources']
-                        self._update_location_state(current_loc, resources=current_loc_resources - resources)
+                    if result.get("captured"):
+                        movement_span.set_status(
+                            trace.StatusCode.ERROR,
+                            f"Resources captured at {next_loc}",
+                        )
+                    elif not result.get("success", False):
+                        self._credit_resources(self.location_id, amount)
+                        refunded = True
+                        movement_span.add_event("resources_returned", {
+                            "resources_amount": amount,
+                            "reason": result.get("message", "rejected"),
+                        })
+                        movement_span.set_status(trace.StatusCode.ERROR, "Resource transfer rejected")
+                    else:
                         # Force metric collection after successful resource transfer
                         self.telemetry.collect_metrics()
-                    else:
-                        movement_span.set_status(trace.StatusCode.ERROR, "Resource transfer failed")
 
             except Exception as e:
-                self.logger.error(f"Failed to send resources to {next_loc} from {current_loc}: {str(e)}")
+                if not refunded:
+                    self._credit_resources(self.location_id, amount)
+                self.logger.error(
+                    f"Failed to send resources to {next_loc} from {self.location_id}: {str(e)}"
+                )
             finally:
                 detach(token)
 
         Thread(target=transfer).start()
-        return True
+
+    # (connect, read) timeouts for every outbound call: a hung peer must
+    # never block a Flask worker thread indefinitely.
+    REQUEST_TIMEOUT = (3, 10)
 
     def _make_request_with_trace(self, method: str, url: str, json_data: Optional[Dict] = None, span_name: str = "http_request") -> Dict:
-        """Make HTTP request with trace context propagated in headers."""
+        """Make HTTP request with trace context propagated in headers.
+
+        Attribute names follow the OpenTelemetry HTTP semantic conventions
+        (``url.full``, ``http.request.method``, ``http.response.status_code``)
+        so tooling that understands the conventions — Tempo's service-graph
+        details, Grafana drilldowns — works without custom mapping.
+
+        Transport errors get exactly one retry after a 2 s backoff. Paired
+        with the idempotent ``/receive_army`` (movement_id dedupe), a retry
+        can never deliver the same army twice.
+        """
         headers = {"Content-Type": "application/json"}
 
         with self.tracer.start_as_current_span(
             span_name,
             kind=SpanKind.CLIENT,
-            attributes={"http.url": url}
+            attributes={
+                "url.full": url,
+                "http.request.method": method.upper(),
+            }
         ) as request_span:
             inject(headers)  # This will now inject the current request_span's context
-            
-            try:
-                if method.lower() == 'get':
-                    response = requests.get(url, headers=headers)
-                elif method.lower() == 'post':
-                    response = requests.post(url, json=json_data, headers=headers)
-                else:
-                    raise ValueError(f"Unsupported method: {method}")
-                
-                request_span.set_attribute("http.status_code", response.status_code)
-                response.raise_for_status()
-                return response.json()
-            except requests.RequestException as e:
-                request_span.set_status(trace.StatusCode.ERROR, str(e))
-                self.logger.error(f"Request failed: {str(e)}")
-                raise
+
+            last_exc = None
+            for attempt in (1, 2):
+                try:
+                    if method.lower() == 'get':
+                        response = requests.get(url, headers=headers, timeout=self.REQUEST_TIMEOUT)
+                    elif method.lower() == 'post':
+                        response = requests.post(url, json=json_data, headers=headers, timeout=self.REQUEST_TIMEOUT)
+                    else:
+                        raise ValueError(f"Unsupported method: {method}")
+
+                    request_span.set_attribute("http.response.status_code", response.status_code)
+                    response.raise_for_status()
+                    return response.json()
+                except (requests.ConnectionError, requests.Timeout) as e:
+                    last_exc = e
+                    if attempt == 1:
+                        request_span.add_event("retry_attempted", {"error": str(e)})
+                        self.logger.warning(f"Request to {url} failed ({e}); retrying once")
+                        time.sleep(2)
+                except requests.RequestException as e:
+                    # HTTP-level errors (4xx/5xx): the peer answered, so a
+                    # retry would not change the outcome. Fail fast.
+                    request_span.record_exception(e)
+                    request_span.set_status(trace.StatusCode.ERROR, str(e))
+                    self.logger.error(f"Request failed: {str(e)}")
+                    raise
+
+            request_span.record_exception(last_exc)
+            request_span.set_status(trace.StatusCode.ERROR, str(last_exc))
+            self.logger.error(f"Request failed after retry: {str(last_exc)}")
+            raise last_exc
 
     def _can_collect_resources(self) -> tuple[bool, Optional[str], Optional[int]]:
         """Check if location can collect resources.
@@ -642,6 +846,66 @@ class LocationServer:
     def _start_resource_cooldown(self):
         with self.lock:
             self.resource_cooldown[self.location_id] = datetime.now() + timedelta(seconds=5)
+
+    # Sanity ceiling for any single army/resource delivery. Generous on
+    # purpose (well above what honest play can produce) — it exists to stop
+    # a stray, duplicated, or hand-crafted request from minting absurd
+    # amounts, not to enforce game balance (the per-map caps do that).
+    MAX_TRANSFER = 10_000
+
+    def _validate_inbound_payload(self, data, amount_key: str) -> Optional[str]:
+        """Validate a /receive_army or /receive_resources payload.
+
+        Only sibling location services call these routes, but a replayed,
+        duplicated, or buggy request must never inject units out of thin
+        air. Returns an error message, or None if the payload is sound.
+        """
+        if not isinstance(data, dict):
+            return "Invalid payload"
+
+        amount = data.get(amount_key)
+        # bool is an int subclass in Python — reject it explicitly.
+        if not isinstance(amount, int) or isinstance(amount, bool):
+            return f"Invalid {amount_key}: must be an integer"
+        if amount <= 0 or amount > self.MAX_TRANSFER:
+            return f"Invalid {amount_key}: {amount} out of range"
+
+        faction = data.get('faction')
+        valid_factions = set(MAPS[self.map_id]["factions"]) | {"neutral"}
+        if faction not in valid_factions:
+            return f"Unknown faction: {faction!r}"
+
+        # Armies and caravans only ever arrive from adjacent locations.
+        source = data.get('source_location')
+        if source not in self.location_info["connections"]:
+            return f"{source!r} is not adjacent to {self.location_id}"
+
+        return None
+
+    def _check_duplicate_movement(self, movement_id: Optional[str]) -> Optional[Dict]:
+        """Return the cached response if this movement was already delivered.
+
+        Pairs with the transport retry in ``_make_request_with_trace``: if
+        the first delivery succeeded but its response was lost, the retry
+        re-sends the same ``movement_id`` and gets the cached result back
+        instead of fighting the battle twice.
+        """
+        if not movement_id:
+            return None
+        now = time.time()
+        with self.lock:
+            self._processed_movements = {
+                k: v for k, v in self._processed_movements.items()
+                if now - v[0] < 120
+            }
+            entry = self._processed_movements.get(movement_id)
+            return dict(entry[1]) if entry else None
+
+    def _record_movement_result(self, movement_id: Optional[str], response: Dict):
+        if not movement_id:
+            return
+        with self.lock:
+            self._processed_movements[movement_id] = (time.time(), dict(response))
 
     def get_location_url(self, location_id):
         """Return the HTTP base URL for reaching another location service.
@@ -679,37 +943,45 @@ class LocationServer:
 
     def _start_passive_generation(self):
         def generate_resources():
+            # The loop body is guarded so a transient failure (e.g. a SQLite
+            # busy timeout) can't kill the thread — a dead economy loop would
+            # silently starve this location for the rest of the game.
             while True:
-                time.sleep(15)
-                # Static identity guards against /reload moving this slot off
-                # of a village type entirely.
-                if self.location_info["type"] != "village":
-                    continue
-                # Live-DB guard: gate on the *current* faction, not the
-                # boot-time identity, so a captured Free Folk camp starts
-                # producing for the new owner the moment its row flips. The
-                # static ``self.location_info["faction"]`` is set at boot
-                # from MAPS config and never updates on battle.
-                location_state = self._get_location_state(self.location_id)
-                if location_state is None:
-                    continue
-                if location_state["faction"] == "barbarian":
-                    continue
-                amount = self._current_rules()["resource_generation"]["village"]
-                with self.tracer.start_as_current_span(
-                    "passive_resource_generation",
-                    attributes={
-                        "location.id": self.location_id,
-                        "resources_gained": amount,
-                        "game.map.id": self.map_id,
-                        "owner.faction": location_state["faction"],
-                    }
-                ):
-                    new_resources = location_state["resources"] + amount
-                    self._update_location_state(self.location_id, resources=new_resources)
-                    self.telemetry.collect_metrics()
+                try:
+                    time.sleep(15)
+                    # Static identity guards against /reload moving this slot off
+                    # of a village type entirely.
+                    if self.location_info["type"] != "village":
+                        continue
+                    # Live-DB guard: gate on the *current* faction, not the
+                    # boot-time identity, so a captured Free Folk camp starts
+                    # producing for the new owner the moment its row flips. The
+                    # static ``self.location_info["faction"]`` is set at boot
+                    # from MAPS config and never updates on battle.
+                    location_state = self._get_location_state(self.location_id)
+                    if location_state is None:
+                        continue
+                    if location_state["faction"] == "barbarian":
+                        continue
+                    amount = self._current_rules()["resource_generation"]["village"]
+                    with self.tracer.start_as_current_span(
+                        "passive_resource_generation",
+                        attributes={
+                            "location.id": self.location_id,
+                            "resources_gained": amount,
+                            "game.map.id": self.map_id,
+                            "owner.faction": location_state["faction"],
+                        }
+                    ):
+                        new_resources = location_state["resources"] + amount
+                        self._update_location_state(self.location_id, resources=new_resources)
+                        self.telemetry.collect_metrics()
+                except Exception as e:
+                    self.logger.error(f"Passive generation tick failed: {e}")
 
-        Thread(target=generate_resources, daemon=True).start()
+        thread = Thread(target=generate_resources, daemon=True, name="passive_generation")
+        thread.start()
+        self._passive_threads["passive_generation"] = thread
 
     def _start_barbarian_growth(self, interval_s: int):
         """Barbarian villages grow +1 army every ``interval_s`` seconds.
@@ -721,27 +993,32 @@ class LocationServer:
         """
         def grow():
             while True:
-                time.sleep(interval_s)
-                if self.location_info["faction"] != "barbarian":
-                    continue
-                with self.tracer.start_as_current_span(
-                    "barbarian_passive_growth",
-                    attributes={
-                        "location.id": self.location_id,
-                        "game.map.id": self.map_id,
-                        "army_gained": 1,
-                    }
-                ):
-                    state = self._get_location_state(self.location_id)
-                    if state is None:
+                try:
+                    time.sleep(interval_s)
+                    if self.location_info["faction"] != "barbarian":
                         continue
-                    # Only grow while still barbarian-controlled.
-                    if state["faction"] != "barbarian":
-                        continue
-                    self._update_location_state(self.location_id, army=state["army"] + 1)
-                    self.telemetry.collect_metrics()
+                    with self.tracer.start_as_current_span(
+                        "barbarian_passive_growth",
+                        attributes={
+                            "location.id": self.location_id,
+                            "game.map.id": self.map_id,
+                            "army_gained": 1,
+                        }
+                    ):
+                        state = self._get_location_state(self.location_id)
+                        if state is None:
+                            continue
+                        # Only grow while still barbarian-controlled.
+                        if state["faction"] != "barbarian":
+                            continue
+                        self._update_location_state(self.location_id, army=state["army"] + 1)
+                        self.telemetry.collect_metrics()
+                except Exception as e:
+                    self.logger.error(f"Barbarian growth tick failed: {e}")
 
-        Thread(target=grow, daemon=True).start()
+        thread = Thread(target=grow, daemon=True, name="barbarian_growth")
+        thread.start()
+        self._passive_threads["barbarian_growth"] = thread
 
     def _start_nights_watch_capital_resource_tick(self, interval_s: int, amount: int):
         """Passive resource generation at the Night's Watch capital (WWA only).
@@ -754,29 +1031,34 @@ class LocationServer:
         """
         def tick():
             while True:
-                time.sleep(interval_s)
-                if (self.location_info["faction"] != "nights_watch"
-                    or self.location_info["type"] != "capital"):
-                    continue
-                with self.tracer.start_as_current_span(
-                    "nights_watch_passive_resource",
-                    attributes={
-                        "location.id": self.location_id,
-                        "game.map.id": self.map_id,
-                        "resources_gained": amount,
-                    }
-                ):
-                    state = self._get_location_state(self.location_id)
-                    if state is None:
+                try:
+                    time.sleep(interval_s)
+                    if (self.location_info["faction"] != "nights_watch"
+                        or self.location_info["type"] != "capital"):
                         continue
-                    if state["faction"] != "nights_watch":
-                        continue
-                    self._update_location_state(
-                        self.location_id, resources=state["resources"] + amount
-                    )
-                    self.telemetry.collect_metrics()
+                    with self.tracer.start_as_current_span(
+                        "nights_watch_passive_resource",
+                        attributes={
+                            "location.id": self.location_id,
+                            "game.map.id": self.map_id,
+                            "resources_gained": amount,
+                        }
+                    ):
+                        state = self._get_location_state(self.location_id)
+                        if state is None:
+                            continue
+                        if state["faction"] != "nights_watch":
+                            continue
+                        self._update_location_state(
+                            self.location_id, resources=state["resources"] + amount
+                        )
+                        self.telemetry.collect_metrics()
+                except Exception as e:
+                    self.logger.error(f"Night's Watch resource tick failed: {e}")
 
-        Thread(target=tick, daemon=True).start()
+        thread = Thread(target=tick, daemon=True, name="nights_watch_resource_tick")
+        thread.start()
+        self._passive_threads["nights_watch_resource_tick"] = thread
 
     def _start_white_walker_corpse_tick(self, interval_s: int):
         """Passive corpse generation at the White Walker fortress.
@@ -785,26 +1067,39 @@ class LocationServer:
         when no battles are happening. Corpses accrue to the faction pool.
         """
         def tick():
+            # Guarded loop: if this thread died, the White Walker AI could
+            # never afford an army when no battles are happening.
             while True:
-                time.sleep(interval_s)
-                if self.location_info["faction"] != "white_walkers" or self.location_info["type"] != "capital":
-                    continue
-                with self.tracer.start_as_current_span(
-                    "white_walker_corpse_tick",
-                    attributes={
-                        "location.id": self.location_id,
-                        "game.map.id": self.map_id,
-                        "game.corpses.harvested": 1,
-                        "corpse.source": "passive",
-                    }
-                ):
-                    self._add_corpses(1, "white_walkers")
-                    self.telemetry.collect_metrics()
+                try:
+                    time.sleep(interval_s)
+                    if self.location_info["faction"] != "white_walkers" or self.location_info["type"] != "capital":
+                        continue
+                    with self.tracer.start_as_current_span(
+                        "white_walker_corpse_tick",
+                        attributes={
+                            "location.id": self.location_id,
+                            "game.map.id": self.map_id,
+                            "game.corpses.harvested": 1,
+                            "corpse.source": "passive",
+                        }
+                    ):
+                        self._add_corpses(1, "white_walkers")
+                        self.telemetry.collect_metrics()
+                except Exception as e:
+                    self.logger.error(f"Corpse tick failed: {e}")
 
-        Thread(target=tick, daemon=True).start()
+        thread = Thread(target=tick, daemon=True, name="white_walker_corpse_tick")
+        thread.start()
+        self._passive_threads["white_walker_corpse_tick"] = thread
 
     def reset_database(self):
         """Reset every location row + the corpse pool to the active map's initial state."""
+        # Re-read the active map *first*: war_map writes the new
+        # active_map_id before calling /reset, so resetting with this
+        # process's in-memory map id would repopulate the table with the
+        # previous map's rows.
+        self._load_identity()
+
         conn = self._get_db_connection()
         cursor = conn.cursor()
 
@@ -823,11 +1118,39 @@ class LocationServer:
 
         cursor.execute("DELETE FROM faction_economy")
 
+        # Seed corpse pools for corpse-currency factions so the AI's
+        # /faction_economy reads and the corpse gauge have a row from t=0
+        # instead of depending on the passive tick having fired first.
+        for faction in MAPS[self.map_id]["factions"]:
+            if get_army_currency(self.map_id, faction) == "corpses":
+                cursor.execute(
+                    "INSERT OR IGNORE INTO faction_economy (faction, corpses) VALUES (?, 0)",
+                    (faction,),
+                )
+
         conn.commit()
         conn.close()
         self.logger.info(f"Database reset to initial state for map {self.map_id}")
 
     def setup_routes(self):
+        @self.app.before_request
+        def _attach_incoming_context():
+            # Attach the extracted W3C context (trace + baggage) as the
+            # *current* context for the whole request. Handlers still pass
+            # context=extract(...) explicitly when starting their span, but
+            # that alone does not make the context current — and outbound
+            # inject() calls plus get_current() captures in background
+            # threads read the *current* context. Without this attach,
+            # baggage (game.session.id, game.actor, …) would stop at this
+            # service's handler span instead of flowing down the cascade.
+            g._otel_ctx_token = attach(extract(request.headers))
+
+        @self.app.teardown_request
+        def _detach_incoming_context(exc):
+            token = getattr(g, "_otel_ctx_token", None)
+            if token is not None:
+                detach(token)
+
         @self.app.route('/', methods=['GET'])
         def info():
             context = extract(request.headers)
@@ -865,7 +1188,14 @@ class LocationServer:
 
         @self.app.route('/health', methods=['GET'])
         def health():
-            return jsonify({"status": "ok"})
+            # Surface passive-thread liveness: the game can look healthy while
+            # an economy loop is dead, so make that observable here (and in
+            # `docker compose ps` once a healthcheck inspects the payload).
+            threads = {name: t.is_alive() for name, t in self._passive_threads.items()}
+            return jsonify({
+                "status": "ok" if all(threads.values()) else "degraded",
+                "threads": threads,
+            })
 
         @self.app.route('/collect_resources', methods=['POST'])
         def collect_resources():
@@ -1040,28 +1370,35 @@ class LocationServer:
                 try:
                     army_size = location_state["army"]
                     current_faction = location_state["faction"]
-                    
+                    movement_id = str(uuid.uuid4())
+
                     move_span.set_attribute("army_size", army_size)
                     move_span.set_attribute("faction", current_faction)
-                    
-                    # Update the source location's army to 0
-                    self._update_location_state(self.location_id, army=0)
-                    
-                    # Force metric collection after army leaves the location
-                    self.telemetry.collect_metrics()
-                    
+                    move_span.set_attribute("game.movement.id", movement_id)
+
+                    # Optimistic-concurrency debit: only succeeds if the army
+                    # count is still what we just read, so two simultaneous
+                    # move requests can't march the same troops twice.
+                    if not self._take_all_army(army_size):
+                        move_span.set_status(trace.StatusCode.ERROR, "Army changed during request")
+                        return jsonify({
+                            "success": False,
+                            "message": "Army changed while processing — try again"
+                        }), 409
+
                     result = self._continue_army_movement(
                         army_size,
                         current_faction,
                         self.location_id,
                         target_location,
                         remaining_path,
-                        is_attack_move
+                        is_attack_move,
+                        movement_id=movement_id
                     )
-                    
+
                     if not result.get("success", True):
                         move_span.set_status(trace.StatusCode.ERROR, result.get("message", "Unknown error"))
-                    
+
                     return jsonify(result)
                 except Exception as e:
                     move_span.record_exception(e)
@@ -1123,39 +1460,44 @@ class LocationServer:
                             "message": "No valid path to enemy capital"
                         }), 400
                     
+                    movement_id = str(uuid.uuid4())
                     attack_span.set_attribute("attack_path", str(attack_path))
                     attack_span.set_attribute("initial_army_size", army_size)
-                    
-                    # Set army to 0 before starting the attack
-                    self._update_location_state(self.location_id, army=0)
-                    
+                    attack_span.set_attribute("game.movement.id", movement_id)
+
                     if len(attack_path) > 1:
+                        # Optimistic-concurrency debit (see /move_army). If a
+                        # later hop fails at the transport level, the movement
+                        # thread credits the army back — no restore needed here.
+                        if not self._take_all_army(army_size):
+                            attack_span.set_status(trace.StatusCode.ERROR, "Army changed during request")
+                            return jsonify({
+                                "success": False,
+                                "message": "Army changed while processing — try again"
+                            }), 409
+
                         next_loc = attack_path[1]
-                        result = self._continue_army_movement(
+                        # remaining_path holds the hops *after* next_loc —
+                        # the same convention /receive_army uses when it
+                        # continues a movement (remaining_path[0] is always
+                        # the hop after the receiver, never the receiver).
+                        self._continue_army_movement(
                             army_size,
                             faction,
                             self.location_id,
                             next_loc,
-                            attack_path[1:],
-                            is_attack_move=True
+                            attack_path[2:],
+                            is_attack_move=True,
+                            movement_id=movement_id
                         )
-                        
-                        if not result.get("success", False):
-                            # If movement fails, restore the army
-                            self._update_location_state(self.location_id, army=army_size)
-                            attack_span.set_status(trace.StatusCode.ERROR, "Failed to start attack")
-                            return jsonify({
-                                "success": False,
-                                "message": f"Failed to start attack: {result.get('message', 'Unknown error')}"
-                            }), 400
-                        
+
                         return jsonify({
                             "success": True,
                             "message": f"All-out attack started with {army_size} troops",
                             "path": attack_path,
                             "army_size": army_size
                         })
-                    
+
                     return jsonify({
                         "success": False,
                         "message": "Invalid attack path"
@@ -1169,14 +1511,11 @@ class LocationServer:
         @self.app.route('/receive_army', methods=['POST'])
         def receive_army():
             try:
-                data = request.get_json()
+                data = request.get_json(silent=True)
                 self.logger.info(f"Received army at {self.location_id}: {data}")
-                
-                if not data or 'army_size' not in data or 'faction' not in data:
-                    return jsonify({"success": False, "message": "Invalid army data"}), 400
-                
+
                 context = extract(request.headers)
-                
+
                 with self.tracer.start_as_current_span(
                     "receive_army",
                     context=context,
@@ -1186,23 +1525,40 @@ class LocationServer:
                         "location_type": self.location_info["type"]
                     }
                 ) as battle_span:
+                    # Harden the inbound payload before touching any state —
+                    # see _validate_inbound_payload for what is rejected.
+                    error = self._validate_inbound_payload(data, 'army_size')
+                    if error:
+                        battle_span.set_status(trace.StatusCode.ERROR, error)
+                        return jsonify({"success": False, "message": error}), 400
+
+                    movement_id = data.get('movement_id')
+                    cached = self._check_duplicate_movement(movement_id)
+                    if cached is not None:
+                        # A transport retry re-delivered an army we already
+                        # processed — return the original outcome instead of
+                        # fighting the battle twice.
+                        battle_span.set_attribute("game.movement.duplicate", True)
+                        battle_span.set_attribute("game.movement.id", movement_id)
+                        return jsonify(cached)
+
                     attacking_army = data['army_size']
                     attacking_faction = data['faction']
-                    source_location = data.get('source_location', 'unknown')
+                    source_location = data['source_location']
                     remaining_path = data.get('remaining_path', [])
                     is_attack_move = data.get('is_attack_move', False)
-                    
+
                     location_state = self._get_location_state(self.location_id)
                     defending_army = location_state["army"]
                     defending_faction = location_state["faction"]
-                    
+
                     battle_span.set_attribute("source_location", source_location)
                     battle_span.set_attribute("attacking_army", attacking_army)
                     battle_span.set_attribute("defending_army", defending_army)
                     battle_span.set_attribute("remaining_path", str(remaining_path))
                     battle_span.set_attribute("is_attack_move", is_attack_move)
+                    battle_span.set_attribute("game.movement.id", movement_id or "")
 
-                    self.logger.info(f"Received army at {self.location_id}: {data}")
                     self.logger.info(f"Remaining path: {remaining_path}, is_attack_move: {is_attack_move}")
                     
                     if attacking_faction == defending_faction:
@@ -1214,25 +1570,27 @@ class LocationServer:
                             self._update_location_state(self.location_id, army=0)
                             battle_span.set_attribute("combined_army_size", attacking_army)
                             self.logger.info(f"Combined armies at {self.location_id}: {attacking_army} (village army was {defending_army})")
-                        
+
                         # Continue movement if there's a path remaining
                         if is_attack_move and remaining_path:
                             next_location = remaining_path[0]
-                            new_remaining_path = remaining_path[1:] if len(remaining_path) > 1 else []
+                            new_remaining_path = remaining_path[1:]
                             self.logger.info(f"Continuing attack from {self.location_id} to {next_location}, new path: {new_remaining_path}")
-                            
+
                             result = self._continue_army_movement(
                                 attacking_army,  # Use the potentially increased army size
                                 attacking_faction,
                                 self.location_id,
                                 next_location,
                                 new_remaining_path,
-                                is_attack_move
+                                is_attack_move,
+                                movement_id=movement_id
                             )
                             battle_span.set_attribute("result", "friendly_passage")
                             self.logger.info(f"Friendly passage result: {result}")
                             # Force metric collection after friendly passage
                             self.telemetry.collect_metrics()
+                            self._record_movement_result(movement_id, result)
                             return jsonify(result)
                         elif not is_attack_move:
                             # Normal army movement - combine armies
@@ -1242,33 +1600,58 @@ class LocationServer:
                             self.logger.info(f"Armies combined at {self.location_info['name']}: {new_army}")
                             # Force metric collection after combining armies
                             self.telemetry.collect_metrics()
-                            return jsonify({
+                            response = {
                                 "success": True,
                                 "message": f"Armies combined at {self.location_info['name']}",
                                 "current_army": new_army,
                                 "faction": defending_faction
-                            })
+                            }
+                            self._record_movement_result(movement_id, response)
+                            return jsonify(response)
                         else:
-                            # All-out attack reached friendly location with no remaining path
-                            # This shouldn't normally happen, but handle it gracefully
-                            if self.location_info["type"] == "capital":
-                                # If it's our own capital, stop here
+                            # All-out attack reached a friendly location with no
+                            # remaining path (e.g. the target flipped to our
+                            # faction mid-flight). The army garrisons here —
+                            # additively, never overwriting whoever already holds
+                            # the location.
+                            if self.location_info["type"] == "village":
+                                # The village garrison was zeroed and merged into
+                                # attacking_army above; write the merged stack back.
                                 self._update_location_state(self.location_id, army=attacking_army)
-                                battle_span.set_attribute("result", "returned_to_capital")
-                                self.logger.warning(f"All-out attack returned to own capital with {attacking_army} troops")
-                            else:
-                                # For villages, the army should already be zeroed out above
                                 battle_span.set_attribute("result", "attack_ended_at_village")
-                                self.logger.warning(f"All-out attack ended at friendly village {self.location_id}")
-                            
+                                self.logger.warning(f"All-out attack ended at friendly village {self.location_id}; {attacking_army} units garrison")
+                            else:
+                                new_army = defending_army + attacking_army
+                                self._update_location_state(self.location_id, army=new_army)
+                                battle_span.set_attribute("result", "returned_to_capital")
+                                self.logger.warning(f"All-out attack ended at {self.location_id} with {attacking_army} troops joining the garrison")
+
                             self.telemetry.collect_metrics()
-                            return jsonify({
+                            response = {
                                 "success": True,
                                 "message": f"Army movement ended at {self.location_info['name']}",
                                 "current_army": self._get_location_state(self.location_id)["army"],
                                 "faction": defending_faction
-                            })
+                            }
+                            self._record_movement_result(movement_id, response)
+                            return jsonify(response)
                     
+                    # ``battle.occurred`` feeds the dashboard TraceQL filter
+                    # ({span.battle.occurred=true}); set it before resolution
+                    # so even a crash mid-battle leaves a queryable span.
+                    battle_span.set_attribute("battle.occurred", True)
+
+                    # Span events mark *points in time* inside the span —
+                    # unlike attributes (span-wide facts), each event carries
+                    # its own timestamp and shows up on the trace timeline.
+                    battle_span.add_event("battle_started", attributes={
+                        "attacking_army": attacking_army,
+                        "defending_army": defending_army,
+                        "attacker_faction": attacking_faction,
+                        "defender_faction": defending_faction,
+                        "location_type": self.location_info["type"],
+                    })
+
                     battle_result, remaining_army, new_faction = self._handle_battle(
                         attacking_army,
                         attacking_faction,
@@ -1277,15 +1660,28 @@ class LocationServer:
                         location_type=self.location_info["type"],
                     )
 
+                    total_casualties = max(0, attacking_army + defending_army - remaining_army)
+                    battle_span.add_event("casualties_calculated", attributes={
+                        "total_casualties": total_casualties,
+                        "outcome": battle_result,
+                        "remaining_army": remaining_army,
+                    })
+
                     # Corpse harvesting: the White Walkers reap from any battle
                     # they win (either as attacker or defender). Corpses equal
                     # the total physical units that died on both sides.
                     if new_faction == "white_walkers":
-                        dead = max(0, attacking_army + defending_army - remaining_army)
-                        if dead > 0:
-                            self._add_corpses(dead, "white_walkers")
-                            battle_span.set_attribute("game.corpses.harvested", dead)
+                        if total_casualties > 0:
+                            self._add_corpses(total_casualties, "white_walkers")
+                            battle_span.set_attribute("game.corpses.harvested", total_casualties)
                             battle_span.set_attribute("corpse.source", "battle")
+
+                    if new_faction != defending_faction:
+                        battle_span.add_event("territory_captured", attributes={
+                            "previous_faction": defending_faction,
+                            "new_faction": new_faction,
+                            "location.id": self.location_id,
+                        })
 
                     self._update_location_state(
                         self.location_id,
@@ -1298,8 +1694,8 @@ class LocationServer:
                     battle_span.set_attribute("game.map.id", self.map_id)
                     if self.location_info["type"] == "wall":
                         battle_span.set_attribute("game.wall.held", new_faction != "neutral")
-                        battle_span.set_attribute("span.wall.battle", True)
-                    
+                        battle_span.set_attribute("wall.battle", True)
+
                     if battle_result == "attacker_victory" and is_attack_move and remaining_path:
                         self.logger.info(f"Continuing army movement at {self.location_id}: {remaining_army}")
                         self.logger.info(f"Battle victory - continuing to {remaining_path[0]}, path: {remaining_path[1:]}")
@@ -1308,11 +1704,13 @@ class LocationServer:
                             attacking_faction,
                             self.location_id,
                             remaining_path[0],
-                            remaining_path[1:] if len(remaining_path) > 1 else [],
-                            is_attack_move
+                            remaining_path[1:],
+                            is_attack_move,
+                            movement_id=movement_id
                         )
+                        self._record_movement_result(movement_id, result)
                         return jsonify(result)
-                    
+
                     if battle_result != "attacker_victory":
                         self.logger.warning(f"Battle result: {battle_result}")
                         battle_span.add_event("battle_result", attributes={
@@ -1321,16 +1719,18 @@ class LocationServer:
                             "defender_faction": defending_faction,
                             "remaining_army": remaining_army,
                         })
-                    
+
                     # Force metric collection after battle resolution
                     self.telemetry.collect_metrics()
-                    
-                    return jsonify({
+
+                    response = {
                         "success": battle_result == "attacker_victory",
                         "message": f"Battle at {self.location_info['name']}: {battle_result}",
                         "current_army": remaining_army,
                         "faction": new_faction
-                    })
+                    }
+                    self._record_movement_result(movement_id, response)
+                    return jsonify(response)
                     
             except Exception as e:
                 self.logger.error(f"Error in receive_army: {str(e)}")
@@ -1428,25 +1828,43 @@ class LocationServer:
                         }), 400
                     
                     span.set_attribute("path_to_capital", str(path))
-                    
-                    if self._transfer_resources_along_path(current_resources, path):
-                        self._start_resource_cooldown()
-                        self.logger.info(f"Resources sent to capital via {path}")
-                        # Force metric collection after initiating resource transfer
-                        self.telemetry.collect_metrics()
-                        return jsonify({
-                            "success": True,
-                            "message": f"Sending {current_resources} resources to capital via {' -> '.join(path)}",
-                            "path": path,
-                            "amount": current_resources
-                        })
-                    else:
-                        span.set_status(trace.StatusCode.ERROR, "Failed to start resource transfer")
-                        self.logger.error(f"Failed to start resource transfer")
+                    span.set_attribute("resource.movement", True)
+
+                    if current_resources <= 0:
+                        span.set_status(trace.StatusCode.ERROR, "No resources to send")
                         return jsonify({
                             "success": False,
-                            "message": "Failed to start resource transfer"
-                        }), 500
+                            "message": "No resources to send"
+                        }), 400
+
+                    if len(path) < 2:
+                        span.set_status(trace.StatusCode.ERROR, "Path too short")
+                        return jsonify({
+                            "success": False,
+                            "message": "Already at the capital"
+                        }), 400
+
+                    # Debit-at-send: guarded so a concurrent spend can't send
+                    # resources this village no longer has. If delivery fails,
+                    # _forward_resources credits the amount back.
+                    if not self._debit_resources(self.location_id, current_resources):
+                        span.set_status(trace.StatusCode.ERROR, "Resources changed during request")
+                        return jsonify({
+                            "success": False,
+                            "message": "Resources changed while processing — try again"
+                        }), 409
+
+                    self._forward_resources(current_resources, faction, path[1], path[1:])
+                    self._start_resource_cooldown()
+                    self.logger.info(f"Resources sent to capital via {path}")
+                    # Force metric collection after initiating resource transfer
+                    self.telemetry.collect_metrics()
+                    return jsonify({
+                        "success": True,
+                        "message": f"Sending {current_resources} resources to capital via {' -> '.join(path)}",
+                        "path": path,
+                        "amount": current_resources
+                    })
                 except Exception as e:
                     span.record_exception(e)
                     span.set_status(trace.StatusCode.ERROR, str(e))
@@ -1458,92 +1876,78 @@ class LocationServer:
         
         @self.app.route('/receive_resources', methods=['POST'])
         def receive_resources():
-            data = request.get_json()
-            if not data or 'resources' not in data or 'faction' not in data:
-                return jsonify({"success": False, "message": "Invalid resource data"}), 400
-            
+            data = request.get_json(silent=True)
+
             context = extract(request.headers)
-            
+
             with self.tracer.start_as_current_span(
                 "receive_resources",
                 context=context,
+                kind=SpanKind.SERVER,
                 attributes={
                     "location": self.location_id,
                     "location_type": self.location_info["type"],
-                    "sending_faction": data['faction'],
-                    "receiving_faction": self._get_location_state(self.location_id)["faction"],
-                    "resources_amount": data['resources']
+                    "resource.movement": True,
                 }
             ) as transfer_span:
+                # Harden the inbound payload before touching any state.
+                error = self._validate_inbound_payload(data, 'resources')
+                if error:
+                    transfer_span.set_status(trace.StatusCode.ERROR, error)
+                    return jsonify({"success": False, "message": error}), 400
+
                 incoming_resources = data['resources']
-                source_location = data.get('source_location', 'unknown')
+                source_location = data['source_location']
                 remaining_path = data.get('remaining_path', [])
                 faction = data['faction']
-                
-                transfer_span.set_attribute("source_location", source_location)
-                
+
                 location_state = self._get_location_state(self.location_id)
                 current_resources = location_state["resources"]
                 current_faction = location_state["faction"]
-                
+
+                transfer_span.set_attribute("source_location", source_location)
+                transfer_span.set_attribute("sending_faction", faction)
+                transfer_span.set_attribute("receiving_faction", current_faction)
+                transfer_span.set_attribute("resources_amount", incoming_resources)
+
                 if current_faction != faction:
+                    # Captured: the holding faction keeps the caravan. The
+                    # ``captured`` flag tells the sender this was a game
+                    # outcome, not a delivery failure — so no refund there.
                     transfer_span.set_status(trace.Status(trace.StatusCode.ERROR, f"Resources captured by {current_faction}"))
-                    self._update_location_state(self.location_id, resources=current_resources + incoming_resources)
-                    # Force metric collection after resource capture
-                    self.telemetry.collect_metrics()
+                    self._credit_resources(self.location_id, incoming_resources)
                     self.logger.error(f"Resources captured by {current_faction}")
                     return jsonify({
                         "success": False,
+                        "captured": True,
                         "message": f"Resources captured by {current_faction}!",
                         "current_resources": current_resources + incoming_resources
                     })
-                
-                new_resources = current_resources + incoming_resources
-                self._update_location_state(self.location_id, resources=new_resources)
-                # Force metric collection after receiving resources
-                self.telemetry.collect_metrics()
-                self.logger.info(f"Resources updated to {new_resources}")
-                
+
                 if len(remaining_path) > 1:
+                    # Intermediate friendly hop: relay onward without banking.
+                    # The caravan was debited at its origin (debit-at-send),
+                    # so crediting here and debiting again would create a
+                    # window where the resources exist twice.
                     next_loc = remaining_path[1]
-                    
-                    def continue_transfer():
-                        with self._start_movement_trace(
-                            "resource_movement",
-                            self.location_id,
-                            next_loc,
-                            resources=incoming_resources
-                        ) as movement_span:
-                            try:
-                                time.sleep(5)
-                                target_url = f"{self.get_location_url(next_loc)}/receive_resources"
-                                self.logger.info(f"Sending resources to {next_loc} with target URL: {target_url}")
-                                result = self._make_request_with_trace('post', target_url, {
-                                    "resources": incoming_resources,
-                                    "source_location": self.location_id,
-                                    "remaining_path": remaining_path[1:],
-                                    "faction": faction
-                                }, span_name="http_request.forward_resources")
-                                
-                                if not result.get("success", False):
-                                    movement_span.set_status(trace.Status(trace.StatusCode.ERROR, "Resource transfer failed"))
-                                
-                                current_state = self._get_location_state(self.location_id)
-                                self._update_location_state(self.location_id, 
-                                    resources=current_state["resources"] - incoming_resources)
-                                # Force metric collection after forwarding resources
-                                self.telemetry.collect_metrics()
-                                self.logger.info(f"Resources updated to {current_state['resources'] - incoming_resources}")
-                            except Exception as e:
-                                movement_span.set_status(trace.Status(trace.StatusCode.ERROR, str(e)))
-                                self.logger.error(f"Failed to forward resources to {next_loc}: {str(e)}")
-                    
-                    Thread(target=continue_transfer).start()
-                
+                    transfer_span.set_attribute("relay_to", next_loc)
+                    self.logger.info(f"Relaying {incoming_resources} resources via {self.location_id} to {next_loc}")
+                    self._forward_resources(incoming_resources, faction, next_loc, remaining_path[1:])
+                    return jsonify({
+                        "success": True,
+                        "message": f"Resources relaying through {self.location_info['name']}",
+                        "current_resources": current_resources
+                    })
+
+                # Final destination: bank the caravan.
+                new_resources = current_resources + incoming_resources
+                self._credit_resources(self.location_id, incoming_resources)
+                self.logger.info(f"Resources updated to {new_resources}")
+
                 transfer_span.set_attribute("final_resources", new_resources)
                 if self.location_info["type"] == "capital":
                     transfer_span.set_attribute("resources_reached_capital", True)
-                
+
                 self.logger.info(f"Resources received at {self.location_info['name']}")
                 return jsonify({
                     "success": True,

--- a/game-of-tracing/app/telemetry.py
+++ b/game-of-tracing/app/telemetry.py
@@ -1,9 +1,10 @@
 import os
 
 from opentelemetry.sdk.resources import SERVICE_NAME, Resource
-from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace import TracerProvider, SpanProcessor
 from opentelemetry.sdk.trace.export import BatchSpanProcessor
 from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+from opentelemetry import baggage as otel_baggage
 from opentelemetry import trace
 
 # Logging setup
@@ -25,6 +26,38 @@ from typing import Iterable
 # Profiling setup (Pyroscope v2 + OTel span-profile linking)
 import pyroscope
 from pyroscope.otel import PyroscopeSpanProcessor
+
+
+class BaggageSpanProcessor(SpanProcessor):
+    """Copy selected W3C Baggage entries onto every span at start.
+
+    Baggage rides along with the trace context — the default propagator
+    injects/extracts the ``baggage`` HTTP header automatically — but it is
+    **not** written to spans by itself. Without this processor the values
+    would cross every service boundary and still be invisible in Tempo.
+
+    With it, any span started while baggage is set (including spans created
+    in background threads, because ``get_current()`` captures baggage too)
+    carries the game context as plain span attributes, so TraceQL like
+    ``{span.game.session.id="<id>"}`` matches the *entire* downstream
+    cascade of a player action, not just the span that set the value.
+
+    This mirrors the contrib package ``opentelemetry-processor-baggage``,
+    reimplemented in a few lines so the mechanism stays readable and the
+    demo carries no extra dependency.
+    """
+
+    # Allow-list, never copy-everything: in an internet-facing system the
+    # baggage header is caller-controlled, so stamping arbitrary entries
+    # onto spans would let clients inject attributes into your telemetry.
+    ALLOWED_KEYS = ("game.session.id", "player.faction", "game.actor")
+
+    def on_start(self, span, parent_context=None):
+        for key in self.ALLOWED_KEYS:
+            value = otel_baggage.get_baggage(key, parent_context)
+            if value is not None:
+                span.set_attribute(key, str(value))
+
 
 class GameTelemetry:
     def __init__(self, service_name, logging_endpoint="http://alloy:4318", tracing_endpoint="http://alloy:4317", metrics_endpoint="http://alloy:4318"):
@@ -83,6 +116,9 @@ class GameTelemetry:
         )
         
         trace.get_tracer_provider().add_span_processor(span_processor)
+        # Stamp allow-listed baggage entries (game.session.id, player.faction,
+        # game.actor) onto every span — see BaggageSpanProcessor docstring.
+        trace.get_tracer_provider().add_span_processor(BaggageSpanProcessor())
         self.tracer = trace.get_tracer(__name__)
 
     def _setup_profiling(self):

--- a/game-of-tracing/config.alloy
+++ b/game-of-tracing/config.alloy
@@ -1,5 +1,9 @@
 /*
- * Alloy Configuration for OpenTelemetry Trace Collection with Tail Sampling
+ * Alloy Configuration for OpenTelemetry Collection (traces, logs, metrics,
+ * profiles). All signals pass through unsampled: receiver → batch →
+ * exporters. The game's span attributes (battle.occurred, player.action,
+ * resource.movement) are designed to support a tail-sampling policy here
+ * if you want to experiment with one — see the scenario README.
  */
 
 // Receive OpenTelemetry traces
@@ -23,7 +27,7 @@ otelcol.processor.batch "default" {
   }
 }
 
-// Send sampled traces to Tempo
+// Send traces to Tempo
 otelcol.exporter.otlp "tempo" {
   client {
     endpoint = "tempo:4317"

--- a/game-of-tracing/war_map/CLAUDE.md
+++ b/game-of-tracing/war_map/CLAUDE.md
@@ -12,15 +12,16 @@
 - Is the **sole writer** of the `game_actions` SQLite table — the record of every action's trace/span IDs that makes span-link replay possible (rows carry a `map_id` column).
 - Activates / deactivates the AI opponent on behalf of the player (auto-activates as `white_walkers` when the chosen map is WWA).
 - Proxies trace-replay queries to Tempo and falls back to local SQLite when Tempo is unavailable.
-- Instruments player actions as `SERVER` spans with `trace.Link`s chaining each action to the previous one in the session.
-- Runs the **wall-hold tick thread** (`_wall_tick_thread`, 30 s cadence) that increments `wall_hold` when one faction owns every wall keep, and declares the WWA winner at 5 consecutive ticks.
+- Instruments player actions as `SERVER` spans with `trace.Link`s chaining each action to the previous one in the session, with `player.action=true` and W3C Baggage (`game.session.id`, `player.faction`, `game.actor`) attached via the `game_baggage()` context manager (`app.py:45`).
+- Runs the **wall-hold tick thread** (`_wall_tick_thread`, 30 s cadence) that increments `wall_hold` when one faction owns every wall keep, and declares the WWA winner at 5 consecutive ticks (flipping the game-over flags directly, not just on the next poll).
+- **Enforces game over**: once a winner is declared, the five player-action endpoints return 409 via `_reject_if_game_over()` (`app.py:850`) and the AI is deactivated exactly once via `_deactivate_ai_once()` (`app.py:832`). Location servers stay permissive by design — in-flight movements should still resolve.
 
 ## File map
 
 | File | Size | Purpose |
 |---|---|---|
-| `app.py` | ~64 KB | Flask app, session/player management, span-link broker, Tempo proxy for replay, AI activation control. |
-| `telemetry.py` | ~3 KB | `GameTelemetry` — traces + logs (no custom metrics), plus Pyroscope profiling with OTel span-profile linkage. |
+| `app.py` | ~90 KB | Flask app, session/player management, span-link broker, Tempo proxy for replay, AI activation control, game-over enforcement. |
+| `telemetry.py` | ~5 KB | `GameTelemetry` — traces + logs (no custom metrics), `BaggageSpanProcessor` (stamps allow-listed baggage onto spans), plus Pyroscope profiling with OTel span-profile linkage. |
 | `templates/index.html` | ~7 KB | Faction selection screen. |
 | `templates/map.html` | ~50 KB | Main SVG-based game map with real-time updates. |
 | `templates/layout.html` | ~4 KB | Shared layout chrome. |
@@ -39,21 +40,21 @@
 | `game_state.db` | All 8 location services (WAL mode, shared) | Canonical game state |
 | `game_sessions.db` | `war_map` **only** | `game_actions` table: `(game_session_id, action_sequence, action_type, player_name, faction, trace_id, span_id, location_id, target_location_id, timestamp, game_state_after, map_id)` |
 
-`game_actions` schema is defined in `init_game_session_tracking()` at `app.py:60-96`. It carries a `UNIQUE(game_session_id, action_sequence)` constraint — the sequence is what lets "next action" look up "previous action" deterministically.
+`game_actions` schema is defined in `init_game_session_tracking()` at `app.py:201`. It carries a `UNIQUE(game_session_id, action_sequence)` constraint — the sequence is what lets "next action" look up "previous action" deterministically.
 
-### Storing an action — `store_game_action()` at `app.py:101-128`
+### Storing an action — `store_game_action()` at `app.py:258`
 
-Called at the tail of every action handler. Reads the current max `action_sequence` for the session, inserts a new row with `next_sequence = max + 1`, returns the sequence number. Persists the active `map_id` (defaults to `get_active_map_id()` when callers don't pass one) so the replay UI can render the correct map layout for each session.
+Called at the tail of every action handler. Reads the current max `action_sequence` for the session, inserts a new row with `next_sequence = max + 1`, returns the sequence number. The MAX+INSERT pair is serialised under a module lock and retried once on `sqlite3.IntegrityError` — a silently dropped row would break the replay chain for the whole session. Persists the active `map_id` (defaults to `get_active_map_id()` when callers don't pass one) so the replay UI can render the correct map layout for each session.
 
 ### Resolving a session's map — `get_session_map_id()`
 
 Used by `replay_session_page` to pick the right layout. Reads the first non-NULL `map_id` from the session's actions (cheap — sessions don't switch maps mid-play), falls back to the active map, then to `DEFAULT_MAP_ID`. Without this, the replay template renders the WoK layout regardless of which map was actually played.
 
-### Reconstructing a previous span context — `get_previous_action_context()` at `app.py:130-170`
+### Reconstructing a previous span context — `get_previous_action_context()` at `app.py:343`
 
 Looks up `(trace_id, span_id)` for `(game_session_id, target_sequence)` in SQLite. Converts the hex strings to integers with `int(result[0], 16)` / `int(result[1], 16)` (this step has bitten agents in the past — the IDs are stored as hex strings, not raw bytes). Constructs a `trace.SpanContext(trace_id=..., span_id=..., is_remote=True, trace_flags=trace.TraceFlags.SAMPLED)` and returns it. The `SAMPLED` flag is required — without it, downstream processors may drop the link.
 
-### Creating a link — `create_span_link_from_context()` at `app.py:172-189`
+### Creating a link — `create_span_link_from_context()` at `app.py:385`
 
 Wraps the reconstructed context in a `trace.Link(span_context, attributes={...})` with:
 
@@ -64,22 +65,29 @@ Wraps the reconstructed context in a `trace.Link(span_context, attributes={...})
 ### Per-action flow inside a player-action handler
 
 ```python
+rejection = _reject_if_game_over()           # 409 once a winner is declared
+if rejection:
+    return rejection
+
 previous_span_context = get_previous_action_context(game_session_id, current_sequence)
 links = [create_span_link_from_context(previous_span_context, "game_sequence")] if previous_span_context else []
 
-with tracer.start_as_current_span(
+# game_baggage() attaches game.session.id / player.faction / game.actor as
+# W3C Baggage *before* the span starts, so the BaggageSpanProcessor stamps
+# them onto this span and inject() carries them to every downstream service.
+with game_baggage(game_session_id, session.get('faction')), tracer.start_as_current_span(
     "move_army",
     kind=SpanKind.SERVER,
     links=links,
     attributes={
         "game.session.id": game_session_id,
         "game.action.sequence": current_sequence + 1,
-        "span.player.action": True,
+        "player.action": True,            # TraceQL: {span.player.action=true}
         "player.name": ...,
         "player.faction": ...,
     },
 ) as span:
-    # ... do the work, call location_api_request, etc.
+    # ... do the work, call make_api_request, etc.
     store_game_action(
         game_session_id, "move_army", ...,
         trace_id=format(span.get_span_context().trace_id, '032x'),
@@ -113,11 +121,17 @@ The replay UI (`replay_session.html`) is backed by Tempo. `app.py` serves as the
 | `TEMPO_URL` | `http://tempo:3200` | Replay-query target |
 | `IN_DOCKER` | unset | Switches location URLs between `localhost:500X` and container DNS |
 
-Location ports are hard-coded in `LOCATION_PORTS` at `app.py:201-210`; mirror any change here in `app/game_config.py`.
+Location ports are hard-coded in `LOCATION_PORTS` at `app.py:416`; mirror any change here in `app/game_config.py`.
+
+All outbound HTTP uses a `(3, 10)` connect/read timeout (`REQUEST_TIMEOUT`), and `get_db_connection()` (`app.py:503`) sets `timeout=15` + `busy_timeout=5000` because `game_state.db` is shared with 8 WAL-mode writers. `map.html` polls `/api/map_data` + `/api/game_status` on a self-scheduling 5 s loop that backs off to 10 s/30 s on consecutive failures behind a "connection lost" banner.
+
+### UI animations are clocked to the server
+
+The location servers deliver every army/resource hop after exactly 5 s (`time.sleep(5)`). `map.html` mirrors this with `SERVER_HOP_MS = 5000`: every `animateTravelingUnit` march lasts exactly one server hop (with a live ETA countdown badge), multi-hop paths chain back-to-back like the server's relays, and each arrival callback triggers `refreshAtArrival()` (refresh at +300 ms and +2 s) so the clash effect and the state flip land together. Map rebuilds are **not** deferred during animations — traveling units are separate DOM elements that survive a marker rebuild, and the source showing `army=0` mid-flight is accurate (debit-at-send). Each poll also diffs faction ownership against the previous poll and fires a clash + event-feed entry for territory flips caused by the AI or the other player. If you change the server's march delay, change `SERVER_HOP_MS` in the same commit.
 
 ## `X-Frame-Options` stripped — intentional
 
-`@app.after_request` at `app.py:191-194` removes `X-Frame-Options` from every response:
+`@app.after_request` at `app.py:404-407` removes `X-Frame-Options` from every response:
 
 ```python
 @app.after_request
@@ -131,7 +145,7 @@ This is deliberate — it lets the UI be embedded in Grafana iframes for the rep
 ## Common edits
 
 **Add a new action type to the span-link chain.**
-1. Add the Flask handler in `app.py`, following the `move_army` / `create_army` pattern: look up previous context, build link, start a SERVER span with link + attributes, call `store_game_action()` at the tail.
+1. Add the Flask handler in `app.py`, following the `move_army` / `create_army` pattern: game-over guard, look up previous context, build link, start a SERVER span (wrapped in `game_baggage()`) with link + attributes including `player.action: True`, call `store_game_action()` at the tail.
 2. Add a renderer case in `templates/replay_session.html` so the replay UI can visualize the new action.
 3. Update the action-types table in [`../SPAN_LINKS.md`](../SPAN_LINKS.md).
 4. Update this doc and [`../AGENTS.md`](../AGENTS.md) if the new action surfaces new span attributes.
@@ -140,22 +154,24 @@ This is deliberate — it lets the UI be embedded in Grafana iframes for the rep
 Edit the TraceQL strings in the replay endpoints (`app.py`). The `game.session.id` tag is required — Tempo uses it to group the session's traces.
 
 **Add attributes to every player-action link.**
-Edit `create_span_link_from_context()` at `app.py:172-189`. The current three (`link.type`, `link.relation`, `game.sequence`) are load-bearing — the replay UI reads them.
+Edit `create_span_link_from_context()` at `app.py:385`. The current three (`link.type`, `link.relation`, `game.sequence`) are load-bearing — the replay UI reads them.
 
 **Change session-tracking schema.**
-Edit `init_game_session_tracking()` at `app.py:60-96`. Because the DB lives on a persistent Docker volume, a schema change requires either `docker compose down -v` before restart **or** a migration script. Flag to the user which one you recommend before changing columns.
+Edit `init_game_session_tracking()` at `app.py:201`. Because the DB lives on a persistent Docker volume, a schema change requires either `docker compose down -v` before restart **or** a migration script. Flag to the user which one you recommend before changing columns.
 
 ## Keep this doc current
 
 Per the sub-agent rule, any change to span-link fields, replay endpoints, env vars, action types, or the line-number anchors above must land in the same work unit. Before returning a response that touched `war_map/`, grep this file for references to anything you changed.
 
 Particularly sensitive references:
-- `app.py:130-170` — `get_previous_action_context`
-- `app.py:172-189` — `create_span_link_from_context`
-- `app.py:60-96` — `init_game_session_tracking`
-- `app.py:101-128` — `store_game_action`
-- `app.py:191-194` — `X-Frame-Options` strip
-- `app.py:201-210` — `LOCATION_PORTS` dict
+- `app.py:45` — `game_baggage` context manager
+- `app.py:201` — `init_game_session_tracking`
+- `app.py:258` — `store_game_action`
+- `app.py:343` — `get_previous_action_context`
+- `app.py:385` — `create_span_link_from_context`
+- `app.py:404-407` — `X-Frame-Options` strip
+- `app.py:416` — `LOCATION_PORTS` dict
+- `app.py:832` / `:850` — `_deactivate_ai_once` / `_reject_if_game_over`
 
 ## Cross-references
 

--- a/game-of-tracing/war_map/app.py
+++ b/game-of-tracing/war_map/app.py
@@ -6,9 +6,11 @@ import threading
 import uuid
 import time
 import atexit
+from contextlib import contextmanager
 from flask import Flask, render_template, jsonify, request, redirect, url_for, session
 from telemetry import GameTelemetry
-from opentelemetry import trace
+from opentelemetry import baggage, trace
+from opentelemetry import context as otel_context
 from opentelemetry.trace import SpanKind
 from opentelemetry.propagate import inject
 
@@ -31,6 +33,41 @@ GAME_SESSIONS_DB = os.environ.get('GAME_SESSIONS_DB', 'game_sessions.db')  # Use
 GAME_OVER = False
 WINNER = None
 VICTORY_MESSAGE = None
+# Fires the AI /deactivate call exactly once per declared winner.
+AI_DEACTIVATED_ON_GAME_OVER = False
+
+# (connect, read) timeouts for outbound HTTP — a hung location server must
+# never block a war_map worker thread indefinitely.
+REQUEST_TIMEOUT = (3, 10)
+
+
+@contextmanager
+def game_baggage(game_session_id=None, faction=None, actor="player"):
+    """Attach game-context entries as W3C Baggage for the enclosed block.
+
+    Baggage travels with the trace context: ``inject(headers)`` writes a
+    ``baggage`` HTTP header alongside ``traceparent``, and every downstream
+    service's propagator extracts it automatically — no per-service code.
+    The BaggageSpanProcessor (telemetry.py) then stamps the allow-listed
+    entries onto every span started while the baggage is set, including
+    spans created later in background threads (``get_current()`` captures
+    baggage too). Net effect: TraceQL like {span.game.session.id="<id>"}
+    matches a player action's *entire* downstream cascade.
+
+    Set the baggage *before* starting the action span so the war_map span
+    itself gets stamped as well.
+    """
+    ctx = otel_context.get_current()
+    if game_session_id:
+        ctx = baggage.set_baggage("game.session.id", str(game_session_id), context=ctx)
+    if faction:
+        ctx = baggage.set_baggage("player.faction", str(faction), context=ctx)
+    ctx = baggage.set_baggage("game.actor", actor, context=ctx)
+    token = otel_context.attach(ctx)
+    try:
+        yield
+    finally:
+        otel_context.detach(token)
 
 # ----------------------------------------------------------------
 # Maps — in-UI picker metadata.
@@ -215,6 +252,9 @@ init_game_session_tracking()
 # initialized lazily on first call to _ensure_game_config_tables() — see
 # the in-process startup path later in this module.
 
+_store_action_lock = threading.Lock()
+
+
 def store_game_action(game_session_id, action_type, player_name, faction,
                      trace_id, span_id, location_id=None, target_location_id=None,
                      game_state=None, map_id=None):
@@ -230,30 +270,42 @@ def store_game_action(game_session_id, action_type, player_name, faction,
         except Exception:
             map_id = DEFAULT_MAP_ID
 
-    conn = sqlite3.connect(GAME_SESSIONS_DB)
-    cursor = conn.cursor()
+    # MAX+1 then INSERT is not atomic; the lock serialises writers in this
+    # process and the IntegrityError retry covers a UNIQUE collision from
+    # any other writer — a silently dropped row here breaks the span-link
+    # replay chain for the whole session.
+    with _store_action_lock:
+        conn = sqlite3.connect(GAME_SESSIONS_DB, timeout=15)
+        try:
+            cursor = conn.cursor()
+            for attempt in (1, 2):
+                cursor.execute(
+                    "SELECT MAX(action_sequence) FROM game_actions WHERE game_session_id = ?",
+                    (game_session_id,))
+                result = cursor.fetchone()
+                next_sequence = (result[0] or 0) + 1
 
-    # Get next sequence number
-    cursor.execute("SELECT MAX(action_sequence) FROM game_actions WHERE game_session_id = ?",
-                   (game_session_id,))
-    result = cursor.fetchone()
-    next_sequence = (result[0] or 0) + 1
+                logger.info(f"Storing action: session={game_session_id}, sequence={next_sequence}, action={action_type}, trace_id={trace_id}, span_id={span_id}, map_id={map_id}")
 
-    # Debug logging
-    logger.info(f"Storing action: session={game_session_id}, sequence={next_sequence}, action={action_type}, trace_id={trace_id}, span_id={span_id}, map_id={map_id}")
-
-    cursor.execute('''
-    INSERT INTO game_actions
-    (game_session_id, action_sequence, action_type, player_name, faction,
-     trace_id, span_id, location_id, target_location_id, timestamp, game_state_after, map_id)
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-    ''', (game_session_id, next_sequence, action_type, player_name, faction,
-          trace_id, span_id, location_id, target_location_id,
-          int(time.time()), json.dumps(game_state) if game_state else None, map_id))
-
-    conn.commit()
-    conn.close()
-    return next_sequence
+                try:
+                    cursor.execute('''
+                    INSERT INTO game_actions
+                    (game_session_id, action_sequence, action_type, player_name, faction,
+                     trace_id, span_id, location_id, target_location_id, timestamp, game_state_after, map_id)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    ''', (game_session_id, next_sequence, action_type, player_name, faction,
+                          trace_id, span_id, location_id, target_location_id,
+                          int(time.time()), json.dumps(game_state) if game_state else None, map_id))
+                    conn.commit()
+                    return next_sequence
+                except sqlite3.IntegrityError:
+                    if attempt == 2:
+                        raise
+                    logger.warning(
+                        f"Sequence collision for session {game_session_id} at {next_sequence}; retrying"
+                    )
+        finally:
+            conn.close()
 
 
 def get_session_map_id(session_id):
@@ -449,8 +501,14 @@ def _slot_port_pairs():
 # Note: GAME_OVER/WINNER/VICTORY_MESSAGE already declared near top of file.
 
 def get_db_connection():
-    """Create a connection to the SQLite database"""
-    conn = sqlite3.connect(DATABASE_FILE)
+    """Create a connection to the SQLite database.
+
+    game_state.db is shared with 8 location-server writers (WAL mode), so
+    mirror their timeout/busy_timeout settings — without them a busy writer
+    surfaces as an immediate 'database is locked' error here.
+    """
+    conn = sqlite3.connect(DATABASE_FILE, timeout=15)
+    conn.execute("PRAGMA busy_timeout=5000")
     conn.row_factory = sqlite3.Row
     return conn
 
@@ -726,30 +784,34 @@ def make_api_request(location_id, endpoint, method='GET', data=None):
     
     headers = {"Content-Type": "application/json"}
     if endpoint in important_endpoints:
-        # Create span only for important operations
+        # Create span only for important operations. Attribute names follow
+        # the OTel HTTP semantic conventions (url.full, http.request.method,
+        # http.response.status_code) so convention-aware tooling works
+        # without custom mapping.
         with tracer.start_as_current_span(
             "location_api_request",
             kind=SpanKind.CLIENT,
             attributes={
                 "location.id": location_id,
                 "location.endpoint": endpoint,
-                "http.method": method
+                "url.full": url,
+                "http.request.method": method
             }
         ) as span:
             inject(headers)  # Inject trace context into headers
             try:
                 if method == 'GET':
-                    response = requests.get(url, headers=headers)
+                    response = requests.get(url, headers=headers, timeout=REQUEST_TIMEOUT)
                 else:  # POST
-                    response = requests.post(url, json=data, headers=headers)
-                
-                span.set_attribute("http.status_code", response.status_code)
+                    response = requests.post(url, json=data, headers=headers, timeout=REQUEST_TIMEOUT)
+
+                span.set_attribute("http.response.status_code", response.status_code)
                 response.raise_for_status()
                 result = response.json()
-                
+
                 if not result.get("success", True):
                     span.set_status(trace.StatusCode.ERROR, result.get("message", "Unknown error"))
-                
+
                 return result
             except requests.RequestException as e:
                 span.record_exception(e)
@@ -759,13 +821,48 @@ def make_api_request(location_id, endpoint, method='GET', data=None):
         # For status checks and other non-important operations, just make the request without tracing
         try:
             if method == 'GET':
-                response = requests.get(url, headers=headers)
+                response = requests.get(url, headers=headers, timeout=REQUEST_TIMEOUT)
             else:  # POST
-                response = requests.post(url, json=data, headers=headers)
+                response = requests.post(url, json=data, headers=headers, timeout=REQUEST_TIMEOUT)
             response.raise_for_status()
             return response.json()
         except requests.RequestException as e:
             return {"error": str(e)}
+
+def _deactivate_ai_once():
+    """POST /deactivate to the AI the first time a winner is declared.
+
+    Without this the AI keeps fighting forever after a wall-hold win — its
+    own self-stop only triggers when its capital flips, which never happens
+    on White Walkers Attack.
+    """
+    global AI_DEACTIVATED_ON_GAME_OVER
+    if AI_DEACTIVATED_ON_GAME_OVER:
+        return
+    AI_DEACTIVATED_ON_GAME_OVER = True
+    try:
+        requests.post(f"{AI_SERVICE_URL}/deactivate", timeout=5)
+        logger.info("AI deactivated: game over")
+    except Exception as e:
+        logger.warning(f"Failed to deactivate AI at game over: {e}")
+
+
+def _reject_if_game_over():
+    """Return a 409 response when a winner has been declared, else None.
+
+    war_map is the single enforcement point for player actions — location
+    servers stay permissive by design (they are also each other's clients
+    for in-flight movements that should still resolve).
+    """
+    if GAME_OVER:
+        return jsonify({
+            "success": False,
+            "game_over": True,
+            "winner": WINNER,
+            "message": VICTORY_MESSAGE or "The war is over.",
+        }), 409
+    return None
+
 
 def check_game_over(locations_data, map_id=None):
     """Dispatch to the right win-condition check based on the active map."""
@@ -786,12 +883,14 @@ def check_capital_capture_win(locations_data):
         GAME_OVER = True
         WINNER = 'northern'
         VICTORY_MESSAGE = "The Northern Kingdom has conquered the Southern Capital! Victory through unity!"
+        _deactivate_ai_once()
         return True
 
     if locations_data.get('northern_capital', {}).get('faction') == 'southern':
         GAME_OVER = True
         WINNER = 'southern'
         VICTORY_MESSAGE = "The Southern Kingdom has conquered the Northern Capital! Glory to the South!"
+        _deactivate_ai_once()
         return True
 
     logger.info("Game is not over")
@@ -814,6 +913,7 @@ def check_wall_hold_win(locations_data, map_id):
         if ticks >= threshold:
             GAME_OVER = True
             WINNER = faction
+            _deactivate_ai_once()
             if faction == "nights_watch":
                 VICTORY_MESSAGE = (
                     "The Night's Watch held the Wall! The Long Night is broken."
@@ -831,10 +931,11 @@ def check_wall_hold_win(locations_data, map_id):
 
 def reset_game_state():
     """Reset the game state"""
-    global GAME_OVER, WINNER, VICTORY_MESSAGE
+    global GAME_OVER, WINNER, VICTORY_MESSAGE, AI_DEACTIVATED_ON_GAME_OVER
     GAME_OVER = False
     WINNER = None
     VICTORY_MESSAGE = None
+    AI_DEACTIVATED_ON_GAME_OVER = False
 
 def reset_game_data():
     """Reset the game completely by resetting each location's state"""
@@ -1184,10 +1285,14 @@ def game_map():
 @app.route('/api/collect_resources', methods=['POST'])
 def collect_resources():
     """API endpoint to collect resources at a location"""
+    rejection = _reject_if_game_over()
+    if rejection:
+        return rejection
+
     # Get game session info for span linking
     game_session_id = session.get('game_session_id')
     current_sequence = session.get('action_sequence', 0)
-    
+
     # Get previous action context for linking
     links = []
     if game_session_id and current_sequence > 0:
@@ -1196,8 +1301,8 @@ def collect_resources():
             link = create_span_link_from_context(previous_span_context, "game_sequence")
             if link:
                 links.append(link)
-    
-    with tracer.start_as_current_span(
+
+    with game_baggage(game_session_id, session.get('faction')), tracer.start_as_current_span(
         "collect_resources",
         kind=SpanKind.SERVER,
         links=links,
@@ -1206,7 +1311,9 @@ def collect_resources():
             "player.faction": session.get('faction', 'Unknown'),
             "game.session.id": game_session_id,
             "game.action.type": "collect_resources",
-            "game.action.sequence": current_sequence + 1
+            "game.action.sequence": current_sequence + 1,
+            # Dashboard TraceQL filter: {span.player.action=true}
+            "player.action": True
         }
     ) as span:
         location_id = request.json.get('location_id')
@@ -1241,10 +1348,14 @@ def collect_resources():
 @app.route('/api/create_army', methods=['POST'])
 def create_army():
     """API endpoint to create an army at a location"""
+    rejection = _reject_if_game_over()
+    if rejection:
+        return rejection
+
     # Get game session info for span linking
     game_session_id = session.get('game_session_id')
     current_sequence = session.get('action_sequence', 0)
-    
+
     # Get previous action context for linking
     links = []
     if game_session_id and current_sequence > 0:
@@ -1253,8 +1364,8 @@ def create_army():
             link = create_span_link_from_context(previous_span_context, "game_sequence")
             if link:
                 links.append(link)
-    
-    with tracer.start_as_current_span(
+
+    with game_baggage(game_session_id, session.get('faction')), tracer.start_as_current_span(
         "create_army",
         kind=SpanKind.SERVER,
         links=links,
@@ -1263,7 +1374,8 @@ def create_army():
             "player.faction": session.get('faction', 'Unknown'),
             "game.session.id": game_session_id,
             "game.action.type": "create_army",
-            "game.action.sequence": current_sequence + 1
+            "game.action.sequence": current_sequence + 1,
+            "player.action": True
         }
     ) as span:
         location_id = request.json.get('location_id')
@@ -1298,13 +1410,17 @@ def create_army():
 @app.route('/api/move_army', methods=['POST'])
 def move_army():
     """API endpoint to move an army"""
+    rejection = _reject_if_game_over()
+    if rejection:
+        return rejection
+
     # Get game session info for span linking
     game_session_id = session.get('game_session_id')
     current_sequence = session.get('action_sequence', 0)
-    
+
     # Debug logging
     logger.info(f"move_army: session={game_session_id}, current_sequence={current_sequence}")
-    
+
     # Get previous action context for linking
     # Note: current_sequence is the last stored sequence number, so we look for that
     previous_span_context = None
@@ -1316,8 +1432,8 @@ def move_army():
             if link:
                 links.append(link)
                 logger.info(f"Created span link to previous action (sequence {current_sequence})")
-    
-    with tracer.start_as_current_span(
+
+    with game_baggage(game_session_id, session.get('faction')), tracer.start_as_current_span(
         "move_army",
         kind=SpanKind.SERVER,
         links=links,  # Add span links here
@@ -1326,7 +1442,8 @@ def move_army():
             "player.faction": session.get('faction', 'Unknown'),
             "game.session.id": game_session_id,
             "game.action.type": "move_army",
-            "game.action.sequence": current_sequence + 1
+            "game.action.sequence": current_sequence + 1,
+            "player.action": True
         }
     ) as span:
         # Debug: log current span info
@@ -1476,12 +1593,17 @@ def reset_game():
 @app.route('/api/send_resources_to_capital', methods=['POST'])
 def send_resources_to_capital():
     """API endpoint to send resources from a village to its capital"""
-    with tracer.start_as_current_span(
+    rejection = _reject_if_game_over()
+    if rejection:
+        return rejection
+
+    with game_baggage(session.get('game_session_id'), session.get('faction')), tracer.start_as_current_span(
         "send_resources_to_capital",
         kind=SpanKind.SERVER,
         attributes={
             "player.name": session.get('player_name', 'Unknown'),
-            "player.faction": session.get('faction', 'Unknown')
+            "player.faction": session.get('faction', 'Unknown'),
+            "player.action": True
         }
     ) as span:
         location_id = request.json.get('location_id')
@@ -1498,10 +1620,14 @@ def send_resources_to_capital():
 @app.route('/api/all_out_attack', methods=['POST'])
 def all_out_attack():
     """API endpoint to launch an all-out attack from a capital"""
+    rejection = _reject_if_game_over()
+    if rejection:
+        return rejection
+
     # Get game session info for span linking
     game_session_id = session.get('game_session_id')
     current_sequence = session.get('action_sequence', 0)
-    
+
     # Get previous action context for linking
     links = []
     if game_session_id and current_sequence > 0:
@@ -1510,8 +1636,8 @@ def all_out_attack():
             link = create_span_link_from_context(previous_span_context, "game_sequence")
             if link:
                 links.append(link)
-    
-    with tracer.start_as_current_span(
+
+    with game_baggage(game_session_id, session.get('faction')), tracer.start_as_current_span(
         "all_out_attack",
         kind=SpanKind.SERVER,
         links=links,
@@ -1520,7 +1646,8 @@ def all_out_attack():
             "player.faction": session.get('faction', 'Unknown'),
             "game.session.id": game_session_id,
             "game.action.type": "all_out_attack",
-            "game.action.sequence": current_sequence + 1
+            "game.action.sequence": current_sequence + 1,
+            "player.action": True
         }
     ) as span:
         location_id = request.json.get('location_id')
@@ -1756,90 +1883,6 @@ def replay_session_page(session_id):
         location_positions=LOCATION_POSITIONS_BY_MAP[map_id],
         location_connections=LOCATION_CONNECTIONS_BY_MAP[map_id],
     )
-    """Debug endpoint to verify restart cleared all data properly"""
-    verification_results = {
-        'game_state_reset': False,
-        'span_links_cleared': False,
-        'faction_assignments_cleared': False,
-        'ai_deactivated': False,
-        'database_reset': False
-    }
-    
-    try:
-        # Check game state
-        verification_results['game_state_reset'] = not GAME_OVER and WINNER is None and VICTORY_MESSAGE is None
-        
-        # Check span links database
-        conn = sqlite3.connect(GAME_SESSIONS_DB)
-        cursor = conn.cursor()
-        cursor.execute("SELECT COUNT(*) FROM game_actions")
-        span_links_count = cursor.fetchone()[0]
-        conn.close()
-        verification_results['span_links_cleared'] = span_links_count == 0
-        
-        # Check faction assignments
-        db_conn = get_db_connection()
-        cursor = db_conn.cursor()
-        cursor.execute("SELECT name FROM sqlite_master WHERE type='table' AND name='war_map'")
-        table_exists = cursor.fetchone() is not None
-        
-        if table_exists:
-            cursor.execute("SELECT COUNT(*) FROM war_map")
-            faction_count = cursor.fetchone()[0]
-            verification_results['faction_assignments_cleared'] = faction_count == 0
-        else:
-            verification_results['faction_assignments_cleared'] = True
-        db_conn.close()
-        
-        # Check AI status
-        try:
-            response = requests.get(f"{AI_SERVICE_URL}/status", timeout=5)
-            if response.status_code == 200:
-                ai_status = response.json()
-                verification_results['ai_deactivated'] = not ai_status.get('active', False)
-            else:
-                verification_results['ai_deactivated'] = True  # Assume deactivated if can't reach
-        except:
-            verification_results['ai_deactivated'] = True  # Assume deactivated if can't reach
-        
-        # Check if location database reset to initial state
-        try:
-            locations_data = {}
-            for loc_id in _current_positions().keys():
-                data = make_api_request(loc_id, '')
-                if 'error' not in data:
-                    locations_data[loc_id] = data
-            
-            # Verify initial state
-            from game_config import LOCATIONS
-            database_reset = True
-            for loc_id, expected in LOCATIONS.items():
-                actual = locations_data.get(loc_id, {})
-                if (actual.get('faction') != expected['faction'] or
-                    actual.get('army') != expected['initial_army'] or
-                    actual.get('resources') != expected['initial_resources']):
-                    database_reset = False
-                    break
-            
-            verification_results['database_reset'] = database_reset
-        except Exception:
-            verification_results['database_reset'] = False
-        
-        # Overall status
-        all_clear = all(verification_results.values())
-        
-        return jsonify({
-            'success': True,
-            'all_systems_reset': all_clear,
-            'details': verification_results
-        })
-        
-    except Exception as e:
-        return jsonify({
-            'success': False,
-            'error': str(e),
-            'details': verification_results
-        }), 500
 
 @app.route('/api/replay/session/<session_id>', methods=['GET'])
 def get_replay_session(session_id):
@@ -2269,6 +2312,10 @@ def _wall_tick_thread():
                             attributes={"faction": holder, "ticks": ticks},
                         )
                         logger.info(f"Wall-hold win detected for {holder} on {map_id}")
+                        # Declare the winner immediately (flips GAME_OVER and
+                        # deactivates the AI) instead of waiting for the next
+                        # UI poll to run the check.
+                        check_wall_hold_win({}, map_id)
                 else:
                     reset_wall_hold(map_id)
                     tick_span.set_attribute("wall.holder", "contested")
@@ -2285,4 +2332,8 @@ threading.Thread(target=_wall_tick_thread, daemon=True, name="wall-tick").start(
 
 if __name__ == '__main__':
     port = int(os.environ.get('PORT', 8080))
-    app.run(host='0.0.0.0', port=port, debug=True) 
+    # use_reloader=False: Werkzeug's reloader forks a second process, which
+    # would start a second wall-tick thread — the WWA hold counter would then
+    # advance at 2x speed (win in 75 s instead of 150 s) in local runs.
+    # Docker is unaffected (it runs via `flask run` with FLASK_DEBUG=0).
+    app.run(host='0.0.0.0', port=port, debug=True, use_reloader=False)

--- a/game-of-tracing/war_map/static/css/style.css
+++ b/game-of-tracing/war_map/static/css/style.css
@@ -1211,6 +1211,24 @@ small.text-muted {
     line-height: 1;
 }
 
+/* ETA countdown under the traveling unit — seconds until the server
+   resolves this hop (animations are clocked to the server's march time) */
+.traveling-unit .unit-eta {
+    position: absolute;
+    bottom: -16px;
+    left: 50%;
+    transform: translateX(-50%);
+    font-size: 10px;
+    font-weight: 700;
+    font-family: 'Inter', sans-serif;
+    color: #e6edf3;
+    background: rgba(13, 17, 23, 0.85);
+    border-radius: 8px;
+    padding: 1px 6px;
+    line-height: 1.4;
+    white-space: nowrap;
+}
+
 @keyframes unitBob {
     0%, 100% { margin-top: 0; }
     50% { margin-top: -4px; }

--- a/game-of-tracing/war_map/telemetry.py
+++ b/game-of-tracing/war_map/telemetry.py
@@ -1,9 +1,10 @@
 import os
 
 from opentelemetry.sdk.resources import SERVICE_NAME, Resource
-from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace import TracerProvider, SpanProcessor
 from opentelemetry.sdk.trace.export import BatchSpanProcessor
 from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+from opentelemetry import baggage as otel_baggage
 from opentelemetry import trace
 
 # Logging setup
@@ -16,6 +17,32 @@ from opentelemetry._logs import set_logger_provider
 # Profiling setup (Pyroscope v2 + OTel span-profile linking)
 import pyroscope
 from pyroscope.otel import PyroscopeSpanProcessor
+
+
+class BaggageSpanProcessor(SpanProcessor):
+    """Copy selected W3C Baggage entries onto every span at start.
+
+    Baggage rides along with the trace context (the default propagator
+    injects/extracts the ``baggage`` HTTP header automatically), but it is
+    **not** written to spans by itself — without this processor the values
+    would cross every service boundary and still be invisible in Tempo.
+    Mirrors the contrib package ``opentelemetry-processor-baggage``;
+    reimplemented in a few lines so the demo carries no extra dependency.
+    Identical copies live in app/, war_map/, and ai_opponent/ telemetry.py
+    (each service is its own Docker build context).
+    """
+
+    # Allow-list, never copy-everything: baggage is caller-controlled in
+    # internet-facing systems, so stamping arbitrary entries onto spans
+    # would let clients inject attributes into your telemetry.
+    ALLOWED_KEYS = ("game.session.id", "player.faction", "game.actor")
+
+    def on_start(self, span, parent_context=None):
+        for key in self.ALLOWED_KEYS:
+            value = otel_baggage.get_baggage(key, parent_context)
+            if value is not None:
+                span.set_attribute(key, str(value))
+
 
 class GameTelemetry:
     def __init__(self, service_name, logging_endpoint="http://alloy:4318", tracing_endpoint="http://alloy:4317"):
@@ -72,6 +99,9 @@ class GameTelemetry:
         )
         
         trace.get_tracer_provider().add_span_processor(span_processor)
+        # Stamp allow-listed baggage entries onto every span — see
+        # BaggageSpanProcessor docstring.
+        trace.get_tracer_provider().add_span_processor(BaggageSpanProcessor())
         self.tracer = trace.get_tracer(__name__)
 
     def _setup_profiling(self):

--- a/game-of-tracing/war_map/templates/map.html
+++ b/game-of-tracing/war_map/templates/map.html
@@ -262,9 +262,12 @@
     // Event feed log (client-side)
     let eventLog = [];
 
-    // Animation tracking -- prevents map refresh from destroying in-flight animations
-    let activeAnimations = 0;
-    let pendingRefresh = false;
+    // The server delivers every army/resource hop after exactly this long
+    // (time.sleep(5) in location_server.py). Animations are clocked to the
+    // same value so the traveling unit arrives, the clash plays, and the
+    // map state flips at the same moment — instead of the animation
+    // finishing seconds before (or after) the server resolves the hop.
+    const SERVER_HOP_MS = 5000;
 
     // DOM elements
     const mapContainer = document.getElementById('mapContainer');
@@ -689,19 +692,10 @@
                 const tgtName = gameState.locations[targetId].name;
                 addEvent(`Army moved from ${srcName} to ${tgtName}`, gameState.playerFaction, 'fa-people-arrows');
 
-                // Delay periodic refresh until animation completes (~4s max)
-                let updateCount = 0;
-                const maxUpdates = 6;
-                setTimeout(() => {
-                    const updateInterval = setInterval(() => {
-                        refreshMapData();
-                        updateCount++;
-                        if (updateCount >= maxUpdates) {
-                            clearInterval(updateInterval);
-                            setTimeout(checkGameStatus, 1000);
-                        }
-                    }, 2500);
-                }, 4500);
+                // The army arrives server-side after SERVER_HOP_MS; the
+                // animation's arrival callback refreshes the map at that
+                // moment. One extra status check catches a capital capture.
+                setTimeout(checkGameStatus, SERVER_HOP_MS + 1500);
 
                 if (result.game_over) {
                     gameState.gameOver = true;
@@ -747,15 +741,39 @@
         }
     }
 
+    // --- Connection-loss banner ---
+    function setConnectionLost(lost) {
+        const mapAlert = document.getElementById('mapAlert');
+        if (!mapAlert) return;
+        if (lost) {
+            mapAlert.textContent = 'Connection lost — retrying…';
+            mapAlert.classList.remove('d-none');
+        } else if (mapAlert.textContent.startsWith('Connection lost')) {
+            mapAlert.classList.add('d-none');
+        }
+    }
+
     async function refreshMapData() {
         try {
             const response = await fetch('/api/map_data');
             const data = await response.json();
 
+            const prevLocations = gameState.locations || {};
             gameState.locations = data.locations;
             gameState.gameOver = data.game_over;
             gameState.winner = data.winner;
             gameState.victoryMessage = data.victory_message;
+
+            // Surface territory flips that happened server-side (AI moves,
+            // the other player, delayed battles) — without this, opponent
+            // captures just silently teleport the marker color on a poll.
+            for (const [id, loc] of Object.entries(data.locations)) {
+                const old = prevLocations[id];
+                if (old && old.faction !== loc.faction) {
+                    showClashEffect(id, loc.faction === gameState.playerFaction ? 'capture' : 'attack');
+                    addEvent(`${loc.name} taken by ${loc.faction.replace('_', ' ')}`, loc.faction, 'fa-flag');
+                }
+            }
 
             // Update the Wall Hold HUD if present (White Walkers Attack).
             if (data.wall_hold) {
@@ -767,31 +785,23 @@
                 if (ww) ww.textContent = `${holds.white_walkers || 0}/${threshold}`;
             }
 
-            // Defer visual rebuild while animations are playing
-            if (activeAnimations > 0) {
-                pendingRefresh = true;
-                updateHUD(); // HUD is safe to update immediately
-                return;
-            }
+            setConnectionLost(false);
 
+            // Rebuild immediately — the map should always show the server's
+            // truth. In-flight units are separate DOM elements (children of
+            // mapContainer, not the markers layer), so a rebuild never
+            // destroys a running animation, and the source showing army=0
+            // the moment a march starts is accurate: the army really has
+            // left (debit-at-send on the server).
             refreshMap();
 
             const moveArmyModal = bootstrap.Modal.getInstance(document.getElementById('moveArmyModal'));
             if (moveArmyModal) moveArmyModal.hide();
+            return true;
         } catch (error) {
             console.error('Error refreshing map data:', error);
-            const mapAlert = document.getElementById('mapAlert');
-            mapAlert.textContent = 'Failed to refresh map data. Please try again.';
-            mapAlert.classList.remove('d-none');
-            setTimeout(() => { mapAlert.classList.add('d-none'); }, 5000);
-        }
-    }
-
-    // Flush a deferred refresh once all animations finish
-    function flushPendingRefresh() {
-        if (pendingRefresh && activeAnimations === 0) {
-            pendingRefresh = false;
-            refreshMap();
+            setConnectionLost(true);
+            return false;
         }
     }
 
@@ -816,9 +826,11 @@
 
         // Poll every 5 s so the wall-hold counter and resource HUD reflect
         // the wall-tick thread (30 s cadence) and AI moves within seconds
-        // rather than up to a minute later.
-        setInterval(refreshMapData, 5000);
-        setInterval(checkGameStatus, 5000);
+        // rather than up to a minute later. Self-scheduling (not
+        // setInterval) so a slow request never overlaps the next poll, and
+        // consecutive failures back off (5 s → 10 s → 30 s) behind a
+        // "connection lost" banner instead of hammering a down server.
+        schedulePoll();
 
         document.getElementById('sendResourcesBtn').addEventListener('click', () => {
             if (gameState.selectedLocation) sendResourcesToCapital(gameState.selectedLocation);
@@ -898,8 +910,6 @@
         const toLoc = gameState.locations[toLocId];
         if (!fromLoc || !toLoc) return;
 
-        activeAnimations++;
-
         const fromX = mapContainer.clientWidth * (fromLoc.x / 100);
         const fromY = mapContainer.clientHeight * (fromLoc.y / 100);
         const toX = mapContainer.clientWidth * (toLoc.x / 100);
@@ -925,17 +935,24 @@
             unit.appendChild(badge);
         }
 
+        // ETA countdown so the player can see how long until the hop
+        // resolves on the server (the march is a fixed SERVER_HOP_MS).
+        const eta = document.createElement('span');
+        eta.className = 'unit-eta';
+        unit.appendChild(eta);
+
         // Start position
         unit.style.left = `${fromX}px`;
         unit.style.top = `${fromY}px`;
         unit.style.transform = 'translate(-50%, -50%)';
         mapContainer.appendChild(unit);
 
-        // Calculate travel distance and duration -- longer for more drama
         const dx = toX - fromX;
         const dy = toY - fromY;
         const distance = Math.sqrt(dx * dx + dy * dy);
-        const duration = Math.max(2000, Math.min(4000, distance * 6)); // 2s - 4s
+        // Clock the animation to the server's march time so arrival on
+        // screen coincides with arrival on the server (see SERVER_HOP_MS).
+        const duration = (opts && opts.durationMs) || SERVER_HOP_MS;
 
         // Add connection pulse dots along the path
         const pulseCount = Math.max(3, Math.round(distance / 80));
@@ -973,6 +990,11 @@
             const cy = fromY + dy * ease;
             unit.style.left = `${cx}px`;
             unit.style.top = `${cy}px`;
+
+            // Seconds until the server resolves this hop
+            const remaining = Math.ceil((duration - elapsed) / 1000);
+            const etaText = remaining > 0 ? `${remaining}s` : '';
+            if (eta.textContent !== etaText) eta.textContent = etaText;
 
             // Drop trail particles every ~60ms
             trailTimer += (now - (step._lastFrame || now));
@@ -1016,9 +1038,7 @@
                 unit.remove();
                 pulses.forEach(p => p.remove());
 
-                activeAnimations--;
                 if (onArrive) onArrive();
-                flushPendingRefresh();
             }
         }
 
@@ -1066,6 +1086,15 @@
         }
     }
 
+    // Refresh state right after a hop resolves on the server. The small
+    // delay covers the network gap between the animation clock and the
+    // server's delivery; the second refresh catches battle aftermath
+    // (chained movements, faction flips propagating).
+    function refreshAtArrival() {
+        setTimeout(refreshMapData, 300);
+        setTimeout(refreshMapData, 2000);
+    }
+
     // Animate army movement with travel + clash at arrival
     function animateArmyMove(sourceId, targetId, faction, isAttack) {
         animateTravelingUnit(sourceId, targetId, faction, 'army', () => {
@@ -1074,10 +1103,12 @@
             } else {
                 showClashEffect(targetId, 'reinforce');
             }
+            refreshAtArrival();
         });
     }
 
-    // Animate resource cart along a multi-hop path
+    // Animate resource cart along a multi-hop path. The server relays each
+    // hop back-to-back (5 s per hop), so the next leg starts immediately.
     function animateResourcePath(path, faction) {
         if (path.length < 2) return;
 
@@ -1092,8 +1123,9 @@
                         // Final destination — gold sparkle
                         showClashEffect(path[hopIndex + 1], 'capture');
                     }
+                    refreshAtArrival();
                     hopIndex++;
-                    setTimeout(nextHop, 300);
+                    nextHop();
                 });
             }
         }
@@ -1138,17 +1170,11 @@
     }
 
     function startResourceTransferUpdates(path) {
-        // Delay refresh until cart animation finishes (~4s per hop)
-        const animDelay = (path.length - 1) * 4500 + 1000;
-        let updateCount = 0;
-        const maxUpdates = path.length * 2;
-        setTimeout(() => {
-            const updateInterval = setInterval(() => {
-                refreshMapData();
-                updateCount++;
-                if (updateCount >= maxUpdates) clearInterval(updateInterval);
-            }, 2500);
-        }, animDelay);
+        // Per-hop refreshes happen in animateResourcePath's arrival
+        // callbacks; this is just a final settle after the whole path
+        // (server time = hops × SERVER_HOP_MS).
+        const settleDelay = (path.length - 1) * SERVER_HOP_MS + 2500;
+        setTimeout(refreshMapData, settleDelay);
     }
 
     function startCooldownTimer(seconds) {
@@ -1189,7 +1215,11 @@
                 showActionStatus('success', result.message);
                 addEvent(`All-out attack launched from ${gameState.locations[locationId].name}!`, gameState.playerFaction, 'fa-skull-crossbones');
 
-                // Animate army marching along the full attack path, hop by hop
+                // Animate army marching along the full attack path, hop by
+                // hop, clocked to the server (SERVER_HOP_MS per hop, hops
+                // are back-to-back). Each arrival shows the clash and
+                // refreshes the map — so if the army dies at an
+                // intermediate battle, the next refresh shows the truth.
                 const hops = (result.path && result.path.length >= 2) ? result.path.length - 1 : 0;
                 if (hops > 0) {
                     let hopIdx = 0;
@@ -1202,28 +1232,17 @@
                                 } else {
                                     showClashEffect(result.path[hopIdx + 1], 'reinforce');
                                 }
+                                refreshAtArrival();
                                 hopIdx++;
-                                setTimeout(nextAttackHop, 200);
+                                nextAttackHop();
                             });
                         }
                     }
                     nextAttackHop();
                 }
 
-                // Delay refreshes until animations finish (~4s per hop + buffer)
-                const animDelay = hops * 4500 + 1000;
-                let updateCount = 0;
-                const maxUpdates = Math.max(3, hops * 2);
-                setTimeout(() => {
-                    const updateInterval = setInterval(() => {
-                        refreshMapData();
-                        updateCount++;
-                        if (updateCount >= maxUpdates) {
-                            clearInterval(updateInterval);
-                            setTimeout(checkGameStatus, 1000);
-                        }
-                    }, 2000);
-                }, animDelay);
+                // Final settle + victory check after the last hop resolves.
+                setTimeout(checkGameStatus, hops * SERVER_HOP_MS + 1500);
 
                 if (result.game_over) {
                     gameState.gameOver = true;
@@ -1252,9 +1271,36 @@
                 checkGameOver();
                 addEvent(`Game over! ${status.winner.charAt(0).toUpperCase() + status.winner.slice(1)} wins!`, status.winner, 'fa-crown');
             }
+            return true;
         } catch (error) {
             console.error('Error checking game status:', error);
+            return false;
         }
+    }
+
+    // --- Polling loop with failure backoff ---
+    const POLL_BASE_MS = 5000;
+    let pollFailures = 0;
+
+    function pollDelay() {
+        if (pollFailures === 0) return POLL_BASE_MS;
+        if (pollFailures === 1) return 10000;
+        return 30000;
+    }
+
+    async function pollOnce() {
+        const mapOk = await refreshMapData();
+        const statusOk = await checkGameStatus();
+        if (mapOk && statusOk) {
+            pollFailures = 0;
+        } else {
+            pollFailures++;
+        }
+        setTimeout(pollOnce, pollDelay());
+    }
+
+    function schedulePoll() {
+        setTimeout(pollOnce, POLL_BASE_MS);
     }
 
     // Expose animation functions for debugging/testing


### PR DESCRIPTION
# Game of Traces — hardening + OTel teaching improvements

This PR improves the `game-of-tracing` scenario along three tracks: **(A)** game-logic hardening so play is reliable, **(B)** new OpenTelemetry teaching concepts (baggage, span events, semantic conventions, exemplars), and **(C)** synchronizing the UI map animations with the server's actual timing.

## Track A — Game-state hardening

**Crash fix (reachable in routine play):** `/receive_resources`'s forwarding thread called `self._start_movement_trace(...)` — a method that **does not exist anywhere**. Any resource transfer whose path crossed more than one hop crashed the thread with `AttributeError` and stranded the resources. Rewritten using the canonical context-capture pattern via a shared `_forward_resources()` helper.

**Movement integrity (a miniature distributed-transactions lesson, documented as such):**
- **Debit-at-send + guarded SQL.** `/move_army` and `/all_out_attack` debit the source with `UPDATE … WHERE army = ?` (optimistic concurrency — the loser of a concurrent race gets a 409 instead of double-marching the same troops). Resource sends use `WHERE resources >= ?`. This also removes the old credit-before-debit windows that duplicated resources for ~5s per hop (permanently, on the captured path).
- **Compensation.** If a delivery fails at the transport level, the in-flight units are credited back additively (`army_returned` / `resources_returned` span events). A *lost battle* or a *captured caravan* is a game outcome — no refund (`captured: true` flag distinguishes the two).
- **Idempotency.** Every movement carries a `movement_id` (also stamped as `game.movement.id` on every hop's spans); `/receive_army` dedupes, so the new single transport retry in the HTTP helper can never fight the same battle twice.
- **Input validation.** `/receive_army` / `/receive_resources` reject out-of-range amounts, unknown factions, and non-adjacent sources.

**Logic fixes:** friendly-passage no longer deletes merged army stacks or overwrites capital garrisons; the all-out-attack path convention is unified (every hop previously **self-delivered once**, doubling travel time); `reset_database()` re-reads the active map before reseeding (map switches used to repopulate with the *old* map's rows) and seeds the corpse pool at t=0 so the White Walker AI works before its first battle.

**Game flow & resilience:** player actions return 409 once a winner is declared and the AI is deactivated exactly once — including wall-hold wins, where the AI previously fought forever; economy caps (`max_resources`/`max_army`/`max_corpses`) clamp passive income centrally; all four passive threads survive transient SQLite errors and report liveness via `/health`; HTTP timeouts everywhere; war_map gets SQLite busy timeouts and a serialized replay-sequence writer (collisions silently broke the replay chain); dead code removed; local Werkzeug reloader disabled (double wall-tick thread made WWA winnable in 75s instead of 150s).

## Track B — OTel teaching additions

- **W3C Baggage (flagship).** war_map sets `game.session.id` / `player.faction` / `game.actor` as baggage before each player action; the AI sets `game.actor="ai"`. A small, heavily-commented allow-list `BaggageSpanProcessor` in each service stamps the entries onto every span. Location servers attach the extracted context per-request (`before_request`), so baggage flows through **every** hop and into the 5s-delayed background-thread spans. Verified: `{span.game.session.id="<id>"}` returns the full downstream cascade.
- **The documented dashboard attributes now exist.** `battle.occurred`, `player.action`, `resource.movement` appeared in README/AGENTS.md as "dashboard-critical — preserve" but were never set anywhere in code. They're real now and verified queryable in Tempo.
- **Span events + exceptions.** Battle spans emit `battle_started` / `casualties_calculated` / `territory_captured`; failure paths consistently `record_exception()`.
- **HTTP semantic conventions.** `url.full`, `http.request.method`, `http.response.status_code` in all three HTTP client helpers, with comments explaining why conventions matter.
- **README** gains teaching sections for baggage, span events, semconv, and the already-wired-but-untaught metric exemplars click-path. The `config.alloy` header claiming "with Tail Sampling" (there is none) is corrected; the new attributes are flagged as ready-made keys for a tail-sampling exercise.

## Track C — UI ↔ server sync

The server delivers every hop after exactly 5s, but animations ran 2–4s based on pixel distance — clashes played seconds before the state actually changed, then markers flipped with no animation. Now:
- Animations are clocked to `SERVER_HOP_MS = 5000` with a **live ETA countdown badge** on the traveling unit; multi-hop paths chain back-to-back like the server's relays.
- The map refreshes exactly at each arrival (clash effect and state flip land together) instead of bursty disconnected `setInterval` storms.
- Refresh-deferral during animations is removed — the map always shows server truth (source showing `army=0` mid-flight is *accurate* with debit-at-send; in-flight units are separate DOM elements that survive rebuilds).
- Territory flips caused by the AI/other player (previously silent marker teleports) now fire a clash effect + event-feed entry, and the 5s poll is self-scheduling with failure backoff behind a "connection lost" banner.

## Verification (full stack run via `docker compose up -d --build`)

- Multi-hop resource send: source debited immediately, relay hop does **not** bank, capital +80 banked, no `AttributeError`
- Army to a stopped container: army 1 → 0 (in flight) → 1 (returned)
- Two parallel `/move_army`: exactly one succeeds, the other 409; lost battle correctly not refunded
- Payload injection (`army_size: 99999`, unknown faction, non-adjacent source) → 400
- Capital capture → `game_over`, player actions 409, AI inactive
- Map switch → identities rebound, no stale rows, corpse pool seeded, corpse-tick thread alive in `/health`
- Tempo: `{span.player.action=true}` / `{span.battle.occurred=true}` / `{span.resource.movement=true}` / `{span.game.movement.id!=""}` all return traces; battle span shows the three events; delayed `army_movement` and downstream `receive_army` spans carry `game.session.id` from baggage
- `python -m py_compile` on all touched Python; `node --check` on the inline map JS

Docs updated in the same change per the scenario's doc-sync rule: `AGENTS.md`, `CLAUDE.md`, `app/CLAUDE.md`, `war_map/CLAUDE.md`, `ai_opponent/CLAUDE.md`, `SPAN_LINKS.md`, `README.md` (incl. refreshed line anchors).

https://claude.ai/code/session_01NR5JkPQkiMWswMkznQYrwJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01NR5JkPQkiMWswMkznQYrwJ)_