### PR TITLE
game-of-tracing: WWA capital-capture win + wall-keep economy

### DIFF
--- a/game-of-tracing/AGENTS.md
+++ b/game-of-tracing/AGENTS.md
@@ -77,7 +77,7 @@ Overriding `DATABASE_FILE` (game_state) or `GAME_SESSIONS_DB` (game_sessions) en
 | Map id | Players | Factions | Win | Notable rules |
 |---|---|---|---|---|
 | `war_of_kingdoms` (default) | 2 | `southern`, `northern`, `neutral` | Capture enemy capital | Classic — 30 resources per army, 20 resource/collect at capitals, village passive +10/15 s |
-| `white_walkers_attack` | 1 (player is `nights_watch`) | `nights_watch`, `white_walkers`, `barbarian`, `neutral` | Hold every `wall` keep for 5 × 30 s ticks | `wall` settlement type doubles defenders; WW spends 5 corpses per army (no resources); barbarian villages grow +1 army every 30 s; WW fortress passively +1 corpse every 15 s |
+| `white_walkers_attack` | 1 (player is `nights_watch`) | `nights_watch`, `white_walkers`, `barbarian`, `neutral` | Capture the enemy fortress, or hold every `wall` keep for 5 × 30 s ticks | `wall` settlement type doubles defenders and earns its holder +5 resources/15 s (sendable to the capital); WW spends 5 corpses per army (no resources); barbarian villages grow +1 army every 30 s; WW fortress passively +1 corpse every 15 s |
 
 Each map also defines a **slot assignments** dict (`slot_1` → logical location id) so the 8 physical containers can serve either map. See "Slot identity" below.
 

--- a/game-of-tracing/CLAUDE.md
+++ b/game-of-tracing/CLAUDE.md
@@ -10,7 +10,7 @@
 
 ### Two maps, one stack
 
-The scenario ships **two maps** selected via an in-UI picker at game start: `war_of_kingdoms` (default 2-player) and `white_walkers_attack` (single-player Night's Watch vs AI White Walkers with `wall` keeps, corpse economy, and a 5-tick hold-to-win condition). Both reuse the same 8 location containers — each container has a constant `SLOT_ID` env and picks up its logical identity from `MAPS[active_map_id]["slot_assignments"][SLOT_ID]` in `app/game_config.py`. Changing maps writes a new `active_map_id` to the shared `game_config` table and POSTs `/reload` to every slot.
+The scenario ships **two maps** selected via an in-UI picker at game start: `war_of_kingdoms` (default 2-player) and `white_walkers_attack` (single-player Night's Watch vs AI White Walkers with income-producing `wall` keeps, a corpse economy, and two win paths — capture the enemy fortress or hold the Wall for 5 ticks). Both reuse the same 8 location containers — each container has a constant `SLOT_ID` env and picks up its logical identity from `MAPS[active_map_id]["slot_assignments"][SLOT_ID]` in `app/game_config.py`. Changing maps writes a new `active_map_id` to the shared `game_config` table and POSTs `/reload` to every slot.
 
 ## Sub-agent dispatch
 

--- a/game-of-tracing/README.md
+++ b/game-of-tracing/README.md
@@ -75,11 +75,14 @@ The Long Night has come. The human plays the **Night's Watch** (player faction);
 
 New mechanics:
 
-- **Wall settlements** run across the middle of the map. Defenders count **2×** when a wall is attacked, making them hard to dislodge.
+- **Wall settlements** run across the middle of the map. Defenders count **2×** when a wall is attacked, making them hard to dislodge. Each wall keep also produces **+5 resources every 15 s** for whoever holds it, and the owner can send the stockpile back to their capital — taking the Wall funds the war.
 - **Corpse economy.** White Walkers spend **corpses** (not resources) to raise new armies at their fortress. Corpses come from winning battles (every unit killed on either side becomes a corpse) plus a slow passive tick at the fortress itself. Cost: 5 corpses per unit.
 - **Barbarians** never attack. They accrue +1 army every 30 s — easy farm for White Walkers, but they also harass unguarded Night's Watch supply lines.
 
-**Win condition:** hold *every* wall settlement continuously for **5 ticks** (150 s, since the tick is 30 s). Any wall changing hands resets the counter.
+**Win conditions** (either side, whichever comes first):
+
+- **Storm the enemy capital.** Capture The Lands of Always Winter and the Night King falls; lose Castle Black and the Long Night wins.
+- **Hold the Wall:** hold *every* wall settlement continuously for **5 ticks** (150 s, since the tick is 30 s). Any wall changing hands resets the counter.
 
 Both maps share the same 8 location containers — the active map lives in `game_state.db`, and the `/reload` endpoint on each service rebinds the slot's identity when the player switches maps via the picker.
 

--- a/game-of-tracing/app/CLAUDE.md
+++ b/game-of-tracing/app/CLAUDE.md
@@ -9,8 +9,8 @@ All 8 locations run the same codebase. A container's **slot** (set via `SLOT_ID`
 - Owns a row in the shared `game_state.db` (resources, army, faction).
 - Exposes an HTTP API for collecting resources, creating armies, moving armies, and launching attacks.
 - Instruments every route with OpenTelemetry traces, logs, and five custom game metrics.
-- Runs passive resource generation for villages (every 15 s) and handles cooldowns for capitals.
-- On the White Walkers Attack map, also runs: passive barbarian army growth (every 30 s at barbarian villages), passive corpse generation (every 15 s at the White Walker fortress), passive resource generation at the Night's Watch capital (+5 every 10 s — WWA has no friendly villages, so this replaces the click-only economy), and the wall multiplier (defenders count 2× at `wall`-type locations).
+- Runs passive resource generation for villages — and, on maps that price the type (WWA's wall keeps, +5/15 s), for `wall` locations — and handles cooldowns for capitals.
+- On the White Walkers Attack map, also runs: passive barbarian army growth (every 30 s at barbarian villages), passive corpse generation (every 15 s at the White Walker fortress, gated on the fortress's *live* faction so it stops once stormed), passive resource generation at the Night's Watch capital (+5 every 10 s — WWA has no friendly villages, so this replaces the click-only economy), and the wall multiplier (defenders count 2× at `wall`-type locations).
 
 Ports 5001-5008:
 
@@ -50,7 +50,7 @@ Service names (hyphenated) match the `SERVICE_NAME` resource attribute used in t
 | `POST` | `/receive_army` | `receive_army` | Target of `_continue_army_movement`; validates payload, dedupes by `movement_id`, resolves battle via `_handle_battle` with span events |
 | `POST` | `/receive_resources` | `receive_resources` | Target of `_forward_resources`; validates payload; banks at destination, relays at intermediate hops (no banking), `captured: true` on faction mismatch |
 | `GET` | `/health` | — | Docker health check; returns `{"status": "ok"\|"degraded", "threads": {name: alive}}` with passive-thread liveness |
-| `POST` | `/send_resources_to_capital` | — | Village → friendly capital; guarded debit-at-send, then `_forward_resources` |
+| `POST` | `/send_resources_to_capital` | — | Village or wall keep → friendly capital; guarded debit-at-send, then `_forward_resources` |
 | `POST` | `/reload` | — | Re-read `active_map_id` + rebind slot identity in place (war_map calls this after `/select_map`) |
 | `GET` | `/faction_economy?faction=...` | — | Read a faction's corpse pool (AI uses it) |
 
@@ -157,12 +157,12 @@ All defined in `app/game_config.py`'s `MAPS["white_walkers_attack"]["rules"]`. A
 - **Wall defender multiplier** — `_handle_battle` accepts a `location_type` argument and scales `defending_army` by `rules["wall_multiplier"]` (2.0 on WWA, 1.0 on WoK) when the location type is `wall`. Remaining defender count is converted back to physical units after the fight.
 - **Corpse economy** — when the battle winner is `white_walkers`, the post-battle hook in `receive_army` calls `self._add_corpses(attacking + defending - remaining, "white_walkers")`. `create_army` reads `get_army_currency(map_id, faction)` and, for `currency == "corpses"`, atomically decrements via `_spend_corpses` instead of touching `resources`. The corpse pool lives in `faction_economy` (persistent) so a `/reload` doesn't wipe it.
 - **Barbarian passive growth** — `_start_barbarian_growth(interval_s)` runs when `faction == "barbarian"`; adds +1 army every `rules["barbarian_army_growth_interval_s"]` (30 s). Guards each iteration against identity changes via `/reload`.
-- **Captured-camp resource generation** — `_start_passive_generation()` is launched for *every* `type == "village"` slot at boot (including barbarian Free Folk camps). The per-iteration `faction != "barbarian"` guard keeps it a no-op while the camp is still barbarian, then it starts producing the standard village amount the moment the player captures it. Without this fallthrough, captured camps stayed unproductive because the thread was never started on barbarian slots.
-- **White Walker passive corpses** — `_start_white_walker_corpse_tick(interval_s)` runs at the WW fortress, +1 corpse every `rules["white_walker_passive_corpse_interval_s"]` (15 s).
+- **Captured-camp and wall-keep resource generation** — `_start_passive_generation()` is launched for *every* `village` and `wall` slot at boot (including barbarian Free Folk camps). Each iteration looks up the per-type amount in `rules["resource_generation"]` (village 10, wall 5 on WWA; walls unpriced on WoK → no-op) and skips while the live owner is `barbarian`, so a captured camp or keep starts producing the moment its row flips. Owners can ship the stockpile home via `/send_resources_to_capital`.
+- **White Walker passive corpses** — `_start_white_walker_corpse_tick(interval_s)` runs at the WW fortress, +1 corpse every `rules["white_walker_passive_corpse_interval_s"]` (15 s), gated on the fortress's *live* DB faction so corpses stop rising once the Night's Watch storms it.
 - **Night's Watch passive resources** — `_start_nights_watch_capital_resource_tick(interval_s, amount)` runs at Castle Black on WWA (`faction == "nights_watch"`, `loc_type == "capital"`), adding `rules["nights_watch_capital_passive_amount"]` resources every `rules["nights_watch_capital_passive_interval_s"]` (5 per 10 s). Manual `/collect_resources` (+20, 5 s cooldown) still works alongside.
 - **Economy caps** — `rules["max_resources"]` (1000), `rules["max_army"]` (50), `rules["max_corpses"]` (200) on *both* maps; clamped centrally in `_update_location_state` / `_credit_*` / `_add_corpses` so AFK passive income can't break the late game.
 - **Thread resilience** — every passive loop wraps its iteration in try/except (a transient SQLite busy error must not kill the economy permanently), registers itself in `self._passive_threads`, and is surfaced via `/health`'s `threads` map.
-- **Corpse pool seeding** — `reset_database()` (`location_server.py:1095`) re-reads the active map *before* repopulating (war_map writes the new `active_map_id` first, then calls `/reset`) and seeds a zero-corpse `faction_economy` row for every corpse-currency faction, so the AI's `/faction_economy` reads work from t=0.
+- **Corpse pool seeding** — `reset_database()` (`location_server.py:1105`) re-reads the active map *before* repopulating (war_map writes the new `active_map_id` first, then calls `/reset`) and seeds a zero-corpse `faction_economy` row for every corpse-currency faction, so the AI's `/faction_economy` reads work from t=0.
 
 ## DB additions (live in `game_state.db`)
 

--- a/game-of-tracing/app/game_config.py
+++ b/game-of-tracing/app/game_config.py
@@ -147,7 +147,8 @@ MAPS = {
         "display_name": "White Walkers Attack",
         "description": (
             "The Long Night has come. As the Night's Watch, hold every Wall "
-            "keep for 5 ticks (150 s) before the White Walkers do. Single-player."
+            "keep for 5 ticks (150 s) before the White Walkers do — or storm "
+            "The Lands of Always Winter. Single-player."
         ),
         "single_player": True,
         "player_faction": "nights_watch",
@@ -273,7 +274,10 @@ MAPS = {
         "rules": {
             # Night's Watch capital collects resources on the classic schedule.
             # White Walker fortress ignores resource_generation (uses corpses).
-            "resource_generation": {"capital": 20, "village": 10},
+            # Wall keeps earn a small passive income for whoever holds them
+            # (and can send it home), so taking the Wall pays — not just
+            # holding it for the tick counter.
+            "resource_generation": {"capital": 20, "village": 10, "wall": 5},
             "army_cost": {
                 "default": 30,
                 "white_walkers": 5,

--- a/game-of-tracing/app/location_server.py
+++ b/game-of-tracing/app/location_server.py
@@ -174,13 +174,13 @@ class LocationServer:
         faction = self.location_info["faction"]
         rules = self._current_rules()
 
-        # Launch the village resource thread for *every* village, including
-        # barbarian-faction slots (Free Folk camps). The thread guards each
-        # iteration on ``faction != "barbarian"``, so it stays a no-op while
-        # the camp is still barbarian and starts producing for the player
-        # the moment they capture it. Without this fallthrough, captured
-        # camps stay unproductive because the thread was never started.
-        if loc_type == "village" and not self._passive_thread_started:
+        # Launch the resource thread for *every* village and wall keep,
+        # including barbarian-faction slots (Free Folk camps). The thread
+        # guards each iteration on ``faction != "barbarian"`` and on the
+        # map's per-type generation amount, so it stays a no-op while the
+        # camp is still barbarian (or the map gives the type no income) and
+        # starts producing for the player the moment they capture it.
+        if loc_type in ("village", "wall") and not self._passive_thread_started:
             self._start_passive_generation()
             self._passive_thread_started = True
 
@@ -949,9 +949,14 @@ class LocationServer:
             while True:
                 try:
                     time.sleep(15)
-                    # Static identity guards against /reload moving this slot off
-                    # of a village type entirely.
-                    if self.location_info["type"] != "village":
+                    # Static identity guards against /reload moving this slot
+                    # off of a producing type entirely.
+                    if self.location_info["type"] not in ("village", "wall"):
+                        continue
+                    amount = self._current_rules()["resource_generation"].get(
+                        self.location_info["type"], 0
+                    )
+                    if amount <= 0:
                         continue
                     # Live-DB guard: gate on the *current* faction, not the
                     # boot-time identity, so a captured Free Folk camp starts
@@ -963,7 +968,6 @@ class LocationServer:
                         continue
                     if location_state["faction"] == "barbarian":
                         continue
-                    amount = self._current_rules()["resource_generation"]["village"]
                     with self.tracer.start_as_current_span(
                         "passive_resource_generation",
                         attributes={
@@ -1074,6 +1078,12 @@ class LocationServer:
                     time.sleep(interval_s)
                     if self.location_info["faction"] != "white_walkers" or self.location_info["type"] != "capital":
                         continue
+                    # Live-DB guard: the boot-time identity never updates on
+                    # battle, so without this the dead would keep rising at a
+                    # fortress the Night's Watch has already stormed.
+                    live_state = self._get_location_state(self.location_id)
+                    if live_state is None or live_state["faction"] != "white_walkers":
+                        continue
                     with self.tracer.start_as_current_span(
                         "white_walker_corpse_tick",
                         attributes={
@@ -1170,7 +1180,7 @@ class LocationServer:
                 with self.lock:
                     now = datetime.now()
                     last_time = self.last_resource_collection.get(self.location_id, datetime.min)
-                    wait_time = timedelta(seconds=15 if self.location_info["type"] == "village" else 5)
+                    wait_time = timedelta(seconds=15 if self.location_info["type"] in ("village", "wall") else 5)
 
                     if now - last_time < wait_time:
                         remaining = wait_time - (now - last_time)
@@ -1791,12 +1801,12 @@ class LocationServer:
                     span.set_attribute("resources_amount", current_resources)
                     span.set_attribute("faction", faction)
                     
-                    if self.location_info["type"] != "village":
-                        span.set_status(trace.StatusCode.ERROR, "Only villages can send resources")
-                        self.logger.error(f"Only villages can send resources to capital")
+                    if self.location_info["type"] not in ("village", "wall"):
+                        span.set_status(trace.StatusCode.ERROR, "Only villages and wall keeps can send resources")
+                        self.logger.error("Only villages and wall keeps can send resources to capital")
                         return jsonify({
                             "success": False,
-                            "message": "Only villages can send resources to capital"
+                            "message": "Only villages and wall keeps can send resources to capital"
                         }), 403
                     
                     resource_factions = {"southern", "northern", "nights_watch"}
@@ -1845,7 +1855,7 @@ class LocationServer:
                         }), 400
 
                     # Debit-at-send: guarded so a concurrent spend can't send
-                    # resources this village no longer has. If delivery fails,
+                    # resources this location no longer has. If delivery fails,
                     # _forward_resources credits the amount back.
                     if not self._debit_resources(self.location_id, current_resources):
                         span.set_status(trace.StatusCode.ERROR, "Resources changed during request")

--- a/game-of-tracing/war_map/CLAUDE.md
+++ b/game-of-tracing/war_map/CLAUDE.md
@@ -14,6 +14,7 @@
 - Proxies trace-replay queries to Tempo and falls back to local SQLite when Tempo is unavailable.
 - Instruments player actions as `SERVER` spans with `trace.Link`s chaining each action to the previous one in the session, with `player.action=true` and W3C Baggage (`game.session.id`, `player.faction`, `game.actor`) attached via the `game_baggage()` context manager (`app.py:45`).
 - Runs the **wall-hold tick thread** (`_wall_tick_thread`, 30 s cadence) that increments `wall_hold` when one faction owns every wall keep, and declares the WWA winner at 5 consecutive ticks (flipping the game-over flags directly, not just on the next poll).
+- **Declares the winner**: `check_game_over()` runs the capital-capture check on *every* map (driven by `CAPITALS_BY_MAP` — a capital held by anyone but its original owner ends the game), plus the wall-hold check on WWA. So on WWA either side can win fast by storming the enemy fortress or slow by holding the Wall.
 - **Enforces game over**: once a winner is declared, the five player-action endpoints return 409 via `_reject_if_game_over()` (`app.py:850`) and the AI is deactivated exactly once via `_deactivate_ai_once()` (`app.py:832`). Location servers stay permissive by design — in-flight movements should still resolve.
 
 ## File map

--- a/game-of-tracing/war_map/app.py
+++ b/game-of-tracing/war_map/app.py
@@ -97,7 +97,7 @@ MAPS_META = {
         "display_name": "White Walkers Attack",
         "description": (
             "The Long Night has come. As the Night's Watch, hold every Wall "
-            "keep for 5 ticks before the White Walkers do. Single-player."
+            "keep for 5 ticks — or storm the enemy fortress. Single-player."
         ),
         "single_player": True,
         "player_faction": "nights_watch",
@@ -832,9 +832,9 @@ def make_api_request(location_id, endpoint, method='GET', data=None):
 def _deactivate_ai_once():
     """POST /deactivate to the AI the first time a winner is declared.
 
-    Without this the AI keeps fighting forever after a wall-hold win — its
-    own self-stop only triggers when its capital flips, which never happens
-    on White Walkers Attack.
+    Without this the AI keeps fighting forever after a wall-hold win or a
+    Castle Black capture — its own self-stop only triggers when its *own*
+    capital flips.
     """
     global AI_DEACTIVATED_ON_GAME_OVER
     if AI_DEACTIVATED_ON_GAME_OVER:
@@ -864,36 +864,64 @@ def _reject_if_game_over():
     return None
 
 
+# Original owner of each capital, per map. A capital held by any other
+# non-neutral faction means the captor has won. Keep in sync with the
+# capital-type locations in app/game_config.py's MAPS[map_id]["locations"].
+CAPITALS_BY_MAP = {
+    "war_of_kingdoms": {
+        "southern_capital": "southern",
+        "northern_capital": "northern",
+    },
+    "white_walkers_attack": {
+        "nights_watch_fortress": "nights_watch",
+        "white_walker_fortress": "white_walkers",
+    },
+}
+
+CAPITAL_CAPTURE_MESSAGES = {
+    ("war_of_kingdoms", "northern"): "The Northern Kingdom has conquered the Southern Capital! Victory through unity!",
+    ("war_of_kingdoms", "southern"): "The Southern Kingdom has conquered the Northern Capital! Glory to the South!",
+    ("white_walkers_attack", "nights_watch"): "The Lands of Always Winter have fallen! The Night King is destroyed and the Long Night is over.",
+    ("white_walkers_attack", "white_walkers"): "Castle Black has fallen. The dead pour south — the Long Night has come for Westeros.",
+}
+
+
 def check_game_over(locations_data, map_id=None):
-    """Dispatch to the right win-condition check based on the active map."""
+    """Dispatch to the right win-condition checks based on the active map.
+
+    Capital capture ends the game on every map. White Walkers Attack adds
+    hold-the-walls as a second, slower path to victory.
+    """
     if map_id is None:
         map_id = get_active_map_id()
+    if check_capital_capture_win(locations_data, map_id):
+        return True
     if map_id == "white_walkers_attack":
-        # WWA games end only via hold-the-walls. Capital captures do not end
-        # the game (the capital can change hands mid-match).
         return check_wall_hold_win(locations_data, map_id)
-    return check_capital_capture_win(locations_data)
+    return False
 
 
-def check_capital_capture_win(locations_data):
-    """Classic WoK win: take the enemy capital."""
+def check_capital_capture_win(locations_data, map_id=None):
+    """Decisive win on every map: take a capital from its original owner."""
     global GAME_OVER, WINNER, VICTORY_MESSAGE
 
-    if locations_data.get('southern_capital', {}).get('faction') == 'northern':
+    if map_id is None:
+        map_id = get_active_map_id()
+
+    for capital_id, original_owner in CAPITALS_BY_MAP.get(map_id, {}).items():
+        captor = locations_data.get(capital_id, {}).get('faction')
+        if not captor or captor in (original_owner, 'neutral', 'barbarian'):
+            continue
         GAME_OVER = True
-        WINNER = 'northern'
-        VICTORY_MESSAGE = "The Northern Kingdom has conquered the Southern Capital! Victory through unity!"
+        WINNER = captor
+        VICTORY_MESSAGE = CAPITAL_CAPTURE_MESSAGES.get(
+            (map_id, captor),
+            f"{captor.replace('_', ' ').title()} has captured the enemy capital!",
+        )
         _deactivate_ai_once()
         return True
 
-    if locations_data.get('northern_capital', {}).get('faction') == 'southern':
-        GAME_OVER = True
-        WINNER = 'southern'
-        VICTORY_MESSAGE = "The Southern Kingdom has conquered the Northern Capital! Glory to the South!"
-        _deactivate_ai_once()
-        return True
-
-    logger.info("Game is not over")
+    logger.debug("Game is not over")
     return False
 
 
@@ -1479,7 +1507,7 @@ def move_army():
         )
         
         # Check if this move resulted in a victory condition
-        if target_id in ['southern_capital', 'northern_capital'] and result.get('success'):
+        if target_id in CAPITALS_BY_MAP.get(get_active_map_id(), {}) and result.get('success'):
             locations_data = {}
             for loc_id in _current_positions().keys():
                 data = make_api_request(loc_id, '')

--- a/game-of-tracing/war_map/templates/map.html
+++ b/game-of-tracing/war_map/templates/map.html
@@ -64,7 +64,7 @@
             <!-- Wall-hold HUD (WWA win-condition tracker) -->
             <div class="wall-hold-hud" id="wallHoldHud">
                 <h6><i class="fas fa-gavel me-1"></i>Wall Hold</h6>
-                <div class="small mb-1">Hold every keep for {{ wall_hold.threshold }} ticks to win.</div>
+                <div class="small mb-1">Hold every keep for {{ wall_hold.threshold }} ticks — or take the enemy fortress.</div>
                 <div class="hold-row nights_watch">
                     <span>Night's Watch</span>
                     <span class="ticks" id="hudHoldNightsWatch">
@@ -350,11 +350,8 @@
             } else {
                 gameOverTitle.textContent = "DEFEAT!";
                 gameOverTitle.classList.add('defeat-text');
-                if (gameState.winner === 'southern') {
-                    gameOverMessage.textContent = "The Southern Kingdom has conquered your capital! Glory to the South!";
-                } else {
-                    gameOverMessage.textContent = "The Northern Kingdom has conquered your capital! Victory through unity!";
-                }
+                gameOverMessage.textContent = gameState.victoryMessage ||
+                    `${(gameState.winner || 'The enemy').replace(/_/g, ' ')} has conquered your capital!`;
                 document.getElementById('victoryAnimation').classList.add('d-none');
                 document.getElementById('defeatAnimation').classList.remove('d-none');
             }
@@ -523,6 +520,7 @@
         // Show/hide buttons
         const isCapital = location.type === 'capital';
         const isVillage = location.type === 'village';
+        const isWall = location.type === 'wall';
         const isPlayerLocation = location.faction === gameState.playerFaction;
 
         document.getElementById('collectResourcesBtn').style.display =
@@ -532,7 +530,7 @@
         document.getElementById('allOutAttackBtn').style.display =
             (isCapital && isPlayerLocation) ? 'block' : 'none';
         document.getElementById('sendResourcesBtn').style.display =
-            (isVillage && isPlayerLocation) ? 'block' : 'none';
+            ((isVillage || isWall) && isPlayerLocation) ? 'block' : 'none';
 
         // Cooldown
         const cooldownSpan = document.getElementById('resourceCooldown');

--- a/game-of-tracing/war_map/templates/map_picker.html
+++ b/game-of-tracing/war_map/templates/map_picker.html
@@ -23,7 +23,7 @@
                             </span>
                             <h4>{{ meta.display_name }}</h4>
                             <p class="faction-motto">
-                                {% if meta.single_player %}Single-player · Hold to win
+                                {% if meta.single_player %}Single-player · Hold or capture to win
                                 {% else %}Two-player · Capture to win
                                 {% endif %}
                             </p>


### PR DESCRIPTION
Follow-up to #201, from playing the White Walkers Attack campaign end-to-end.

## What was broken

1. **Storming a fortress did nothing.** `check_game_over` routed WWA to the wall-hold check only, so capturing The Lands of Always Winter (or losing Castle Black) never ended the game — the AI quietly self-deactivated but the player got no victory screen and the match never resolved.
2. **No economy at the castles.** The four wall keeps were economically inert: no `resource_generation` price for the `wall` type, no passive thread, `/send_resources_to_capital` rejected non-villages, and the UI hid the send button on walls. Castle Black's slow trickle was the map's only income.

## Changes

- **Capital capture now ends the game on every map**, driven by a `CAPITALS_BY_MAP` table (a capital held by anyone but its original owner declares the captor the winner) with per-map victory messages. Wall-hold stays as WWA's alternative slow win; the dispatch runs capital capture first. The post-move victory check no longer hardcodes the WoK capital ids.
- **Defeat overlay** uses the server's victory message instead of hardcoded War-of-Kingdoms text (a WWA loss used to blame the "Northern Kingdom").
- **Corpse tick gates on the fortress's live DB faction**, so the dead stop rising once the Night's Watch storms it.
- **Wall keeps earn +5 resources / 15 s** for their holder (neutral keeps accrue it as capturable loot, matching villages). Owners can send the stockpile to their capital — the send button now shows on player-owned walls — and the passive-generation loop reads the per-type amount from the map rules instead of hardcoding the village rate.
- Docs swept in the same commit (README, AGENTS.md, CLAUDE.md files, map-picker copy, shifted line anchors).

## Verification (played in Docker)

- Castle Black passive income ticks +5/10 s; walls accrue +5/15 s while neutral and after capture.
- Captured `wall_west`, sent 40 banked resources home — delivered to Castle Black, wall debited and re-accruing.
- Stormed the WW fortress: `winner: nights_watch` with the new message, player actions return 409, AI reports `active: false`, corpse pool frozen.
- Simulated a WW capture of Castle Black: loss declared with the Castle Black message, AI deactivated.
- War of Kingdoms regression: northern capture of the southern capital still declares the original message verbatim.

https://claude.ai/code/session_01NR5JkPQkiMWswMkznQYrwJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01NR5JkPQkiMWswMkznQYrwJ)_