### PR TITLE
Add OTel load balancing scenario (otelcol.exporter.loadbalancing)

### DIFF
--- a/.github/scenario-list.txt
+++ b/.github/scenario-list.txt
@@ -18,6 +18,7 @@ mongodb-monitoring
 mysql-monitoring
 nginx-monitoring
 otel-basic-tracing
+otel-loadbalancing
 otel-metrics-pipeline
 otel-span-metrics
 otel-tail-sampling

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ These scenarios show distributed tracing with OpenTelemetry and Tempo.
 | [Distributed tracing](trace-delivery/) | Learn distributed tracing through a sofa delivery workflow from order to doorstep. |
 | [Game of tracing](game-of-tracing/) | Play an interactive strategy game that teaches distributed tracing, sampling, and service graphs. |
 | [OpenTelemetry basic tracing](otel-basic-tracing/) | Collect and visualize OpenTelemetry traces with Alloy and Tempo. |
+| [OpenTelemetry load balancing](otel-loadbalancing/) | Shard traces across two tail-sampling Alloy instances with `otelcol.exporter.loadbalancing` -- same trace ID, same backend. |
 | [OpenTelemetry service graphs](otel-tracing-service-graphs/) | Generate service graphs with the Alloy `servicegraph` connector. |
 | [OpenTelemetry span metrics](otel-span-metrics/) | Generate RED metrics from OpenTelemetry traces with the span metrics connector. Request rate, error rate, and duration. |
 | [OpenTelemetry tail sampling](otel-tail-sampling/) | Apply tail sampling policies to OpenTelemetry traces with Alloy and Tempo. |

--- a/otel-loadbalancing/README.md
+++ b/otel-loadbalancing/README.md
@@ -1,0 +1,73 @@
+# OpenTelemetry Trace-Aware Load Balancing with Grafana Alloy
+
+Tail sampling only works if a single instance sees *every* span of a trace — and a single instance is exactly what you don't want in a highly-available sampling tier. This scenario shows the standard answer: a load-balancer Alloy in front that shards traffic across two tail-sampling Alloys **by trace ID** with [`otelcol.exporter.loadbalancing`](https://grafana.com/docs/alloy/latest/reference/components/otelcol/otelcol.exporter.loadbalancing/).
+
+```
+                                       ┌──> alloy-downstream-1 ──┐
+trace-generator ──OTLP──> alloy-lb ────┤    (tail sampling)      ├──> Tempo ──> Grafana
+                       routing_key =   └──> alloy-downstream-2 ──┘
+                         "traceID"          (tail sampling)
+```
+
+The generator makes the problem real: it exports **every span in its own OTLP request**. A round-robin balancer would scatter the four spans of each trace across both downstreams, and tail sampling would make contradictory half-trace decisions. `routing_key = "traceID"` reassembles the stream so each downstream sees whole traces.
+
+## Prerequisites
+
+- Docker and Docker Compose installed
+
+## Getting Started
+
+```bash
+git clone https://github.com/grafana/alloy-scenarios.git
+cd alloy-scenarios/otel-loadbalancing
+docker compose up -d --build
+```
+
+## Access Points
+
+| Service              | URL                    |
+|----------------------|------------------------|
+| Grafana              | http://localhost:3000  |
+| Alloy UI (LB tier)   | http://localhost:12345 |
+| Alloy UI (downstream 1) | http://localhost:12346 |
+| Alloy UI (downstream 2) | http://localhost:12347 |
+| Prometheus           | http://localhost:9090  |
+| Tempo                | http://localhost:3200  |
+
+## What to Expect
+
+The generator emits one `checkout` trace per second with exactly four spans. ~15% carry an error and ~18% are slower than 2 seconds; the downstream tail samplers keep only those (policies: `status_code` + `latency` — deliberately no probabilistic fallback, so every sampling decision is explainable).
+
+**See the split.** In Grafana **Explore → Prometheus**:
+
+```promql
+sum by (instance) (rate(otelcol_receiver_accepted_spans_total{job="alloy-downstream"}[2m]))
+```
+
+Both downstream instances receive a steady share of spans — that's the load balancer distributing traces.
+
+**See the affinity.** In **Explore → Tempo**, search for traces of service `trace-generator` and open any of them: every sampled trace has all **4/4 spans**. Because each span travelled in its own OTLP request and the sampling policies are deterministic, a complete trace is only possible if the load balancer routed all of its spans to the same downstream instance.
+
+**See the sampling.** Compare span rates entering the downstream tier with spans leaving it for Tempo:
+
+```promql
+sum(rate(otelcol_receiver_accepted_spans_total{job="alloy-downstream"}[2m]))
+```
+
+```promql
+sum(rate(otelcol_exporter_sent_spans_total{job="alloy-downstream"}[2m]))
+```
+
+The gap is the healthy, fast traffic tail sampling dropped.
+
+## Scaling the Pattern
+
+* Add a third downstream: one more compose service plus one more hostname in `config-lb.alloy`'s `resolver.static.hostnames` — the consistent hash redistributes automatically.
+* On Kubernetes, swap the `static` resolver for the `dns` or `k8s` resolver so the downstream set tracks a headless Service or pod selector.
+* `routing_key = "service"` groups by service name instead — useful in front of `otelcol.connector.spanmetrics` rather than tail sampling.
+
+## Stopping the Scenario
+
+```bash
+docker compose down
+```

--- a/otel-loadbalancing/app/Dockerfile
+++ b/otel-loadbalancing/app/Dockerfile
@@ -1,0 +1,11 @@
+ARG PYTHON_VERSION=3.11-slim@sha256:a3ab0b966bc4e91546a033e22093cb840908979487a9fc0e6e38295747e49ac0
+FROM python:${PYTHON_VERSION}
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY main.py .
+
+CMD ["python", "main.py"]

--- a/otel-loadbalancing/app/main.py
+++ b/otel-loadbalancing/app/main.py
@@ -1,0 +1,91 @@
+"""Trace generator for the otel-loadbalancing scenario.
+
+Emits one trace per second with EXACTLY four spans (checkout -> auth,
+inventory, payment), and exports every span in its own OTLP request
+(SimpleSpanProcessor). Spans of one trace arriving in separate requests is
+the hard case for sampling infrastructure: a round-robin load balancer
+would scatter them across the downstream tier, while routing_key=traceID
+keeps them together. The fixed span count makes that property checkable --
+every sampled trace in Tempo must have 4/4 spans.
+
+Span durations are set with explicit timestamps instead of real sleeps, so
+slow traces cost nothing to produce:
+  - ~15% of traces mark the payment span as ERROR  (caught by status_code)
+  - ~15% of traces run slower than 2s end-to-end   (caught by latency)
+  - the rest are healthy and fast, and tail sampling drops them
+"""
+
+import os
+import random
+import time
+
+from opentelemetry import trace
+from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.trace import SpanKind, StatusCode
+
+MS = 1_000_000  # nanoseconds per millisecond
+
+provider = TracerProvider(
+    resource=Resource.create({"service.name": "trace-generator"})
+)
+# SimpleSpanProcessor exports each span as soon as it ends -- one OTLP
+# request per span -- so the load balancer has real reassembly work to do.
+provider.add_span_processor(
+    SimpleSpanProcessor(
+        OTLPSpanExporter(
+            endpoint=os.environ.get(
+                "OTEL_EXPORTER_OTLP_ENDPOINT", "http://alloy-lb:4317"
+            ),
+            insecure=True,
+        )
+    )
+)
+trace.set_tracer_provider(provider)
+tracer = trace.get_tracer("checkout-flow")
+
+
+def emit_trace(seq: int) -> None:
+    is_error = random.random() < 0.15
+    is_slow = not is_error and random.random() < 0.18
+
+    start = time.time_ns()
+    root = tracer.start_span("checkout", start_time=start, kind=SpanKind.SERVER)
+    root.set_attribute("order.id", seq)
+    ctx = trace.set_span_in_context(root)
+
+    # Three child spans, back to back. The payment step is where errors
+    # and slowness are injected.
+    steps = [
+        ("auth", random.randint(10, 60)),
+        ("inventory", random.randint(20, 120)),
+        ("payment", random.randint(2200, 3500) if is_slow else random.randint(40, 300)),
+    ]
+
+    cursor = start
+    for name, duration_ms in steps:
+        child = tracer.start_span(name, context=ctx, start_time=cursor, kind=SpanKind.INTERNAL)
+        cursor += duration_ms * MS
+        if name == "payment" and is_error:
+            child.set_status(StatusCode.ERROR, "card declined")
+        child.end(end_time=cursor)
+
+    if is_error:
+        root.set_status(StatusCode.ERROR, "checkout failed")
+    root.end(end_time=cursor + 5 * MS)
+
+
+def main() -> None:
+    seq = 1000
+    while True:
+        emit_trace(seq)
+        if seq % 30 == 0:
+            print(f"emitted {seq - 999} traces", flush=True)
+        seq += 1
+        time.sleep(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/otel-loadbalancing/app/requirements.txt
+++ b/otel-loadbalancing/app/requirements.txt
@@ -1,0 +1,2 @@
+opentelemetry-sdk==1.42.1
+opentelemetry-exporter-otlp-proto-grpc==1.42.1

--- a/otel-loadbalancing/config-downstream.alloy
+++ b/otel-loadbalancing/config-downstream.alloy
@@ -1,0 +1,74 @@
+// ###############################
+// #### Downstream Tier Alloy ####
+// ###############################
+//
+// Both downstream instances run this identical configuration: receive the
+// shard of traces the load balancer routes here, make a tail-sampling
+// decision per WHOLE trace, and forward the keepers to Tempo.
+
+// Enable live debugging for the Alloy UI.
+livedebugging {
+	enabled = true
+}
+
+// Receive the trace shard from the load-balancer tier.
+otelcol.receiver.otlp "default" {
+	grpc {}
+
+	output {
+		traces = [otelcol.processor.tail_sampling.default.input]
+	}
+}
+
+// Tail sampling: both policies are deterministic (no probabilistic
+// fallback), which makes the scenario verifiable -- a sampled trace can
+// only be complete in Tempo if every one of its spans reached this same
+// instance. Errors and slow traces are kept; healthy fast traces are
+// dropped, which is the point of tail sampling.
+otelcol.processor.tail_sampling "default" {
+	// How long to buffer spans before deciding. Late spans of a trace must
+	// arrive within this window.
+	decision_wait = "5s"
+
+	// Keep every trace that contains an error span.
+	policy {
+		name = "errors"
+		type = "status_code"
+
+		status_code {
+			status_codes = ["ERROR"]
+		}
+	}
+
+	// Keep every trace slower than 2 seconds end-to-end.
+	policy {
+		name = "slow"
+		type = "latency"
+
+		latency {
+			threshold_ms = 2000
+		}
+	}
+
+	output {
+		traces = [otelcol.processor.batch.default.input]
+	}
+}
+
+// Batch processor to improve performance.
+otelcol.processor.batch "default" {
+	output {
+		traces = [otelcol.exporter.otlp.tempo.input]
+	}
+}
+
+// Send sampled traces to the shared Tempo instance.
+otelcol.exporter.otlp "tempo" {
+	client {
+		endpoint = "tempo:4317"
+
+		tls {
+			insecure = true
+		}
+	}
+}

--- a/otel-loadbalancing/config-lb.alloy
+++ b/otel-loadbalancing/config-lb.alloy
@@ -1,0 +1,49 @@
+// ##################################
+// #### Load-Balancer Tier Alloy ####
+// ##################################
+//
+// Receives every span and shards traces across the two downstream Alloy
+// instances by trace ID, so each downstream tail sampler sees WHOLE
+// traces. Scale the sampling tier by adding hostnames to the resolver --
+// no other config changes needed.
+
+// Enable live debugging for the Alloy UI.
+livedebugging {
+	enabled = true
+}
+
+// Receive OpenTelemetry traces from instrumented applications.
+otelcol.receiver.otlp "default" {
+	grpc {}
+	http {}
+
+	output {
+		traces = [otelcol.exporter.loadbalancing.default.input]
+	}
+}
+
+// Trace-aware load balancing: routing_key = "traceID" guarantees that all
+// spans sharing a trace ID -- even when they arrive in separate OTLP
+// requests -- are exported to the SAME downstream instance. That property
+// is what makes tail sampling correct behind a load balancer.
+otelcol.exporter.loadbalancing "default" {
+	routing_key = "traceID"
+
+	resolver {
+		// The static resolver fits Docker Compose. In Kubernetes, use the
+		// dns or k8s resolver to track downstream replicas automatically.
+		static {
+			hostnames = ["alloy-downstream-1:4317", "alloy-downstream-2:4317"]
+		}
+	}
+
+	protocol {
+		otlp {
+			client {
+				tls {
+					insecure = true
+				}
+			}
+		}
+	}
+}

--- a/otel-loadbalancing/docker-compose.coda.yml
+++ b/otel-loadbalancing/docker-compose.coda.yml
@@ -1,0 +1,8 @@
+services:
+  # Emits one trace per second with exactly four spans, exporting every
+  # span in its own OTLP request -- the hard case a trace-aware load
+  # balancer exists to solve.
+  trace-generator:
+    build: ./app
+    environment:
+      - OTEL_EXPORTER_OTLP_ENDPOINT=http://alloy-lb:4317

--- a/otel-loadbalancing/docker-compose.yml
+++ b/otel-loadbalancing/docker-compose.yml
@@ -1,0 +1,108 @@
+services:
+  # Tempo for tracing (single backend shared by both downstream Alloys)
+  tempo:
+    image: grafana/tempo:${GRAFANA_TEMPO_VERSION:-2.10.4}
+    command: ["-config.file=/etc/tempo.yaml"]
+    ports:
+      - 3200:3200/tcp
+    volumes:
+      - ./tempo-config.yaml:/etc/tempo.yaml
+
+  # Prometheus scrapes all three Alloy instances; the per-instance
+  # otelcol_receiver metrics are how you SEE the load balancer's split.
+  prometheus:
+    image: prom/prometheus:${PROMETHEUS_VERSION:-v3.11.3}
+    command:
+      - --web.enable-remote-write-receiver
+      - --config.file=/etc/prometheus/prometheus.yml
+    ports:
+      - 9090:9090/tcp
+    volumes:
+      - ./prom-config.yaml:/etc/prometheus/prometheus.yml
+
+  grafana:
+    image: grafana/grafana:${GRAFANA_VERSION:-13.0.2}
+    environment:
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_BASIC_ENABLED=false
+    ports:
+      - 3000:3000/tcp
+    entrypoint:
+      - sh
+      - -euc
+      - |
+        mkdir -p /etc/grafana/provisioning/datasources
+        cat <<EOF > /etc/grafana/provisioning/datasources/ds.yaml
+        apiVersion: 1
+        datasources:
+        - name: Tempo
+          type: tempo
+          access: proxy
+          orgId: 1
+          url: http://tempo:3200
+          basicAuth: false
+          isDefault: true
+          version: 1
+          editable: false
+        - name: Prometheus
+          type: prometheus
+          access: proxy
+          orgId: 1
+          url: http://prometheus:9090
+          basicAuth: false
+          isDefault: false
+          version: 1
+          editable: false
+        EOF
+        /run.sh
+    depends_on:
+      - tempo
+      - prometheus
+
+  # Downstream tier: two identical Alloy instances running tail sampling.
+  # They share one config file; only the published UI port differs.
+  alloy-downstream-1:
+    image: grafana/alloy:${GRAFANA_ALLOY_VERSION:-v1.16.1}
+    ports:
+      - 12346:12345
+    volumes:
+      - ./config-downstream.alloy:/etc/alloy/config.alloy
+    command: run --server.http.listen-addr=0.0.0.0:12345 --storage.path=/var/lib/alloy/data /etc/alloy/config.alloy
+    depends_on:
+      - tempo
+
+  alloy-downstream-2:
+    image: grafana/alloy:${GRAFANA_ALLOY_VERSION:-v1.16.1}
+    ports:
+      - 12347:12345
+    volumes:
+      - ./config-downstream.alloy:/etc/alloy/config.alloy
+    command: run --server.http.listen-addr=0.0.0.0:12345 --storage.path=/var/lib/alloy/data /etc/alloy/config.alloy
+    depends_on:
+      - tempo
+
+  # Load-balancer tier: receives all OTLP traffic and shards it across the
+  # two downstream instances by trace ID.
+  alloy-lb:
+    image: grafana/alloy:${GRAFANA_ALLOY_VERSION:-v1.16.1}
+    ports:
+      - 12345:12345
+      - 4317:4317
+      - 4318:4318
+    volumes:
+      - ./config-lb.alloy:/etc/alloy/config.alloy
+    command: run --server.http.listen-addr=0.0.0.0:12345 --storage.path=/var/lib/alloy/data /etc/alloy/config.alloy
+    depends_on:
+      - alloy-downstream-1
+      - alloy-downstream-2
+
+  # Emits one trace per second with exactly four spans, exporting every
+  # span in its own OTLP request -- the hard case a trace-aware load
+  # balancer exists to solve.
+  trace-generator:
+    build: ./app
+    environment:
+      - OTEL_EXPORTER_OTLP_ENDPOINT=http://alloy-lb:4317
+    depends_on:
+      - alloy-lb

--- a/otel-loadbalancing/prom-config.yaml
+++ b/otel-loadbalancing/prom-config.yaml
@@ -1,0 +1,15 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+# Scrape every Alloy instance's own metrics. The per-instance
+# otelcol_receiver/otelcol_exporter series are how you observe the load
+# balancer's split across the downstream tier.
+scrape_configs:
+  - job_name: 'alloy-lb'
+    static_configs:
+      - targets: ['alloy-lb:12345']
+
+  - job_name: 'alloy-downstream'
+    static_configs:
+      - targets: ['alloy-downstream-1:12345', 'alloy-downstream-2:12345']

--- a/otel-loadbalancing/tempo-config.yaml
+++ b/otel-loadbalancing/tempo-config.yaml
@@ -1,0 +1,26 @@
+stream_over_http_enabled: true
+server:
+  http_listen_port: 3200
+  log_level: info
+
+distributor:
+  receivers:
+    otlp:
+      protocols:
+        grpc:
+          endpoint: "tempo:4317"
+
+ingester:
+  max_block_duration: 5m               # cut the headblock when this much time passes. set for demo purposes
+
+compactor:
+  compaction:
+    block_retention: 720h              # overall Tempo trace retention. set for demo purposes
+
+storage:
+  trace:
+    backend: local
+    wal:
+      path: /var/tempo/wal
+    local:
+      path: /var/tempo/blocks


### PR DESCRIPTION
Adds the **otel-loadbalancing** scenario: a load-balancer Alloy shards traces by trace ID across two tail-sampling Alloy instances with `otelcol.exporter.loadbalancing` — the standard pattern for scaling tail sampling horizontally.

Closes #102. Part of #90.

## What it does

```
trace-generator ──OTLP──> alloy-lb ──routing_key=traceID──> alloy-downstream-1/2 ──> Tempo
                                                            (tail sampling: errors + >2s)
```

- The generator makes the problem real **and the result checkable**: it exports every span in its own OTLP request (`SimpleSpanProcessor`) and emits exactly **4 spans per trace** with explicit timestamps (~15% error traces, ~18% slow traces). A round-robin balancer would scatter each trace across both downstreams.
- The downstream samplers use only **deterministic** policies (`status_code` + `latency` — deliberately no probabilistic fallback), so a sampled trace can only appear complete in Tempo if every one of its spans reached the same downstream instance. Trace completeness == affinity proof.
- Prometheus scrapes all three Alloys; per-instance `otelcol_receiver_accepted_spans_total` makes the split visible. Both downstream UIs are exposed (12346/12347).

## Files

| File | Purpose |
|---|---|
| `otel-loadbalancing/config-lb.alloy` | receiver → loadbalancing exporter (static resolver) |
| `otel-loadbalancing/config-downstream.alloy` | shared by both downstreams: receiver → tail_sampling → batch → Tempo |
| `otel-loadbalancing/docker-compose.yml` + `docker-compose.coda.yml` | 7 services / generator-only |
| `otel-loadbalancing/app/` | pinned OTel SDK 1.42.1 generator (python digest-pinned base) |
| `otel-loadbalancing/{prom,tempo}-config.yaml`, `README.md` | backends + docs |
| `.github/scenario-list.txt`, `README.md` | registration + Tracing table row |

## e2e evidence (full stack run)

```
GRAFANA HEALTHY                              # CI probe
per-instance accepted spans:  alloy-downstream-1: 36, alloy-downstream-2: 64   # split works
trace completeness:           complete: 6, incomplete: 0   # every sampled trace is 4/4 spans
sampling:                     received 220 spans -> sent 32 to Tempo            # errors+slow only
docker compose ps --status exited -> (empty)
```

## Notes

- README explains scaling (add a hostname; dns/k8s resolvers on Kubernetes) and the `routing_key="service"` variant for spanmetrics.
