### PR TITLE
Add trace correlation scenario (OpenMetrics exemplars + Tempo)

### DIFF
--- a/.github/scenario-list.txt
+++ b/.github/scenario-list.txt
@@ -30,6 +30,7 @@ snmp
 syslog
 systemd-journal
 trace-delivery
+trace-log-correlation-exemplars
 vault-secrets
 windows
 windows-events

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ These scenarios show distributed tracing with OpenTelemetry and Tempo.
 | [OpenTelemetry service graphs](otel-tracing-service-graphs/) | Generate service graphs with the Alloy `servicegraph` connector. |
 | [OpenTelemetry span metrics](otel-span-metrics/) | Generate RED metrics from OpenTelemetry traces with the span metrics connector. Request rate, error rate, and duration. |
 | [OpenTelemetry tail sampling](otel-tail-sampling/) | Apply tail sampling policies to OpenTelemetry traces with Alloy and Tempo. |
+| [Trace correlation with exemplars](trace-log-correlation-exemplars/) | Jump from a latency histogram to the exact trace behind it with OpenMetrics exemplars flowing through Alloy into Prometheus and Tempo. |
 
 ### Metrics
 

--- a/trace-log-correlation-exemplars/README.md
+++ b/trace-log-correlation-exemplars/README.md
@@ -1,0 +1,76 @@
+# Trace Correlation with Exemplars
+
+Click a dot on a latency histogram and land on the exact trace that caused it. This scenario wires up the full [exemplar](https://grafana.com/docs/grafana/latest/fundamentals/exemplars/) path — one of the signature LGTM-stack tricks — end to end:
+
+```
+demo app ──OTLP traces──────────────> Alloy ──otlp──> Tempo
+   │                                    │                ▲
+   └──/metrics (OpenMetrics with        └─remote_write   │ click-through
+      trace_id exemplars) <──scrape──┘    (send_exemplars)│
+                                          ▼               │
+                                      Prometheus ──> Grafana panel with
+                                      (exemplar-storage)  exemplar dots
+```
+
+Every link in that chain has a setting that must be right, and each one is spelled out in this scenario's files:
+
+| Link | Where | Setting |
+|------|-------|---------|
+| App embeds trace ID in the histogram | `app/app.py` | `CHECKOUT_LATENCY.observe(value, {"trace_id": ...})`, exposed via **OpenMetrics** exposition (the classic Prometheus text format drops exemplars) |
+| Alloy scrapes exemplars | `config.alloy` | `prometheus.scrape` with `scrape_protocols = ["OpenMetricsText1.0.0", ...]` |
+| Alloy forwards exemplars | `config.alloy` | `prometheus.remote_write` endpoint with `send_exemplars = true` |
+| Prometheus stores exemplars | `docker-compose.yml` | `--enable-feature=exemplar-storage` |
+| Grafana links dots to traces | `grafana/datasources/datasources.yaml` | `exemplarTraceIdDestinations: [{name: trace_id, datasourceUid: tempo}]` |
+
+## Prerequisites
+
+- Docker and Docker Compose installed
+
+## Getting Started
+
+```bash
+git clone https://github.com/grafana/alloy-scenarios.git
+cd alloy-scenarios/trace-log-correlation-exemplars
+docker compose up -d --build
+```
+
+## Access Points
+
+| Service    | URL                          |
+|------------|------------------------------|
+| Grafana    | http://localhost:3000        |
+| Alloy UI   | http://localhost:12345       |
+| Prometheus | http://localhost:9090        |
+| Tempo      | http://localhost:3200        |
+| Demo app   | http://localhost:8080/checkout |
+
+## What to Expect
+
+The demo app requests its own `/checkout` endpoint every two seconds; ~10% of requests are deliberately slow.
+
+Open Grafana at http://localhost:3000 → **Dashboards** → **Checkout Latency with Exemplars**. After a minute you'll see the p95/p50 latency lines with **exemplar dots** scattered around them (exemplars are pre-enabled on the panel). Hover a dot — especially a high one — and click **Query with Tempo**: Grafana opens the exact trace whose `checkout.delay_ms` attribute explains the latency you clicked on.
+
+You can verify the chain headlessly too:
+
+```bash
+# 1. Pull an exemplar trace ID out of Prometheus...
+curl -sG http://localhost:9090/api/v1/query_exemplars \
+  --data-urlencode 'query=checkout_duration_seconds_bucket' \
+  --data-urlencode "start=$(date -d '-10 min' +%s)" \
+  --data-urlencode "end=$(date +%s)" | jq -r '.data[0].exemplars[-1].labels.trace_id'
+
+# 2. ...and fetch that exact trace from Tempo.
+curl -s http://localhost:3200/api/traces/<trace_id> | jq '.batches[0].scopeSpans[0].spans[0].name'
+```
+
+## Customizing
+
+* Rename the exemplar label in `app.py` — and change `exemplarTraceIdDestinations[0].name` to match.
+* Exemplars attach to histogram **bucket** samples: query `checkout_duration_seconds_bucket` (not `_sum`) when using the Prometheus exemplars API.
+* Add routes to the app; any histogram observed inside an active span can carry that span's trace ID.
+
+## Stopping the Scenario
+
+```bash
+docker compose down
+```

--- a/trace-log-correlation-exemplars/app/Dockerfile
+++ b/trace-log-correlation-exemplars/app/Dockerfile
@@ -1,0 +1,11 @@
+ARG PYTHON_VERSION=3.11-slim@sha256:a3ab0b966bc4e91546a033e22093cb840908979487a9fc0e6e38295747e49ac0
+FROM python:${PYTHON_VERSION}
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY app.py .
+
+CMD ["python", "app.py"]

--- a/trace-log-correlation-exemplars/app/app.py
+++ b/trace-log-correlation-exemplars/app/app.py
@@ -1,0 +1,100 @@
+"""Checkout service for the trace-log-correlation-exemplars scenario.
+
+Every /checkout request produces two correlated signals:
+  1. an OTLP trace exported through Alloy to Tempo, and
+  2. a histogram observation whose exemplar carries that trace's ID.
+
+The exemplar is the bridge: Prometheus stores it next to the histogram
+bucket sample, and Grafana turns it into a click-through link to the
+exact Tempo trace that produced the latency you are looking at.
+"""
+
+import os
+import random
+import threading
+import time
+
+import requests
+from flask import Flask, Response
+from opentelemetry import trace
+from opentelemetry.exporter.otlp.proto.grpc.trace_exporter import OTLPSpanExporter
+from opentelemetry.instrumentation.flask import FlaskInstrumentor
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from prometheus_client import REGISTRY, Histogram
+from prometheus_client.openmetrics.exposition import (
+    CONTENT_TYPE_LATEST,
+    generate_latest,
+)
+
+provider = TracerProvider(
+    resource=Resource.create({"service.name": "checkout-service"})
+)
+provider.add_span_processor(
+    BatchSpanProcessor(
+        OTLPSpanExporter(
+            endpoint=os.environ.get(
+                "OTEL_EXPORTER_OTLP_ENDPOINT", "http://alloy:4317"
+            ),
+            insecure=True,
+        )
+    )
+)
+trace.set_tracer_provider(provider)
+tracer = trace.get_tracer("checkout-service")
+
+app = Flask(__name__)
+FlaskInstrumentor().instrument_app(app, excluded_urls="metrics")
+
+CHECKOUT_LATENCY = Histogram(
+    "checkout_duration_seconds",
+    "Time spent handling /checkout requests.",
+    buckets=(0.05, 0.1, 0.25, 0.5, 1.0, 2.5),
+)
+
+
+@app.route("/checkout")
+def checkout():
+    start = time.monotonic()
+    with tracer.start_as_current_span("process-checkout") as span:
+        # Simulated work: mostly fast, occasionally slow enough to be the
+        # interesting dot on the latency panel.
+        delay = random.uniform(0.02, 0.15)
+        if random.random() < 0.1:
+            delay += random.uniform(0.3, 0.9)
+        time.sleep(delay)
+        span.set_attribute("checkout.delay_ms", round(delay * 1000))
+
+        # The exemplar: attach the current trace ID to this observation.
+        # OpenMetrics exemplar label values are capped at 128 characters;
+        # a 32-hex trace ID fits comfortably.
+        trace_id = format(span.get_span_context().trace_id, "032x")
+        CHECKOUT_LATENCY.observe(
+            time.monotonic() - start, {"trace_id": trace_id}
+        )
+        return {"status": "ok", "trace_id": trace_id}
+
+
+@app.route("/metrics")
+def metrics():
+    # Exemplars are only rendered in the OpenMetrics exposition format --
+    # prometheus_client's default text format drops them, which is why
+    # this handler uses the openmetrics generate_latest.
+    return Response(generate_latest(REGISTRY), mimetype=CONTENT_TYPE_LATEST)
+
+
+def generate_load():
+    """Request /checkout forever so traces and exemplars keep flowing."""
+    session = requests.Session()
+    while True:
+        try:
+            session.get("http://localhost:8080/checkout", timeout=5)
+        except requests.RequestException:
+            pass
+        time.sleep(2)
+
+
+if __name__ == "__main__":
+    threading.Thread(target=generate_load, daemon=True).start()
+    app.run(host="0.0.0.0", port=8080, threaded=True)

--- a/trace-log-correlation-exemplars/app/requirements.txt
+++ b/trace-log-correlation-exemplars/app/requirements.txt
@@ -1,0 +1,7 @@
+flask==3.1.3
+requests==2.34.2
+prometheus-client==0.25.0
+opentelemetry-api==1.42.1
+opentelemetry-sdk==1.42.1
+opentelemetry-exporter-otlp-proto-grpc==1.42.1
+opentelemetry-instrumentation-flask==0.63b1

--- a/trace-log-correlation-exemplars/config.alloy
+++ b/trace-log-correlation-exemplars/config.alloy
@@ -1,0 +1,64 @@
+// #############################################
+// #### Traces + Exemplar-Carrying Metrics  ####
+// #############################################
+
+// Enable live debugging for the Alloy UI.
+livedebugging {
+	enabled = true
+}
+
+// ---- Trace pipeline: app -> Alloy -> Tempo ----
+
+// Receive OpenTelemetry traces from the demo app.
+otelcol.receiver.otlp "default" {
+	grpc {}
+	http {}
+
+	output {
+		traces = [otelcol.processor.batch.default.input]
+	}
+}
+
+// Batch processor to improve performance.
+otelcol.processor.batch "default" {
+	output {
+		traces = [otelcol.exporter.otlp.tempo.input]
+	}
+}
+
+// Send traces to Tempo -- the destination the exemplar links point at.
+otelcol.exporter.otlp "tempo" {
+	client {
+		endpoint = "tempo:4317"
+
+		tls {
+			insecure = true
+		}
+	}
+}
+
+// ---- Metric pipeline: app /metrics -> Alloy -> Prometheus ----
+
+// Scrape the demo app. Exemplars only exist in the OpenMetrics exposition
+// format, so the scrape negotiates OpenMetrics first -- with plain
+// Prometheus text the trace IDs would be silently absent.
+prometheus.scrape "demo_app" {
+	targets = [{
+		__address__ = "demo-app:8080",
+	}]
+	forward_to = [prometheus.remote_write.default.receiver]
+
+	scrape_interval  = "10s"
+	scrape_protocols = ["OpenMetricsText1.0.0", "PrometheusText0.0.4"]
+}
+
+// Forward metrics AND their exemplars to Prometheus. send_exemplars is
+// the default, but it is the load-bearing setting of this scenario, so
+// it is spelled out.
+prometheus.remote_write "default" {
+	endpoint {
+		url = "http://prometheus:9090/api/v1/write"
+
+		send_exemplars = true
+	}
+}

--- a/trace-log-correlation-exemplars/docker-compose.coda.yml
+++ b/trace-log-correlation-exemplars/docker-compose.coda.yml
@@ -1,0 +1,10 @@
+services:
+  # Flask checkout service: every request produces an OTLP trace AND a
+  # histogram observation carrying that trace's ID as an exemplar. A
+  # built-in load thread keeps requests flowing forever.
+  demo-app:
+    build: ./app
+    environment:
+      - OTEL_EXPORTER_OTLP_ENDPOINT=http://alloy:4317
+    ports:
+      - 8080:8080

--- a/trace-log-correlation-exemplars/docker-compose.yml
+++ b/trace-log-correlation-exemplars/docker-compose.yml
@@ -1,0 +1,67 @@
+services:
+  # Prometheus with exemplar storage enabled -- without this flag the
+  # exemplars Alloy sends with remote write are silently dropped.
+  prometheus:
+    image: prom/prometheus:${PROMETHEUS_VERSION:-v3.11.3}
+    command:
+      - --web.enable-remote-write-receiver
+      - --enable-feature=exemplar-storage
+      - --config.file=/etc/prometheus/prometheus.yml
+    ports:
+      - 9090:9090/tcp
+    volumes:
+      - ./prom-config.yaml:/etc/prometheus/prometheus.yml
+
+  # Tempo stores the traces the exemplars point at.
+  tempo:
+    image: grafana/tempo:${GRAFANA_TEMPO_VERSION:-2.10.4}
+    command: ["-config.file=/etc/tempo.yaml"]
+    ports:
+      - 3200:3200/tcp
+    volumes:
+      - ./tempo-config.yaml:/etc/tempo.yaml
+
+  # Grafana is provisioned from ./grafana: the Prometheus datasource carries
+  # exemplarTraceIdDestinations (trace_id -> Tempo), which is what turns
+  # exemplar dots into clickable links, plus a dashboard with exemplars
+  # already switched on.
+  grafana:
+    image: grafana/grafana:${GRAFANA_VERSION:-13.0.2}
+    environment:
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_BASIC_ENABLED=false
+    volumes:
+      - ./grafana:/etc/grafana/provisioning
+    ports:
+      - 3000:3000/tcp
+    depends_on:
+      - prometheus
+      - tempo
+
+  # Alloy: one pipeline for traces (OTLP -> Tempo), one for metrics
+  # (OpenMetrics scrape -> Prometheus, exemplars riding along).
+  alloy:
+    image: grafana/alloy:${GRAFANA_ALLOY_VERSION:-v1.16.1}
+    ports:
+      - 12345:12345
+      - 4317:4317
+      - 4318:4318
+    volumes:
+      - ./config.alloy:/etc/alloy/config.alloy
+    command: run --server.http.listen-addr=0.0.0.0:12345 --storage.path=/var/lib/alloy/data /etc/alloy/config.alloy
+    depends_on:
+      - prometheus
+      - tempo
+
+  # Flask checkout service: every request produces an OTLP trace AND a
+  # histogram observation carrying that trace's ID as an exemplar. A
+  # built-in load thread keeps requests flowing forever.
+  demo-app:
+    build: ./app
+    environment:
+      - OTEL_EXPORTER_OTLP_ENDPOINT=http://alloy:4317
+    ports:
+      - 8080:8080
+    depends_on:
+      - alloy

--- a/trace-log-correlation-exemplars/grafana/dashboards/dashboards.yaml
+++ b/trace-log-correlation-exemplars/grafana/dashboards/dashboards.yaml
@@ -1,0 +1,12 @@
+apiVersion: 1
+providers:
+  - name: 'trace-log-correlation-exemplars'
+    orgId: 1
+    folder: ''
+    type: file
+    disableDeletion: true
+    updateIntervalSeconds: 10
+    allowUiUpdates: false
+    options:
+      path: /etc/grafana/provisioning/dashboards
+      foldersFromFilesStructure: false

--- a/trace-log-correlation-exemplars/grafana/dashboards/exemplars-dashboard.json
+++ b/trace-log-correlation-exemplars/grafana/dashboards/exemplars-dashboard.json
@@ -1,0 +1,53 @@
+{
+  "uid": "checkout-exemplars",
+  "title": "Checkout Latency with Exemplars",
+  "schemaVersion": 39,
+  "refresh": "10s",
+  "time": { "from": "now-15m", "to": "now" },
+  "panels": [
+    {
+      "id": 1,
+      "type": "timeseries",
+      "title": "Checkout latency p95 — the dots are exemplars, click one to open its trace in Tempo",
+      "gridPos": { "h": 12, "w": 24, "x": 0, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s",
+          "custom": { "drawStyle": "line", "fillOpacity": 10, "showPoints": "never" }
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(checkout_duration_seconds_bucket[1m])))",
+          "legendFormat": "p95",
+          "exemplar": true
+        },
+        {
+          "refId": "B",
+          "expr": "histogram_quantile(0.50, sum by (le) (rate(checkout_duration_seconds_bucket[1m])))",
+          "legendFormat": "p50",
+          "exemplar": false
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "type": "timeseries",
+      "title": "Checkout request rate",
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 12 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": { "defaults": { "unit": "reqps" }, "overrides": [] },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum(rate(checkout_duration_seconds_count[1m]))",
+          "legendFormat": "requests/s",
+          "exemplar": false
+        }
+      ]
+    }
+  ]
+}

--- a/trace-log-correlation-exemplars/grafana/datasources/datasources.yaml
+++ b/trace-log-correlation-exemplars/grafana/datasources/datasources.yaml
@@ -1,0 +1,31 @@
+apiVersion: 1
+datasources:
+  - name: Tempo
+    uid: tempo
+    type: tempo
+    access: proxy
+    orgId: 1
+    url: http://tempo:3200
+    basicAuth: false
+    isDefault: false
+    version: 1
+    editable: false
+
+  - name: Prometheus
+    uid: prometheus
+    type: prometheus
+    access: proxy
+    orgId: 1
+    url: http://prometheus:9090
+    basicAuth: false
+    isDefault: true
+    version: 1
+    editable: false
+    jsonData:
+      # The wiring that makes exemplar dots clickable: when a panel shows
+      # an exemplar whose label key is trace_id, Grafana renders a
+      # "Query with Tempo" link that opens that exact trace. The name must
+      # match the exemplar label the app emits.
+      exemplarTraceIdDestinations:
+        - name: trace_id
+          datasourceUid: tempo

--- a/trace-log-correlation-exemplars/prom-config.yaml
+++ b/trace-log-correlation-exemplars/prom-config.yaml
@@ -1,0 +1,3 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s

--- a/trace-log-correlation-exemplars/tempo-config.yaml
+++ b/trace-log-correlation-exemplars/tempo-config.yaml
@@ -1,0 +1,26 @@
+stream_over_http_enabled: true
+server:
+  http_listen_port: 3200
+  log_level: info
+
+distributor:
+  receivers:
+    otlp:
+      protocols:
+        grpc:
+          endpoint: "tempo:4317"
+
+ingester:
+  max_block_duration: 5m               # cut the headblock when this much time passes. set for demo purposes
+
+compactor:
+  compaction:
+    block_retention: 720h              # overall Tempo trace retention. set for demo purposes
+
+storage:
+  trace:
+    backend: local
+    wal:
+      path: /var/tempo/wal
+    local:
+      path: /var/tempo/blocks


### PR DESCRIPTION
Adds the **trace-log-correlation-exemplars** scenario: click an exemplar dot on a latency histogram in Grafana and open the exact Tempo trace that produced it. Every link of the chain is wired and labeled.

Closes #103. Part of #90.

## What it does

| Link | Setting |
|---|---|
| App embeds trace ID | `Histogram.observe(value, {"trace_id": <32-hex>})` served via **OpenMetrics** exposition (classic text format drops exemplars) |
| Alloy scrapes exemplars | `prometheus.scrape` with `scrape_protocols = ["OpenMetricsText1.0.0", ...]` |
| Alloy forwards them | `prometheus.remote_write` endpoint `send_exemplars = true` |
| Prometheus stores them | `--enable-feature=exemplar-storage` |
| Grafana links dots → traces | provisioned datasource `exemplarTraceIdDestinations: [{name: trace_id, datasourceUid: tempo}]` |

A provisioned dashboard ("Checkout Latency with Exemplars") ships with `"exemplar": true` on the p95 panel, so the dots are visible out of the box. The Flask app self-loads every 2s forever (~10% deliberately slow requests), keeping the CI no-exited-containers gate green.

## Files

| File | Purpose |
|---|---|
| `trace-log-correlation-exemplars/app/` | Flask + OTel SDK app (pinned: flask 3.1.3, prometheus-client 0.25.0, otel 1.42.1, instr-flask 0.63b1) |
| `trace-log-correlation-exemplars/config.alloy` | OTLP→Tempo + OpenMetrics scrape→Prometheus (64 lines) |
| `trace-log-correlation-exemplars/grafana/` | datasources (exemplar wiring) + dashboard provisioning |
| `trace-log-correlation-exemplars/docker-compose.yml` + `.coda.yml` | full stack / app only |
| `{prom,tempo}-config.yaml`, `README.md` | backends + docs |
| `.github/scenario-list.txt`, `README.md` | registration + Tracing table row |

## e2e evidence (full stack run)

```
GRAFANA HEALTHY
exposition: checkout_duration_seconds_bucket{le="0.1"} 1.0 # {trace_id="cc8633..."} 0.0657 ...
EXEMPLARS STORED IN PROMETHEUS          # /api/v1/query_exemplars non-empty
exemplar trace_id cc8633673a6f74c24a63d21cd5f01b3c -> TRACE IN TEMPO (checkout-service, 2 spans)
datasource wiring: [{"datasourceUid":"tempo","name":"trace_id"}]
dashboard provisioned: "Checkout Latency with Exemplars"
docker compose ps --status exited -> (empty)
```

The headless equivalent of the click-through (exemplar → `/api/traces/<id>`) is documented in the README.
