### PR TITLE
Add Java profiling scenario (pyroscope.java + async-profiler)

### DIFF
--- a/.github/scenario-list.txt
+++ b/.github/scenario-list.txt
@@ -6,6 +6,7 @@ elasticsearch-monitoring
 faro-frontend-observability
 game-of-tracing
 gelf-log-ingestion
+java-profiling
 kafka
 linux
 log-api-gateway

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ These scenarios collect continuous profiles from applications.
 | -------- | ----------- |
 | [Continuous profiling](continuous-profiling/) | Collect and visualize CPU, memory, and goroutine profiles from Go applications with Grafana Pyroscope. |
 | [eBPF host profiling](ebpf-host-profiling/) | Profile every process on a Linux host with `pyroscope.ebpf` -- no language agents, no application code changes. Uses Docker container discovery to attribute samples per workload. |
+| [Java profiling](java-profiling/) | Attach async-profiler to a running JVM with `pyroscope.java` -- CPU and allocation flame graphs with no agent jar and no code changes. |
 
 ### Secrets and configuration
 

--- a/java-profiling/README.md
+++ b/java-profiling/README.md
@@ -1,0 +1,68 @@
+# Java Continuous Profiling with Grafana Alloy
+
+This scenario demonstrates zero-code-change JVM profiling with Alloy's [`pyroscope.java`](https://grafana.com/docs/alloy/latest/reference/components/pyroscope/pyroscope.java/) component: Alloy discovers a running JVM with `discovery.process`, attaches [async-profiler](https://github.com/async-profiler/async-profiler) to it, and streams CPU and allocation profiles to Grafana Pyroscope.
+
+The demo app (`app/Main.java`) has two deterministic hot paths so the flame graphs are easy to read:
+
+* `Main.burnCpu` → dominates the **CPU** profile (`process_cpu`)
+* `Main.churnAllocations` → dominates the **allocation** profile (`memory:alloc_in_new_tlab_bytes`)
+
+## How the attach works (and why the compose file looks like this)
+
+`pyroscope.java` uses the JVM dynamic-attach mechanism, which requires Alloy and the target JVM to effectively share a machine:
+
+| Compose setting | Why |
+|-----------------|-----|
+| `pid: "container:java-app"` on the `alloy` service | Alloy must see the JVM in its own PID namespace for `discovery.process` and the attach handshake |
+| `cap_add: [SYS_PTRACE]` | The attach mechanism performs ptrace-style access checks |
+| `jvm-tmp` volume mounted at `/tmp` in **both** containers | The JVM's attach socket (`/tmp/.java_pid<PID>`) and the async-profiler library Alloy extracts must be visible to both processes at the same path |
+| `container_name: java-app` | Gives the `pid:` reference a stable target |
+
+No agent jar, no `-javaagent` flag, no code changes — the JVM is started like any other app.
+
+## Prerequisites
+
+- Docker and Docker Compose installed
+
+## Getting Started
+
+```bash
+git clone https://github.com/grafana/alloy-scenarios.git
+cd alloy-scenarios/java-profiling
+docker compose up -d --build
+```
+
+## Access Points
+
+| Service   | URL                    |
+|-----------|------------------------|
+| Grafana   | http://localhost:3000  |
+| Pyroscope | http://localhost:4040  |
+| Alloy UI  | http://localhost:12345 |
+
+## What to Expect
+
+Profiles arrive after the first collection interval (15 seconds in `config.alloy`). In Grafana, open **Drilldown → Profiles** (or the Pyroscope UI at http://localhost:4040) and select the `java-app` service:
+
+* **process_cpu** — the flame graph is dominated by `Main.burnCpu` → `Main.countPrimes` → `Main.isPrime`, with real method names rather than `[unknown]` frames (the Dockerfile passes `-XX:+DebugNonSafepoints` for accurate JIT frame info).
+* **memory:alloc_in_new_tlab_bytes** — dominated by `Main.churnAllocations` allocating 256 KiB blocks through a bounded ring.
+* **lock** and **wall** profiles are also collected (`lock = "10ms"` in `profiling_config`).
+
+To verify headlessly:
+
+```bash
+curl -s 'http://localhost:4040/pyroscope/render?query=process_cpu:cpu:nanoseconds:cpu:nanoseconds%7Bservice_name%3D%22java-app%22%7D&from=now-5m&format=json' \
+  | jq -r '.flamebearer.names[]' | grep Main.burnCpu
+```
+
+## Configuration Notes
+
+* `event = "itimer"` (the default) samples CPU with setitimer signals and needs no `perf_event` kernel access, so it works in restricted environments such as CI runners and containers without extra privileges. Where the kernel allows perf events, `event = "cpu"` gives kernel-stack visibility too.
+* `discovery.process` requires root and PID-namespace visibility — both provided by the compose settings above.
+* If you recreate the `java-app` container, restart the `alloy` container too: its `pid: "container:java-app"` binding refers to the container instance that existed when Alloy started.
+
+## Stopping the Scenario
+
+```bash
+docker compose down
+```

--- a/java-profiling/app/Dockerfile
+++ b/java-profiling/app/Dockerfile
@@ -1,0 +1,13 @@
+# Pinned by digest; renovate's docker manager tracks the base image.
+FROM eclipse-temurin:21-jdk@sha256:949f7645022e8cd5cd65eac4b342e7505c86b721b6338f8b677c6f2edc180262
+
+WORKDIR /app
+COPY Main.java .
+# Precompile rather than using java's source-file launcher, so the flame
+# graph frames are plain Main.* methods.
+RUN javac Main.java
+
+# DebugNonSafepoints makes the JIT keep debug info outside safepoints,
+# which is what gives async-profiler accurate line-level frames. The small
+# heap keeps the allocation churn cheap.
+CMD ["java", "-Xmx256m", "-XX:+UnlockDiagnosticVMOptions", "-XX:+DebugNonSafepoints", "Main"]

--- a/java-profiling/app/Main.java
+++ b/java-profiling/app/Main.java
@@ -1,0 +1,78 @@
+import java.util.ArrayDeque;
+
+/**
+ * Deterministic JVM workload for the java-profiling scenario.
+ *
+ * Two daemon threads give the profiler something recognizable to attribute:
+ *  - burnCpu: tight prime-counting loops, so the CPU flame graph is
+ *    dominated by Main.burnCpu / Main.countPrimes.
+ *  - churnAllocations: steady byte[] churn through a bounded ring, so the
+ *    allocation profile (alloc_in_new_tlab) is dominated by
+ *    Main.churnAllocations.
+ */
+public class Main {
+
+    // Results are published into this sink so the JIT can't elide the work.
+    private static volatile long sink;
+
+    public static void main(String[] args) throws InterruptedException {
+        Thread cpu = new Thread(Main::burnCpu, "cpu-burner");
+        cpu.setDaemon(true);
+        cpu.start();
+
+        Thread alloc = new Thread(Main::churnAllocations, "alloc-churner");
+        alloc.setDaemon(true);
+        alloc.start();
+
+        // Heartbeat keeps the container's main process alive forever and
+        // gives `docker logs` a sign of life.
+        while (true) {
+            System.out.println("java-app alive; sink=" + sink);
+            Thread.sleep(30_000);
+        }
+    }
+
+    private static void burnCpu() {
+        while (true) {
+            sink = countPrimes(50_000);
+        }
+    }
+
+    private static long countPrimes(int limit) {
+        long count = 0;
+        for (int n = 2; n < limit; n++) {
+            if (isPrime(n)) {
+                count++;
+            }
+        }
+        return count;
+    }
+
+    private static boolean isPrime(int n) {
+        for (int d = 2; (long) d * d <= n; d++) {
+            if (n % d == 0) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static void churnAllocations() {
+        ArrayDeque<byte[]> ring = new ArrayDeque<>();
+        while (true) {
+            byte[] block = new byte[256 * 1024];
+            block[0] = 1;
+            ring.addLast(block);
+            if (ring.size() > 32) {
+                ring.removeFirst();
+            }
+            sink += block.length;
+            try {
+                Thread.sleep(5);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                return;
+            }
+        }
+    }
+}

--- a/java-profiling/config.alloy
+++ b/java-profiling/config.alloy
@@ -1,0 +1,62 @@
+// #################################
+// #### Profiling Configuration ####
+// #################################
+
+// Enable live debugging for the Alloy UI.
+livedebugging {
+	enabled = true
+}
+
+// Discover processes visible to Alloy. Because the container runs with
+// pid: "container:java-app", the only foreign process in view is the
+// demo JVM -- exactly the one to profile.
+discovery.process "all" {
+	refresh_interval = "5s"
+
+	discover_config {
+		exe         = true
+		commandline = true
+	}
+}
+
+// Keep only java processes and name the application. service_name is the
+// label Pyroscope groups profiles under.
+discovery.relabel "java" {
+	targets = discovery.process.all.targets
+
+	rule {
+		source_labels = ["__meta_process_exe"]
+		regex         = ".*/java$"
+		action        = "keep"
+	}
+
+	rule {
+		target_label = "service_name"
+		replacement  = "java-app"
+	}
+}
+
+// Attach async-profiler to the discovered JVM and collect CPU and
+// allocation profiles. The "itimer" event needs no perf_event access,
+// so it works in restricted environments such as CI runners; switch to
+// event = "cpu" for perf-based sampling where the kernel allows it.
+pyroscope.java "jvm" {
+	targets    = discovery.relabel.java.output
+	forward_to = [pyroscope.write.default.receiver]
+
+	profiling_config {
+		interval    = "15s"
+		cpu         = true
+		event       = "itimer"
+		sample_rate = 100
+		alloc       = "512k"
+		lock        = "10ms"
+	}
+}
+
+// Push the collected profiles to the local Pyroscope server.
+pyroscope.write "default" {
+	endpoint {
+		url = "http://pyroscope:4040"
+	}
+}

--- a/java-profiling/docker-compose.coda.yml
+++ b/java-profiling/docker-compose.coda.yml
@@ -1,0 +1,14 @@
+services:
+  # The JVM workload under profile: two deterministic hot paths
+  # (Main.burnCpu and Main.churnAllocations) so the flame graphs have
+  # recognizable frames. The fixed container_name lets the Alloy service
+  # in the main compose file join this exact container's PID namespace.
+  java-app:
+    build: ./app
+    container_name: java-app
+    restart: unless-stopped
+    volumes:
+      - jvm-tmp:/tmp
+
+volumes:
+  jvm-tmp:

--- a/java-profiling/docker-compose.yml
+++ b/java-profiling/docker-compose.yml
@@ -1,0 +1,73 @@
+services:
+  # Pyroscope: continuous profiling backend and UI
+  pyroscope:
+    image: grafana/pyroscope:${GRAFANA_PYROSCOPE_VERSION:-2.0.3}
+    ports:
+      - 4040:4040
+
+  # Grafana: visualize flame graphs via the Pyroscope datasource
+  grafana:
+    image: grafana/grafana:${GRAFANA_VERSION:-13.0.2}
+    environment:
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_BASIC_ENABLED=false
+    ports:
+      - 3000:3000/tcp
+    entrypoint:
+      - sh
+      - -euc
+      - |
+        mkdir -p /etc/grafana/provisioning/datasources
+        cat <<EOF > /etc/grafana/provisioning/datasources/ds.yaml
+        apiVersion: 1
+        datasources:
+        - name: Pyroscope
+          type: grafana-pyroscope-datasource
+          access: proxy
+          orgId: 1
+          url: http://pyroscope:4040
+          basicAuth: false
+          isDefault: true
+          version: 1
+          editable: false
+        EOF
+        /run.sh
+    depends_on:
+      - pyroscope
+
+  # The JVM workload under profile: two deterministic hot paths
+  # (Main.burnCpu and Main.churnAllocations) so the flame graphs have
+  # recognizable frames. The fixed container_name lets the Alloy service
+  # join this exact container's PID namespace below.
+  java-app:
+    build: ./app
+    container_name: java-app
+    restart: unless-stopped
+    volumes:
+      # Shared with Alloy: the JVM attach handshake (/tmp/.java_pid<PID>)
+      # and the async-profiler library Alloy extracts both live in /tmp,
+      # and must be visible to BOTH containers at the same path.
+      - jvm-tmp:/tmp
+
+  # Alloy with pyroscope.java. async-profiler attaches to a running JVM,
+  # which requires Alloy to (a) see the JVM's PID namespace -- hence
+  # pid: "container:java-app" -- (b) ptrace it -- hence SYS_PTRACE -- and
+  # (c) share /tmp with it for the attach socket and the profiler library.
+  alloy:
+    image: grafana/alloy:${GRAFANA_ALLOY_VERSION:-v1.16.1}
+    pid: "container:java-app"
+    cap_add:
+      - SYS_PTRACE
+    ports:
+      - 12345:12345
+    volumes:
+      - ./config.alloy:/etc/alloy/config.alloy
+      - jvm-tmp:/tmp
+    command: run --server.http.listen-addr=0.0.0.0:12345 --storage.path=/var/lib/alloy/data /etc/alloy/config.alloy
+    depends_on:
+      - pyroscope
+      - java-app
+
+volumes:
+  jvm-tmp:


### PR DESCRIPTION
Adds the **java-profiling** scenario: zero-code-change JVM profiling with `pyroscope.java` — Alloy discovers the JVM with `discovery.process`, attaches async-profiler, and streams CPU + allocation profiles to Pyroscope with real method-level frames.

Closes #105. Part of #90.

## What it does

The compose wiring *is* the lesson — the JVM dynamic-attach mechanism needs Alloy and the target to effectively share a machine:

| Compose setting | Why |
|---|---|
| `pid: "container:java-app"` on alloy | PID-namespace visibility for `discovery.process` + the attach handshake |
| `cap_add: [SYS_PTRACE]` | attach performs ptrace-style access checks |
| shared `jvm-tmp` volume on `/tmp` of both containers | the JVM attach socket (`/tmp/.java_pid<PID>`) and the async-profiler library Alloy extracts must be visible to both at the same path |

The workload (`app/Main.java`, precompiled in the Dockerfile from a digest-pinned `eclipse-temurin:21-jdk`, run with `-XX:+DebugNonSafepoints`) has two deterministic hot paths so the flame graphs are readable: `Main.burnCpu` (CPU) and `Main.churnAllocations` (alloc). `event = "itimer"` keeps sampling free of `perf_event_paranoid` dependencies, so this also works on restricted CI runners.

## Files

| File | Purpose |
|---|---|
| `java-profiling/docker-compose.yml` + `.coda.yml` | pyroscope + grafana + java-app + alloy / app only |
| `java-profiling/config.alloy` | discovery.process → relabel keep `.*/java$` → pyroscope.java → pyroscope.write (62 lines) |
| `java-profiling/app/{Dockerfile, Main.java}` | pinned temurin 21 base; deterministic workload |
| `java-profiling/README.md` | attach mechanics + what to look for + headless check |
| `.github/scenario-list.txt`, `README.md` | registration + Profiling table row |

## e2e evidence (full stack run)

```
GRAFANA HEALTHY
PASS: CPU flame graph contains Main.burnCpu        # /pyroscope/render, process_cpu
PASS: alloc profile contains Main.churnAllocations # memory:alloc_in_new_tlab_bytes
top CPU frames: Main.churnAllocations, Main.burnCpu, Main.countPrimes, Main.isPrime
alloy log: "using embedded asprof dist" (clean attach, no errors)
docker compose ps --status exited -> (empty)
```

Both success criteria from the issue (CPU **and** allocation profile types with method-level frames, no `[unknown]`) verified via the render API.
