### PR TITLE
Add Promtail to Alloy migration scenario (alloy convert)

### DIFF
--- a/.github/scenario-list.txt
+++ b/.github/scenario-list.txt
@@ -23,6 +23,7 @@ otel-span-metrics
 otel-tail-sampling
 otel-tracing-service-graphs
 postgres-monitoring
+promtail-to-alloy-migration
 redis-monitoring
 routing
 self-monitoring

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ These scenarios focus on log collection, log parsing, log routing, and log redac
 | [Logs from file](logs-file/) | Tail log files with Alloy. |
 | [Logs over TCP](logs-tcp/) | Receive and process TCP logs in JSON format. |
 | [Popular logging frameworks](app-instrumentation/logging/popular-logging-frameworks/) | Parse logs from popular logging frameworks across 7 programming languages. |
+| [Promtail to Alloy migration](promtail-to-alloy-migration/) | Run Promtail (EOL March 2026) and its `alloy convert` equivalent side by side against one log file and verify identical results in Loki. |
 | [Structured log parsing](mail-house/) | Parse structured logs into labels and structured metadata. |
 | [Syslog monitoring](syslog/) | Monitor non-RFC5424 compliant syslog messages with `rsyslog` and Alloy. |
 | [systemd journal](systemd-journal/) | Forward systemd journal entries to Loki with filters and labels tuned for fast queries. |

--- a/image-versions.env
+++ b/image-versions.env
@@ -55,3 +55,7 @@ VAULT_VERSION=2.0.2
 # cloudwatch-metrics scenario
 # renovate: datasource=docker depName=localstack/localstack
 LOCALSTACK_VERSION=4.14.0
+
+# promtail-to-alloy-migration scenario
+# renovate: datasource=docker depName=grafana/promtail
+PROMTAIL_VERSION=3.6.11

--- a/promtail-to-alloy-migration/README.md
+++ b/promtail-to-alloy-migration/README.md
@@ -1,0 +1,93 @@
+# Promtail to Alloy Migration
+
+This scenario is a side-by-side migration playbook: the same log file is tailed by **Promtail** (using `promtail-config.yaml`) and by **Alloy** (using `config.alloy`, derived with `alloy convert`), and both ship to the same Loki instance. Query Loki for either pipeline and you get identical log lines with identical labels — only the `collector` label differs.
+
+[Promtail reached end of life on March 2, 2026](https://grafana.com/docs/loki/latest/send-data/promtail/): commercial support has ended and no future updates will be provided. [Grafana Alloy](https://grafana.com/docs/alloy/latest/) is its successor, and `alloy convert` automates most of the migration.
+
+## Prerequisites
+
+- Docker and Docker Compose installed
+
+## Getting Started
+
+```bash
+git clone https://github.com/grafana/alloy-scenarios.git
+cd alloy-scenarios/promtail-to-alloy-migration
+docker compose up -d
+```
+
+## Access Points
+
+| Service  | URL                    |
+|----------|------------------------|
+| Grafana  | http://localhost:3000  |
+| Alloy UI | http://localhost:12345 |
+| Loki     | http://localhost:3100  |
+
+## Configuration Mapping
+
+Every block in `promtail-config.yaml` maps to an Alloy component in `config.alloy` (both files carry matching comments):
+
+| Promtail | Alloy | Notes |
+|----------|-------|-------|
+| `server:` | — | Alloy's HTTP server is a CLI flag (`--server.http.listen-addr`); no config block needed |
+| `positions:` | — | Read offsets live in Alloy's `--storage.path` automatically. The converter also emits `legacy_positions_file` so an in-place migration resumes exactly where Promtail stopped |
+| `clients.url` | `loki.write` → `endpoint.url` | Same push endpoint |
+| `clients.external_labels` | `loki.write` → `external_labels` | This scenario uses it to tag the collector |
+| `scrape_configs.static_configs` + `__path__` | `local.file_match` → `path_targets` | Static labels ride along on the target |
+| file tailing (implicit) | `loki.source.file` | Both add the `filename` label automatically |
+| `pipeline_stages: - regex` | `loki.process` → `stage.regex` | Identical regex syntax |
+| `pipeline_stages: - labels` | `loki.process` → `stage.labels` | Identical label promotion |
+
+## Run the Converter Yourself
+
+Reproduce the conversion with:
+
+```bash
+docker run --rm -v "$(pwd)":/work grafana/alloy:v1.16.1 \
+  convert --source-format=promtail --output=/work/converted.alloy /work/promtail-config.yaml
+```
+
+The committed `config.alloy` is semantically equivalent to the converter's output with a few deliberate differences, so the two are worth diffing:
+
+* The converter inlines the targets on `loki.source.file` with a `file_match { enabled = true }` block; the committed config uses the equivalent — and more common — `local.file_match` component.
+* The converter emits `legacy_positions_file = "/tmp/positions.yaml"` so a real migration picks up exactly where Promtail's positions file left off. This scenario omits it: both collectors deliberately read the file from the beginning so their output can be compared.
+* `external_labels` is changed from `collector = "promtail"` to `collector = "alloy"` — that label is how you tell the two pipelines apart in Loki.
+
+## Verify the Pipelines Are Equivalent
+
+Open Grafana at http://localhost:3000, navigate to **Explore**, select the **Loki** datasource, and compare:
+
+```logql
+{job="demo-app", collector="promtail"}
+```
+
+```logql
+{job="demo-app", collector="alloy"}
+```
+
+Both return the same lines with the same `job`, `level`, `service`, and `filename` labels. To watch them track each other:
+
+```logql
+sum by (collector) (count_over_time({job="demo-app"}[1m]))
+```
+
+The two series sit on top of each other — that's the migration proof.
+
+## What to Expect
+
+The `log-generator` container writes one structured logfmt line per second:
+
+```
+2026-06-11T10:00:00Z level=INFO service=payments msg="processed order 1000 in 20ms"
+```
+
+Both collectors tail `/var/log/demo/app.log` (mounted read-only at the same path in each container so the `filename` label matches), extract `level` and `service` as labels with a regex pipeline, and push to Loki with their own `collector` external label.
+
+You can also inspect the Alloy side of the migration at http://localhost:12345 — live debugging is enabled, so you can watch `loki.process` parse lines in real time.
+
+## Stopping the Scenario
+
+```bash
+docker compose down
+```

--- a/promtail-to-alloy-migration/config.alloy
+++ b/promtail-to-alloy-migration/config.alloy
@@ -1,0 +1,65 @@
+// ############################################
+// #### Promtail -> Alloy Migration Result ####
+// ############################################
+//
+// This is the Alloy equivalent of promtail-config.yaml, derived with:
+//
+//   alloy convert --source-format=promtail \
+//     --output=config.alloy promtail-config.yaml
+//
+// and then renamed/commented for readability (the converter emits the
+// same components with generated labels). Each component notes the
+// Promtail block it replaces. Promtail's positions file has no component
+// here: Alloy tracks read offsets in its --storage.path automatically.
+
+// Enable live debugging for the Alloy UI.
+livedebugging {
+	enabled = true
+}
+
+// scrape_configs.static_configs (with __path__) -> local.file_match.
+// The static labels (job) ride along on the target.
+local.file_match "demo" {
+	path_targets = [{
+		__path__ = "/var/log/demo/*.log",
+		job      = "demo-app",
+	}]
+}
+
+// The tailing engine inside scrape_configs -> loki.source.file.
+// Like Promtail, it adds the filename label automatically.
+loki.source.file "demo" {
+	targets    = local.file_match.demo.targets
+	forward_to = [loki.process.parse.receiver]
+}
+
+// pipeline_stages -> loki.process. The stage blocks are 1:1 with
+// Promtail's pipeline stages, same syntax for the regex itself.
+loki.process "parse" {
+	// pipeline_stages[0] "- regex" -> stage.regex
+	stage.regex {
+		expression = ".*level=(?P<level>\\w+) service=(?P<service>\\w+).*"
+	}
+
+	// pipeline_stages[1] "- labels" -> stage.labels
+	stage.labels {
+		values = {
+			level   = "",
+			service = "",
+		}
+	}
+
+	forward_to = [loki.write.default.receiver]
+}
+
+// clients -> loki.write: same push endpoint, and the external label that
+// marks which collector shipped each line (promtail vs alloy).
+loki.write "default" {
+	endpoint {
+		url = "http://loki:3100/loki/api/v1/push"
+	}
+
+	external_labels = {
+		collector = "alloy",
+	}
+}

--- a/promtail-to-alloy-migration/docker-compose.coda.yml
+++ b/promtail-to-alloy-migration/docker-compose.coda.yml
@@ -1,0 +1,10 @@
+services:
+  # Writes one structured logfmt line per second to /var/log/demo/app.log.
+  # Both collectors tail the same file, which is what makes their output
+  # directly comparable in Loki.
+  log-generator:
+    image: python:${PYTHON_VERSION:-3.11-slim}
+    volumes:
+      - ./main.py:/main.py
+      - ./logs:/var/log/demo
+    command: ["python3", "/main.py"]

--- a/promtail-to-alloy-migration/docker-compose.yml
+++ b/promtail-to-alloy-migration/docker-compose.yml
@@ -1,0 +1,75 @@
+services:
+  # Writes one structured logfmt line per second to /var/log/demo/app.log.
+  # Both collectors tail the same file, which is what makes their output
+  # directly comparable in Loki.
+  log-generator:
+    image: python:${PYTHON_VERSION:-3.11-slim}
+    volumes:
+      - ./main.py:/main.py
+      - ./logs:/var/log/demo
+    command: ["python3", "/main.py"]
+
+  # The "before": Promtail reached end of life on March 2, 2026. This
+  # container runs the legacy pipeline that config.alloy replaces.
+  promtail:
+    image: grafana/promtail:${PROMTAIL_VERSION:-3.6.11}
+    volumes:
+      - ./promtail-config.yaml:/etc/promtail/config.yml
+      # Same mount path as the Alloy container so both pipelines emit an
+      # identical filename label.
+      - ./logs:/var/log/demo:ro
+    depends_on:
+      - loki
+      - log-generator
+
+  # The "after": the equivalent Alloy pipeline, derived with
+  # `alloy convert --source-format=promtail`.
+  alloy:
+    image: grafana/alloy:${GRAFANA_ALLOY_VERSION:-v1.16.1}
+    ports:
+      - 12345:12345
+    volumes:
+      - ./config.alloy:/etc/alloy/config.alloy
+      - ./logs:/var/log/demo:ro
+    command: run --server.http.listen-addr=0.0.0.0:12345 --storage.path=/var/lib/alloy/data /etc/alloy/config.alloy
+    depends_on:
+      - loki
+      - log-generator
+
+  loki:
+    image: grafana/loki:${GRAFANA_LOKI_VERSION:-3.6.10}
+    ports:
+      - "3100:3100"
+    volumes:
+      - ./loki-config.yaml:/etc/loki/local-config.yaml
+    command: -config.file=/etc/loki/local-config.yaml
+
+  grafana:
+    image: grafana/grafana:${GRAFANA_VERSION:-13.0.2}
+    environment:
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_BASIC_ENABLED=false
+    ports:
+      - 3000:3000/tcp
+    entrypoint:
+      - sh
+      - -euc
+      - |
+        mkdir -p /etc/grafana/provisioning/datasources
+        cat <<EOF > /etc/grafana/provisioning/datasources/ds.yaml
+        apiVersion: 1
+        datasources:
+        - name: Loki
+          type: loki
+          access: proxy
+          orgId: 1
+          url: http://loki:3100
+          basicAuth: false
+          isDefault: true
+          version: 1
+          editable: false
+        EOF
+        /run.sh
+    depends_on:
+      - loki

--- a/promtail-to-alloy-migration/loki-config.yaml
+++ b/promtail-to-alloy-migration/loki-config.yaml
@@ -1,0 +1,46 @@
+
+# This is a complete configuration to deploy Loki backed by the filesystem.
+# The index will be shipped to the storage via tsdb-shipper.
+
+auth_enabled: false
+
+limits_config:
+  allow_structured_metadata: true
+  volume_enabled: true
+
+server:
+  http_listen_port: 3100
+
+common:
+  ring:
+    instance_addr: 0.0.0.0
+    kvstore:
+      store: inmemory
+  replication_factor: 1
+  path_prefix: /tmp/loki
+
+schema_config:
+  configs:
+  - from: 2020-05-15
+    store: tsdb
+    object_store: filesystem
+    schema: v13
+    index:
+      prefix: index_
+      period: 24h
+
+storage_config:
+  tsdb_shipper:
+    active_index_directory: /tmp/loki/index
+    cache_location: /tmp/loki/index_cache
+  filesystem:
+    directory: /tmp/loki/chunks
+
+pattern_ingester:
+  enabled: true
+
+# Note: We are setting the max chunk age far lower than the default expected value
+# This is due to the fact this scenario is used within the LogCLI demo and we need a short flush time.
+# To show how logcli stats --since 24h '{service_name="Delivery World", package_size="Large"}' works.
+ingester:
+  max_chunk_age: 5m # Should be 2 hours

--- a/promtail-to-alloy-migration/main.py
+++ b/promtail-to-alloy-migration/main.py
@@ -1,0 +1,38 @@
+"""Structured-log generator for the promtail-to-alloy-migration scenario.
+
+Writes one logfmt line per second to /var/log/demo/app.log. The rotation
+through levels and services is deterministic (counter-based, not random)
+so the two collection pipelines can be diffed line-for-line in Loki.
+"""
+
+import itertools
+import os
+import time
+from datetime import datetime, timezone
+
+LOG_DIR = "/var/log/demo"
+LOG_FILE = os.path.join(LOG_DIR, "app.log")
+
+LEVELS = ["INFO", "INFO", "DEBUG", "WARN", "ERROR"]
+SERVICES = ["payments", "checkout", "inventory"]
+
+
+def main():
+    os.makedirs(LOG_DIR, exist_ok=True)
+    levels = itertools.cycle(LEVELS)
+    services = itertools.cycle(SERVICES)
+
+    with open(LOG_FILE, "a", buffering=1) as f:
+        for order_id in itertools.count(1000):
+            ts = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+            line = (
+                f'{ts} level={next(levels)} service={next(services)} '
+                f'msg="processed order {order_id} in {order_id % 90 + 10}ms"'
+            )
+            f.write(line + "\n")
+            print(line, flush=True)
+            time.sleep(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/promtail-to-alloy-migration/promtail-config.yaml
+++ b/promtail-to-alloy-migration/promtail-config.yaml
@@ -1,0 +1,38 @@
+# The "before" configuration. Promtail reached end of life on March 2,
+# 2026; config.alloy in this directory is its `alloy convert` equivalent.
+# The README maps every block below to the Alloy component that replaces it.
+
+server:
+  http_listen_port: 9080
+  grpc_listen_port: 0
+
+# Promtail tracks how far it has read each file in a positions file.
+# Alloy keeps the same bookkeeping in its storage.path (WAL) instead.
+positions:
+  filename: /tmp/positions.yaml
+
+# clients -> loki.write: the push endpoint and the external label that
+# marks which collector shipped each line.
+clients:
+  - url: http://loki:3100/loki/api/v1/push
+    external_labels:
+      collector: promtail
+
+# scrape_configs -> local.file_match (target discovery) + loki.source.file
+# (tailing) + loki.process (pipeline stages).
+scrape_configs:
+  - job_name: demo-app
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: demo-app
+          __path__: /var/log/demo/*.log
+    pipeline_stages:
+      # - regex -> stage.regex: extract level and service from the line.
+      - regex:
+          expression: '.*level=(?P<level>\w+) service=(?P<service>\w+).*'
+      # - labels -> stage.labels: promote the captures to Loki labels.
+      - labels:
+          level:
+          service:


### PR DESCRIPTION
Adds the **promtail-to-alloy-migration** scenario: Promtail (EOL March 2, 2026) and its `alloy convert`-derived equivalent tail the same log file side by side, ship to the same Loki, and return identical query results — the migration proof, runnable.

Closes #106. Part of #90.

## What it does

- One deterministic logfmt generator (1 line/sec) writes to a file both collectors mount **at the same path** (`/var/log/demo`), so even the `filename` label matches.
- `promtail-config.yaml` (the "before") and `config.alloy` (the "after") carry matching comments mapping every block: `clients`→`loki.write`, `static_configs`+`__path__`→`local.file_match`, `pipeline_stages.regex/labels`→`stage.regex`/`stage.labels`, `positions`→Alloy storage.path (+ the converter's `legacy_positions_file` explained in the README).
- Only the `collector` external label differs (`promtail` vs `alloy`); the README documents how to reproduce the conversion with `alloy convert --source-format=promtail` and the deliberate diffs vs raw converter output.
- Adds `PROMTAIL_VERSION=3.6.11` (newest published promtail) to `image-versions.env` with the renovate annotation; the compose fallback matches (check-image-versions gate).

## Files

| File | Purpose |
|---|---|
| `promtail-to-alloy-migration/{promtail-config.yaml, config.alloy}` | the before/after pair with mapping comments |
| `promtail-to-alloy-migration/main.py` | deterministic logfmt generator (runs forever) |
| `promtail-to-alloy-migration/docker-compose.yml` + `.coda.yml` | 5 services / generator only |
| `promtail-to-alloy-migration/{loki-config.yaml, README.md}` | backend + mapping table/EOL framing |
| `image-versions.env`, `.github/scenario-list.txt`, `README.md` | promtail pin + registration + Logs table row |

## e2e evidence (full stack run)

```
GRAFANA HEALTHY / BOTH COLLECTORS SHIPPING
line sets over a 10-min window:  26 promtail lines vs 26 alloy lines -> diff: PASS identical
label sets via /loki/api/v1/series with `collector` deleted -> collapse to 1 set per combination
  e.g. {filename="/var/log/demo/app.log", job="demo-app", level="INFO", service="payments", service_name="payments"}
docker compose ps --status exited -> (empty)
```
