### PR TITLE
Add Claude skill to create or review README files for new and existing scenarios

### DIFF
--- a/skills/README.md
+++ b/skills/README.md
@@ -1,0 +1,29 @@
+# Skills library
+
+AI skills for creating and reviewing scenario README files in **alloy-scenarios**.
+
+For technical writers, engineers, and contributors who use Cursor, VS Code, or Claude Code.
+
+## Skills
+
+| Skill | Purpose |
+| ----- | ------- |
+| [`docs-review/SKILL.md`](docs-review/SKILL.md) | Create or review scenario README files for style and technical accuracy |
+
+### What you control
+
+Skills draft and review content but never commit, push, or publish on their own. You decide when to advance each step, what to keep, and when to submit. The agent handles research, formatting, and checking. You own the final output.
+
+### Shared resources
+
+The `shared/` directory is the single source of truth for cross-cutting references. Skills load these by relative path.
+
+| File | Purpose |
+| ---- | ------- |
+| [`shared/repo-context.md`](shared/repo-context.md) | Repository layout, workflow, and baseline README examples |
+| [`shared/style-guide.md`](shared/style-guide.md) | Writers Toolkit rules and README template |
+| [`shared/best-practices.md`](shared/best-practices.md) | Config-first workflow and common pitfalls |
+| [`shared/alloy-verification.md`](shared/alloy-verification.md) | Verify Alloy claims against external docs |
+| [`shared/technical-verification.md`](shared/technical-verification.md) | Technical review workflow for README claims |
+| [`shared/verification-checklist.md`](shared/verification-checklist.md) | Handoff checklist |
+| [`shared/README.md`](shared/README.md) | Overview of the shared directory |

--- a/skills/docs-review/SKILL.md
+++ b/skills/docs-review/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: docs-review
+description: >-
+  Create or review scenario README files in alloy-scenarios from existing
+  Docker Compose, Helm, and config.alloy files. Use when drafting a new scenario
+  README, rewriting an existing README, checking Writers Toolkit style, or
+  verifying README accuracy against scenario configs and Grafana Alloy
+  documentation.
+---
+
+# Scenario README create and review
+
+Create or update a single scenario `README.md` in **alloy-scenarios**.
+This repository documents scenarios only through per-directory README files.
+
+Do not create other documentation pages.
+Do not edit scenario configuration files.
+Do not commit, push, or open pull requests unless the user explicitly asks.
+
+## Before you begin
+
+Read these shared files in order:
+
+1. [`../shared/repo-context.md`](../shared/repo-context.md)
+2. [`../shared/style-guide.md`](../shared/style-guide.md)
+3. [`../shared/best-practices.md`](../shared/best-practices.md)
+
+Then read every configuration file in the target scenario directory.
+See **Config files to read** in [`../shared/best-practices.md`](../shared/best-practices.md).
+
+Ask the user for the scenario directory path if it is not clear from context.
+
+## Step 1: Choose create or review
+
+| Condition                                        | Path       |
+| ------------------------------------------------ | ---------- |
+| `README.md` is missing, empty, or a stub         | **Create** |
+| `README.md` already exists with scenario content | **Review** |
+
+Create and review use the same style, structure, and verification rules.
+
+## Step 2: Create a new README
+
+1. Read the closest baseline README listed in [`../shared/repo-context.md`](../shared/repo-context.md).
+2. Draft `README.md` using the template in [`../shared/style-guide.md`](../shared/style-guide.md).
+3. Derive every command, port, URL, component name, and query from the scenario config files.
+4. Omit optional template sections that do not apply.
+5. Follow [`../shared/technical-verification.md`](../shared/technical-verification.md).
+6. Verify Alloy component claims with [`../shared/alloy-verification.md`](../shared/alloy-verification.md).
+7. Run through [`../shared/verification-checklist.md`](../shared/verification-checklist.md).
+8. Present the draft README to the user. Do not commit.
+
+## Step 3: Review an existing README
+
+1. Read the current `README.md` alongside the scenario config files.
+2. Load the previous version for preservation checks:
+
+   ```sh
+   git show HEAD:<scenario-dir>/README.md
+   ```
+
+   If the file is new on this branch, compare against the merge base or ask the user which version to preserve against.
+
+3. Classify the change:
+
+   - **Style/editorial** — wording and structure only, no new technical claims
+   - **Technical** — commands, ports, component names, queries, credentials, or pipeline behavior
+
+   When in doubt, treat it as **technical**.
+
+4. Follow [`../shared/technical-verification.md`](../shared/technical-verification.md).
+5. Verify Alloy component claims with [`../shared/alloy-verification.md`](../shared/alloy-verification.md).
+6. Apply [`../shared/style-guide.md`](../shared/style-guide.md) and [`../shared/best-practices.md`](../shared/best-practices.md).
+7. Confirm every command, query, credential, env var, and demo manifest from the original README is still present unless the configs changed.
+8. Run through [`../shared/verification-checklist.md`](../shared/verification-checklist.md).
+9. Apply fixes to `README.md` only. Present results to the user. Do not commit.
+
+## Style and format requirements
+
+Apply every rule in [`../shared/style-guide.md`](../shared/style-guide.md). In particular:
+
+- Active voice, second person, present tense, contractions
+- Sentence case for headings and emphasis used as subheadings
+- No gerunds in headings
+- No parentheses or brackets in prose
+- "Refer to" not "see"
+- "Check" not "confirm" in troubleshoot steps
+- Every fenced code block must have a language tag
+
+Remove AI-tell phrasing listed in [`../shared/best-practices.md`](../shared/best-practices.md).
+
+## Technical verification
+
+Scenario config files outrank the README when they disagree.
+Fix the README to match the configs.
+If a config looks wrong, flag it for the contributor instead of changing it.
+
+For Alloy component names, arguments, and behavior, verify against the latest reference:
+
+https://grafana.com/docs/alloy/latest/reference/components/
+
+Follow [`../shared/technical-verification.md`](../shared/technical-verification.md) for the full workflow.
+
+## Handoff
+
+Present a summary that includes:
+
+1. **Task** — create or review
+2. **Scenario directory**
+3. **Changes made** — or the full draft for create
+4. **Style issues** found and fixed
+5. **Technical verification** — claims checked against configs and Alloy docs, with any divergences
+6. **Preservation** — on review, any content from the original README that was kept, restored, or intentionally dropped
+7. **Open questions** — config problems or claims you could not verify
+8. **Checklist** — note any items from [`../shared/verification-checklist.md`](../shared/verification-checklist.md) the user should confirm before submitting
+
+## Reference
+
+| File | Purpose |
+| ---- | ------- |
+| [`../shared/repo-context.md`](../shared/repo-context.md) | Repository layout and baseline READMEs |
+| [`../shared/style-guide.md`](../shared/style-guide.md) | Style rules and README template |
+| [`../shared/best-practices.md`](../shared/best-practices.md) | Config-first workflow and pitfalls |
+| [`../shared/technical-verification.md`](../shared/technical-verification.md) | Technical review steps |
+| [`../shared/alloy-verification.md`](../shared/alloy-verification.md) | Alloy docs cross-check |
+| [`../shared/verification-checklist.md`](../shared/verification-checklist.md) | Pre-submit checklist |

--- a/skills/shared/README.md
+++ b/skills/shared/README.md
@@ -1,0 +1,49 @@
+# Shared resources for README skills
+
+Foundation files for creating and reviewing scenario `README.md` files in **alloy-scenarios**.
+
+This repository documents scenarios through one README per directory. These files do not support Hugo pages, release notes, or product reference documentation.
+
+## Files
+
+| File | Purpose |
+| ---- | ------- |
+| [`repo-context.md`](repo-context.md) | Repository layout, contributor workflow, baseline README examples |
+| [`style-guide.md`](style-guide.md) | Writers Toolkit rules and README template |
+| [`best-practices.md`](best-practices.md) | Config-first workflow, pitfalls, and good patterns |
+| [`alloy-verification.md`](alloy-verification.md) | How to verify Alloy claims against external docs |
+| [`technical-verification.md`](technical-verification.md) | End-to-end technical review workflow for README claims |
+| [`verification-checklist.md`](verification-checklist.md) | Handoff checklist before submitting README changes |
+
+## Workflow
+
+### Create a new README
+
+1. Read [`repo-context.md`](repo-context.md)
+2. Read the scenario config files
+3. Draft with the README template in [`style-guide.md`](style-guide.md)
+4. Follow [`best-practices.md`](best-practices.md)
+5. Run [`verification-checklist.md`](verification-checklist.md)
+
+### Review an existing README
+
+1. Read [`repo-context.md`](repo-context.md)
+2. Read the scenario config files and the current README
+3. Compare against the previous README to preserve commands, queries, and credentials
+4. Apply [`style-guide.md`](style-guide.md) and [`best-practices.md`](best-practices.md)
+5. Follow [`technical-verification.md`](technical-verification.md) and [`alloy-verification.md`](alloy-verification.md)
+6. Run [`verification-checklist.md`](verification-checklist.md)
+
+## Skills that use these files
+
+- [`../docs-review/SKILL.md`](../docs-review/SKILL.md) — create or review scenario README files
+
+See [`../README.md`](../README.md) for the skills library overview.
+
+## Maintenance
+
+Update these files when:
+
+- Baseline scenario README structure changes
+- New verification patterns are discovered
+- Repository layout or run workflow changes

--- a/skills/shared/alloy-verification.md
+++ b/skills/shared/alloy-verification.md
@@ -1,0 +1,62 @@
+# Alloy technical verification
+
+Use this guide when a README names Alloy components, arguments, endpoints, or pipeline behavior.
+
+## Primary source
+
+Verify against the latest Grafana Alloy component reference:
+
+https://grafana.com/docs/alloy/latest/reference/components/
+
+Search for the exact block type named in `config.alloy`, for example `loki.source.file`, `prometheus.scrape`, or `otelcol.receiver.otlp`.
+
+## Secondary source
+
+Verify deployment commands, ports, service names, and URLs against files in the scenario directory:
+
+- `config.alloy`
+- `docker-compose.yml` and `docker-compose.coda.yml`
+- Backend configs such as `loki-config.yaml`, `prom-config.yaml`, `tempo-config.yaml`
+- Helm values files in `k8s/` scenarios
+
+The scenario configs outrank the README when they disagree.
+
+## What to verify
+
+| Claim type                                        | Check against                                              |
+| ------------------------------------------------- | ---------------------------------------------------------- |
+| Component block names                             | `config.alloy` and Alloy component reference               |
+| `forward_to`, labels, scrape intervals, endpoints | `config.alloy`                                             |
+| Ports and localhost URLs                          | `docker-compose.yml` port mappings                         |
+| Backend URLs inside the stack                     | compose files or backend configs                           |
+| Helm chart names, release names, values keys      | scenario Helm values files                                 |
+| Image tags when documented                        | `image-versions.env` and compose `${VAR:-default}` entries |
+
+## Risk levels
+
+**High risk** — always verify:
+
+- Exact `config.alloy` block names users will search for in the Alloy UI
+- Commands users copy and paste
+- Ports, URLs, and credentials
+- Query examples tied to labels the scenario actually sets
+
+**Medium risk** — verify when stated explicitly:
+
+- What a component does in this scenario's pipeline
+- Optional features enabled or disabled in config
+- Number of parallel paths or sources
+
+**Low risk** — spot-check:
+
+- General descriptions of Grafana, Loki, Prometheus, or Tempo roles in the stack
+
+## When Alloy docs and configs disagree
+
+1. Don't change or edit the scenario config files
+2. If the config looks wrong and doesn't match the Alloy documentation, flag it for the contributor to investigate instead of inventing behavior from memory
+
+## Preservation on rewrite
+
+When reviewing an existing README, verify that commands, queries, credentials, env vars, and demo manifests from the original file still appear in the updated version.
+Use `git show HEAD:<scenario>/README.md` or the branch base for comparison.

--- a/skills/shared/best-practices.md
+++ b/skills/shared/best-practices.md
@@ -1,0 +1,106 @@
+# README authoring best practices
+
+Best practices for creating and reviewing scenario README files in **alloy-scenarios**.
+
+## Config-first workflow
+
+Read the scenario configuration before writing or editing prose.
+
+**Docker scenarios**
+
+- `config.alloy`
+- `docker-compose.yml` and `docker-compose.coda.yml` if present
+- Backend configs in the scenario directory
+- `app/` demo code when it affects **Try it out**
+
+**Kubernetes scenarios**
+
+- Helm values files in the scenario directory
+- `kind.yml` when present
+
+Don't invent components, ports, commands, or URLs that aren't supported by these files.
+Don't edit these files.
+If there is a potential problem in the scenarion configurations, flag it for the contributor to investigate.
+
+## Create or review with the same rules
+
+| Task       | Starting point                             | Extra step                                                                |
+| ---------- | ------------------------------------------ | ------------------------------------------------------------------------- |
+| **Create** | Config files exist, README missing or stub | Draft from configs using the README template                              |
+| **Review** | README already exists                      | Preserve every command, query, credential, and manifest from the original |
+
+Style, structure, and verification rules are identical for both tasks.
+
+## Pre-writing checklist
+
+- [ ] Read [`repo-context.md`](repo-context.md) for repository layout
+- [ ] Read the scenario config files in the target directory
+- [ ] Read the closest baseline README named in `repo-context.md`
+- [ ] Read [`style-guide.md`](style-guide.md)
+- [ ] For rewrites, read the current README and note content that must be preserved
+
+## Verification sources
+
+1. Scenario config files in the directory
+2. [`technical-verification.md`](technical-verification.md) for the review workflow
+3. [`alloy-verification.md`](alloy-verification.md) for Alloy component claims
+4. [`verification-checklist.md`](verification-checklist.md) before handoff
+
+## Common pitfalls
+
+### Invented pipeline details
+
+**Problem**: Documenting components or labels that are not in `config.alloy`
+
+**Solution**: Walk the README pipeline section in the same order as the config file and use exact block names
+
+### Commands that don't match the repo
+
+**Problem**: Guessing install or run commands
+
+**Solution**: Copy commands from compose files, `run-example.sh` usage, or existing baseline READMEs for the same deployment pattern
+
+### Lost content on rewrite
+
+**Problem**: Improving style but dropping demo commands, queries, or credentials
+
+**Solution**: Compare against the previous README and restore anything missing
+
+### AI-tell phrasing
+
+Replace patterns such as:
+
+- "This scenario demonstrates" → "This scenario shows"
+- "will install" / "will be used to" → active present tense
+- "pre-configured" → "configured"
+- "See" → "Refer to"
+- "Confirm" in troubleshoot steps → "Check"
+- Blockquote notes about abstracting configuration
+
+### Weak examples
+
+**Problem**: Queries or dashboards that don't match labels the scenario sets
+
+**Solution**: Take query examples from labels and jobs defined in `config.alloy` or from the prior README
+
+## Good patterns
+
+**Introduction before the first heading**
+
+State what the scenario collects, what the user runs, and which config file defines Alloy.
+
+**Understand the configuration**
+
+Name each Alloy block with the exact identifier from `config.alloy` and state what it forwards to next.
+
+**Try it out**
+
+Use numbered steps, put LogQL, PromQL, or TraceQL in sub-bullets, and end with Alloy UI live debug when the scenario supports it.
+
+**Troubleshoot common problems**
+
+Open with one sentence that states the scope, then use `###` subsections with imperative fix steps.
+
+## Before handoff
+
+Run [`verification-checklist.md`](verification-checklist.md).

--- a/skills/shared/repo-context.md
+++ b/skills/shared/repo-context.md
@@ -1,0 +1,72 @@
+# alloy-scenarios repository context
+
+Read this file before creating or reviewing a scenario README.
+
+## What this repository documents
+
+- **Only** `<scenario-dir>/README.md` files
+- Each README is a self-contained install, run, and explore workflow
+- The root `README.md` is a scenario index, not a substitute for per-scenario READMEs
+
+## Scenario layout
+
+Most scenarios are **Docker-based**:
+
+```text
+scenario-name/
+├── docker-compose.yml       # LGMT stack + Alloy
+├── docker-compose.coda.yml  # Optional demo app services
+├── config.alloy             # Alloy pipeline
+├── loki-config.yaml         # When Loki is used
+├── prom-config.yaml         # When Prometheus is used
+├── tempo-config.yaml        # When Tempo is used
+├── README.md                # Scenario documentation
+└── app/                     # Optional demo application
+```
+
+Kubernetes scenarios live under `k8s/` and use Helm values files instead of Docker Compose. Treat them as an exception, not the default pattern.
+
+## Contributor workflow
+
+1. Create or update the scenario configuration files first
+2. Create or update `README.md` to match those files
+3. Verify the README against scenario configs and the Alloy component reference
+
+The README skill supports two paths with the same rules:
+
+- **Review** — README already exists; improve style and fix inaccuracies without dropping content
+- **Create** — README does not exist yet; draft from configs using the README template
+
+## Running scenarios
+
+From a scenario directory:
+
+```sh
+docker compose up -d
+```
+
+From the repository root with pinned image versions:
+
+```sh
+./run-example.sh <scenario-dir>
+```
+
+Image versions are centralized in `image-versions.env`. Compose files reference them with `${VAR:-default}` syntax.
+
+## Baseline README examples
+
+Use these as structure and tone references:
+
+| Pattern                  | Example                                                       |
+| ------------------------ | ------------------------------------------------------------- |
+| Docker, full workflow    | `linux/README.md`                                             |
+| Docker, shorter          | `kafka/README.md`                                             |
+| Docker, processing focus | `log-api-gateway/README.md`, `log-secret-filtering/README.md` |
+| Kubernetes Helm          | `k8s/logs/README.md`                                          |
+| Kubernetes manifests     | `k8s/events/README.md`                                        |
+
+## Other repo references
+
+- `CLAUDE.md` — project conventions and scenario checklist
+- `.cursor/docker-example.mdc` — Docker scenario boilerplate
+- `.cursor/k8s-example.mdc` — Kubernetes scenario boilerplate

--- a/skills/shared/style-guide.md
+++ b/skills/shared/style-guide.md
@@ -1,0 +1,118 @@
+## Style guide
+
+Always strictly adhere to the documentation style guide.
+
+### Scope
+
+This repository documents scenarios through **one file per scenario**: `<scenario-dir>/README.md`.
+Each README is a single-page workflow that explains how to install, run, explore, customize, and stop the demo.
+Do not create other documentation pages in this repository.
+
+Write for someone who wants to run the scenario end to end with minimal prior Alloy knowledge.
+
+### Product naming (Grafana organization)
+
+- Write for Grafana Labs users, not staff
+- Do not document how to develop on the Alloy project
+- Do not document deployment for Grafana Cloud products
+- Use long product names with "Grafana" in the README title
+- Use short product names without "Grafana" in the README body
+- Always use "Grafana Cloud," not "Cloud."
+- Mention metrics, logs, traces, profiles in this order
+
+### Style
+
+- Follow Every Page is Page One
+- Keep READMEs short and focused
+- Use present simple tense, second-person, and active voice
+- Use simple words, short sentences, and few adjectives or adverbs
+- Prefer contractions
+- Use sentence case for titles, headings, and UI
+- Bold UI text
+- Reference UI text, not element types such as button or tab
+- Do not use gerunds in headings
+- Do not use parentheses or brackets in prose
+
+### Structure
+
+- Write a short introduction before the first `##` heading
+- Add a brief overview sentence after each `##` and `###` heading where it helps
+- Structure content under `##` headings
+- Use `###` for troubleshoot subsections and related subsections
+- Do not use lists as a substitute for paragraphs
+- Use ", for example," for examples
+- Use relative links for other scenarios in this repository
+- Use "refer to" instead of "see."
+- Separate code and output blocks
+- Use `<VARIABLE>` in commands and _VARIABLE_ in prose for placeholders
+
+### README conventions
+
+- Always add a language tag to fenced code blocks. Do not use bare ` ``` ` fences.
+- Common tags: `sh` for shell commands, `yaml` for Kubernetes and Helm manifests, `alloy` for `config.alloy` excerpts, `text` for ASCII diagrams and env var lines, `markdown` for README examples
+- Use `config.alloy` block names exactly as they appear in the scenario file
+- Capitalize **Pod** in prose; use lowercase in `kubectl` commands and YAML
+- Docker scenarios may document two run options: `docker compose up -d` from the scenario directory, or `./run-example.sh <scenario-dir>` from the repository root
+
+## README template
+
+Always use this template for scenario `README.md` files.
+Derive commands, component names, and URLs from the scenario config files.
+Apply the style guide above.
+
+```markdown
+# <Scenario title>
+
+Introduction explaining what the scenario demonstrates, which telemetry it collects, what you install or run, and how Alloy is configured.
+
+## Before you begin
+
+List prerequisites, tools, and ports that must be free.
+
+## Compare with a related scenario
+
+Optional. Include a comparison table when a closely related scenario exists in the repository.
+
+## Understand the architecture
+
+Short overview, ASCII diagram, and labeled bullets for each component in the flow.
+
+## Run the scenario
+
+Numbered setup steps. Include clone, deploy or install commands, and a step to confirm the stack is ready.
+
+## Access the services
+
+Optional. Explain how to reach services that are not available on localhost.
+
+## Explore the services
+
+List each service URL, what you can do there, and login credentials when required.
+
+## Understand the configuration
+
+Walk through how Alloy and the backends are configured, in pipeline or dependency order.
+
+## Try it out
+
+Steps to generate telemetry, run queries or open dashboards, and inspect the pipeline in the Alloy UI.
+
+## Customize the scenario
+
+Common configuration changes and the command to apply them.
+
+## Troubleshoot common problems
+
+Overview sentence, then h3 subsections for each common failure and its fix.
+
+## Stop the scenario
+
+Command to tear down the demo environment.
+
+## Next steps
+
+Links to related Alloy documentation, sibling scenarios, and other examples in this repository.
+```
+
+Omit optional sections that do not apply to the scenario.
+Skip **Access the services** when all services are already reachable on localhost.

--- a/skills/shared/technical-verification.md
+++ b/skills/shared/technical-verification.md
@@ -1,0 +1,43 @@
+# Technical verification
+
+When creating or reviewing a scenario README, treat every factual claim about commands, ports, components, queries, or pipeline behavior as verifiable.
+
+## 1. Identify verifiable claims
+
+Flag statements about:
+
+- `config.alloy` block names, labels, endpoints, and `forward_to` wiring
+- Docker Compose commands, ports, and service names
+- Helm chart names, release names, and values file keys
+- LogQL, PromQL, TraceQL, or dashboard examples
+- Credentials, URLs, and install order
+
+## 2. Verify against scenario files first
+
+Read the scenario directory configs listed in [`repo-context.md`](repo-context.md).
+
+Use the **Scenario config verification** and **Preservation check** sections of [`verification-checklist.md`](verification-checklist.md).
+
+## 3. Verify Alloy claims against external docs
+
+Follow [`alloy-verification.md`](alloy-verification.md).
+
+Use the latest component reference at https://grafana.com/docs/alloy/latest/reference/components/
+
+## 4. Prioritize by risk
+
+- **High risk** — copy-paste commands, ports, block names, credentials, query labels. Always verify.
+- **Medium risk** — component behavior described in prose, optional pipeline paths. Verify against config and Alloy docs.
+- **Low risk** — general role of Grafana or a backend in the stack. Spot-check.
+
+If you cannot verify a claim, flag it for the contributor instead of assuming it is correct.
+
+## 5. Report findings
+
+For each divergence, note:
+
+- The claim as written in the README
+- What the scenario config or Alloy reference says
+- Whether they match
+
+Present technical findings separately from style issues.

--- a/skills/shared/verification-checklist.md
+++ b/skills/shared/verification-checklist.md
@@ -1,0 +1,66 @@
+# README verification checklist
+
+Use this checklist when creating or reviewing a scenario `README.md`.
+
+## Pre-writing
+
+- [ ] Read [`repo-context.md`](repo-context.md)
+- [ ] Read all config files in the scenario directory
+- [ ] Read the closest baseline README for structure and tone
+- [ ] For rewrites, captured commands, queries, and credentials that must be preserved
+
+## Scenario config verification
+
+- [ ] Run and install commands match `docker-compose.yml`, Helm values, or the existing README
+- [ ] Ports and localhost URLs match compose port mappings or documented port-forwards
+- [ ] Service names and in-stack URLs match compose or backend configs
+- [ ] `config.alloy` block names in the README match the file exactly
+- [ ] Pipeline order in the README matches the config file
+- [ ] Backend endpoints match `loki.write`, `prometheus.remote_write`, or equivalent blocks
+- [ ] Image version notes match `image-versions.env` when the README mentions pinned versions
+
+## Alloy documentation verification
+
+Follow [`alloy-verification.md`](alloy-verification.md).
+
+- [ ] Each named Alloy component exists in the latest component reference
+- [ ] Arguments and behavior described in the README match the reference and the scenario config
+- [ ] High-risk claims such as block names, ports, and copy-paste commands are verified
+
+## README structure
+
+- [ ] Follows the README template in [`style-guide.md`](style-guide.md)
+- [ ] Optional sections omitted when they do not apply
+- [ ] Introduction appears before the first `##` heading
+
+## Style guide compliance
+
+- [ ] Active voice, second person, present tense
+- [ ] Sentence case for headings and emphasis used as subheadings
+- [ ] Contractions used naturally
+- [ ] "Refer to" used instead of "see"
+- [ ] No gerunds in headings
+- [ ] No parentheses or brackets in prose
+- [ ] Brief overview after major headings where helpful
+- [ ] Prose explanations, not bullet lists standing in for paragraphs
+- [ ] Every fenced code block has a language tag
+
+## Example and query quality
+
+- [ ] Examples reflect what this scenario actually collects
+- [ ] LogQL, PromQL, TraceQL, or dashboard steps use labels and jobs from the config
+- [ ] Demo commands and manifests from the original README are preserved on rewrite
+
+## Preservation check (rewrite only)
+
+- [ ] All shell commands from the original README are still present
+- [ ] Credentials and default URLs preserved
+- [ ] Query examples preserved or intentionally replaced with equivalent coverage
+- [ ] Install order and Helm release names unchanged unless configs changed
+
+## Final review
+
+- [ ] Read the README as a first-time user would
+- [ ] Every technical claim traces to a scenario config file or Alloy reference page
+- [ ] **Stop the scenario** and **Next steps** sections are present
+- [ ] Relative links to sibling scenarios resolve


### PR DESCRIPTION
This PR adds a comprehensive Claude skill that users can use to:

1. Create a new README.md file for a newly created scenario.
2. Review an existing README.md for style, technical accuracy, and completeness.

Run the skill by calling: `docs-review <scenario directory>`.

The skill knows what files to review in the directory and uses the Docker YAML, Alloy config, and Helm Charts to build a comprehensive README file that complies with Grafana styles. 
The review validates the README content against the scenario configuration and the latest Alloy documentation.
If the skill finds errors in the config, it will flag the errors to the contributor with a summary of the error.
If the skill finds errors in an existing README file, it uses the Docker, Alloy and/or Helm Chart as the source of truth and will update the README to match.
When the skill is finished it presents a summary of what it did.