### PR TITLE
Add custom-builds/minimal-otel scenario (OCB)

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,15 @@ Refer to the [OTel examples README](otel-examples/) for details.
 | [PII redaction](otel-examples/pii-redaction/) | Scrub personally identifiable information, credit cards, emails, and IP addresses from traces and logs with OpenTelemetry Transformation Language `replace_pattern`. |
 | [Resource enrichment](otel-examples/resource-enrichment/) | Attach host, OS, and Docker metadata to all signals with `resourcedetection`. |
 
+### Custom builds
+
+These scenarios build your own Alloy components and ship them in a custom image.
+Refer to the [Custom builds README](custom-builds/) for the compile-in model and build-time expectations.
+
+| Scenario | Description |
+| -------- | ----------- |
+| [Minimal OTel collector](custom-builds/minimal-otel/) | Build a collector with only the OTel parts you need using the OpenTelemetry Collector Builder (OCB). The image is ~41 MB versus ~670 MB for full Alloy. |
+
 ## Contribute
 
 Contributions of scenarios and improvements are welcome.

--- a/custom-builds/README.md
+++ b/custom-builds/README.md
@@ -1,0 +1,26 @@
+# Custom Alloy builds
+
+These scenarios show how to **build a tailored Grafana Alloy / OpenTelemetry Collector image** instead of using the stock `grafana/alloy` distribution — for example when you want a slim collector that contains only the parts you use, or (later) when you need a component that doesn't ship by default.
+
+## How building a custom Alloy works
+
+Alloy is a single compiled Go binary. It has **no dynamic plugin system** — you can't drop a `.so` file next to it and have it loaded at runtime. Anything custom must be **compiled in**. There are two supported, documented ways to produce a tailored build:
+
+1. **Build a custom OpenTelemetry Collector distribution with OCB.** The [OpenTelemetry Collector Builder (OCB)](https://github.com/open-telemetry/opentelemetry-collector/tree/main/cmd/builder) assembles a collector from only the modules you list in a manifest. Alloy itself uses OCB internally to generate its OpenTelemetry engine (see `collector/builder-config.yaml` in the Alloy repo). This is the right tool when your goal is "only what I need." It's what the scenario below demonstrates.
+
+2. **Fork Alloy and add a Go component.** You add a package under `internal/component/...`, register it in `internal/component/all`, and rebuild with `make alloy`. The new component then works in normal Alloy (River) configuration, exactly like the built-in components. This is documented in Alloy's [developer guide for adding components](https://github.com/grafana/alloy/blob/main/docs/developer/add-otel-component.md). (Worked examples of this path may be added here later.)
+
+> **Note:** Alloy also has a config-language feature called [**custom components**](https://grafana.com/docs/alloy/latest/get-started/components/custom-components/) — the `declare` and `import` blocks. That feature bundles *existing built-in* components into reusable units; it involves no Go and no rebuild. It is a different thing from what these scenarios teach (producing a custom image), which is why this directory is named `custom-builds` rather than `custom-components`.
+
+## The scenarios
+
+| Scenario | What it teaches | Build method |
+| -------- | --------------- | ------------ |
+| [minimal-otel](minimal-otel/) | Build a collector with **only the OTel parts you need** (OTLP in, batch/memory_limiter, OTLP out) and compare its image size to full Alloy. | OCB |
+
+`minimal-otel` produces a **pure OpenTelemetry Collector** (Alloy's lineage), so it is configured with an OTel **YAML** file (`config.yaml`), not Alloy River syntax. The image versions in its `docker-compose.yml` are pinned to the values in the repo-root `image-versions.env`.
+
+## Honest limitations (no hand-waving)
+
+- There is **no build flag that slims the full Alloy (River) binary** to "only OTel." Alloy's `GO_TAGS` only toggle a few platform features (for example `netgo`, `embedalloyui`, `promtail_journal_enabled`). That is why `minimal-otel` uses OCB to produce a separate, minimal OTel Collector instead of a trimmed Alloy.
+- Alloy ships an in-process, OCB-generated OTel engine you can run with `alloy otel`, but it is currently **experimental**, so `minimal-otel` anchors on standalone OCB and only mentions the engine as the Alloy-native equivalent.

--- a/custom-builds/README.md
+++ b/custom-builds/README.md
@@ -1,26 +1,40 @@
 # Custom Alloy builds
 
-These scenarios show how to **build a tailored Grafana Alloy / OpenTelemetry Collector image** instead of using the stock `grafana/alloy` distribution — for example when you want a slim collector that contains only the parts you use, or (later) when you need a component that doesn't ship by default.
+These scenarios show how to build a tailored image based on Grafana Alloy or OpenTelemetry Collector instead of the default `grafana/alloy` image.
+You'll use this approach when you want a smaller OpenTelemetry Collector image for a focused pipeline, or when you need custom build behavior.
 
-## How building a custom Alloy works
+## How custom Alloy builds work
 
-Alloy is a single compiled Go binary. It has **no dynamic plugin system** — you can't drop a `.so` file next to it and have it loaded at runtime. Anything custom must be **compiled in**. There are two supported, documented ways to produce a tailored build:
+Grafana Alloy includes an OpenTelemetry engine.
+It uses the OpenTelemetry Collector runtime and OpenTelemetry YAML configuration for that engine.
+Refer to the published documentation for [OpenTelemetry in Alloy](https://grafana.com/docs/alloy/latest/introduction/otel_alloy/).
 
-1. **Build a custom OpenTelemetry Collector distribution with OCB.** The [OpenTelemetry Collector Builder (OCB)](https://github.com/open-telemetry/opentelemetry-collector/tree/main/cmd/builder) assembles a collector from only the modules you list in a manifest. Alloy itself uses OCB internally to generate its OpenTelemetry engine (see `collector/builder-config.yaml` in the Alloy repo). This is the right tool when your goal is "only what I need." It's what the scenario below demonstrates.
+You can build custom images with two common paths:
 
-2. **Fork Alloy and add a Go component.** You add a package under `internal/component/...`, register it in `internal/component/all`, and rebuild with `make alloy`. The new component then works in normal Alloy (River) configuration, exactly like the built-in components. This is documented in Alloy's [developer guide for adding components](https://github.com/grafana/alloy/blob/main/docs/developer/add-otel-component.md). (Worked examples of this path may be added here later.)
+1. **Build a custom OpenTelemetry Collector distribution with OCB.**
+   The [OpenTelemetry Collector Builder](https://opentelemetry.io/docs/collector/custom-collector/) builds a Collector distribution from modules you list in a manifest.
+   Alloy documentation describes OCB custom builds in [Grafana Alloy maintenance scope](https://grafana.com/docs/alloy/latest/reference/release-information/alloy-maintenance/).
 
-> **Note:** Alloy also has a config-language feature called [**custom components**](https://grafana.com/docs/alloy/latest/get-started/components/custom-components/) — the `declare` and `import` blocks. That feature bundles *existing built-in* components into reusable units; it involves no Go and no rebuild. It is a different thing from what these scenarios teach (producing a custom image), which is why this directory is named `custom-builds` rather than `custom-components`.
+2. **Fork Alloy and add a Go component.**
+   You add a component in source code and rebuild Alloy.
+   This path targets advanced customizations in Alloy syntax pipelines.
+   Grafana Alloy public docs focus on OCB custom builds.
+   For this workflow, refer to the developer guide in the Alloy repository: [Add OpenTelemetry components](https://github.com/grafana/alloy/blob/main/docs/developer/add-otel-component.md).
 
-## The scenarios
+> **Note:** Alloy also includes [custom components](https://grafana.com/docs/alloy/latest/get-started/components/custom-components/) through `declare` and `import` blocks.
+> That feature composes existing components in Alloy syntax.
+> It doesn't build a custom binary.
 
-| Scenario | What it teaches | Build method |
-| -------- | --------------- | ------------ |
-| [minimal-otel](minimal-otel/) | Build a collector with **only the OTel parts you need** (OTLP in, batch/memory_limiter, OTLP out) and compare its image size to full Alloy. | OCB |
+## Scenarios
 
-`minimal-otel` produces a **pure OpenTelemetry Collector** (Alloy's lineage), so it is configured with an OTel **YAML** file (`config.yaml`), not Alloy River syntax. The image versions in its `docker-compose.yml` are pinned to the values in the repo-root `image-versions.env`.
+| Scenario                      | Description                                                                                                                             | Build method |
+| ----------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- | ------------ |
+| [minimal-otel](minimal-otel/) | Build a collector with only the OpenTelemetry components you need for OTLP receive, batch and memory limit processing, and OTLP export. | OCB          |
 
-## Honest limitations (no hand-waving)
+## Known limits
 
-- There is **no build flag that slims the full Alloy (River) binary** to "only OTel." Alloy's `GO_TAGS` only toggle a few platform features (for example `netgo`, `embedalloyui`, `promtail_journal_enabled`). That is why `minimal-otel` uses OCB to produce a separate, minimal OTel Collector instead of a trimmed Alloy.
-- Alloy ships an in-process, OCB-generated OTel engine you can run with `alloy otel`, but it is currently **experimental**, so `minimal-otel` anchors on standalone OCB and only mentions the engine as the Alloy-native equivalent.
+- The `alloy otel` command is experimental.
+  Refer to the published [otel command reference](https://grafana.com/docs/alloy/latest/reference/cli/otel/).
+- Custom builds can include behavior outside standard maintenance scope.
+  Refer to [Grafana Alloy maintenance scope](https://grafana.com/docs/alloy/latest/reference/release-information/alloy-maintenance/).
+- `minimal-otel` uses standalone OpenTelemetry Collector build output and OpenTelemetry YAML configuration.

--- a/custom-builds/minimal-otel/Dockerfile
+++ b/custom-builds/minimal-otel/Dockerfile
@@ -1,0 +1,27 @@
+# Build a minimal OpenTelemetry Collector with the OpenTelemetry Collector
+# Builder (OCB), then package the single static binary into a tiny runtime image.
+#
+# OCB reads builder-config.yaml, generates the collector's main package with only
+# the listed components, and compiles it. Because we list just OTLP + batch +
+# memory_limiter + debug, the binary is a fraction of the size of full Alloy.
+
+ARG GO_VERSION=1.25
+FROM golang:${GO_VERSION} AS build
+
+# OCB version. Keep this in step with the otelcol_version in builder-config.yaml.
+ARG OCB_VERSION=v0.147.0
+
+# Static binary so it runs on a distroless/scratch base.
+ENV CGO_ENABLED=0
+
+WORKDIR /build
+COPY builder-config.yaml .
+
+# Generate and compile the distribution. Output binary: ./_build/minimal-otelcol
+RUN go run go.opentelemetry.io/collector/cmd/builder@${OCB_VERSION} --config builder-config.yaml
+
+# Minimal runtime: distroless static (no shell, no package manager).
+FROM gcr.io/distroless/static-debian12:nonroot
+COPY --from=build /build/_build/minimal-otelcol /minimal-otelcol
+ENTRYPOINT ["/minimal-otelcol"]
+CMD ["--config=/etc/otelcol/config.yaml"]

--- a/custom-builds/minimal-otel/README.md
+++ b/custom-builds/minimal-otel/README.md
@@ -1,30 +1,22 @@
-# Build only what you need (minimal OTel Collector)
+# Build only what you need with a minimal OpenTelemetry Collector
 
-Grafana Alloy is a distribution of the OpenTelemetry Collector. The full `grafana/alloy` image bundles every component Alloy ships — Prometheus pipelines, Loki pipelines, dozens of OTel components, the Alloy UI, and more. That's convenient, but if all you need is "receive OTLP, batch it, forward OTLP," you're shipping a lot of code you'll never run.
-
-This scenario shows how to build a collector that contains **only the parts you need**, using the [OpenTelemetry Collector Builder (OCB)](https://github.com/open-telemetry/opentelemetry-collector/tree/main/cmd/builder) — the same tool Alloy uses internally to generate its OTel engine.
-
-The payoff: the image in this scenario is about **41 MB**, versus **~670 MB** for full `grafana/alloy:v1.17.0`.
+This scenario shows how to build a minimal OpenTelemetry Collector image and run a traces pipeline end to end.
+You generate traces, process traces with memory and batch processors, and export traces to Tempo for exploration in Grafana.
+This scenario uses OpenTelemetry YAML in `config.yaml` and not [Alloy syntax](https://grafana.com/docs/alloy/latest/get-started/syntax/).
 
 ## Before you begin
 
 Ensure you have the following:
 
 - [Docker][docker] and [Docker Compose][docker-compose].
-- Ports 3000 for Grafana, 3200 for Tempo, and 4317/4318 for the minimal collector's OTLP receiver free on the host.
+- Ports `3000`, `3200`, `4317`, and `4318` free on your host.
 
 [docker]: https://docs.docker.com/get-docker/
 [docker-compose]: https://docs.docker.com/compose/install/
 
-## Why OCB and not "trim Alloy"
-
-There is no build flag that slims the full Alloy (River) binary down to "just the OTel parts" — Alloy's `GO_TAGS` only toggle a few platform features. The OTel-native way to get a minimal collector is OCB: you declare the components you want in a manifest, and OCB generates and compiles a collector with exactly those.
-
-Alloy does have an in-process, OCB-generated OTel engine you can run with `alloy otel`, but it is currently **experimental**, so this scenario uses standalone OCB. The result is a pure OpenTelemetry Collector — configured with an OTel **YAML** file, not Alloy River syntax.
-
 ## Understand the architecture
 
-telemetrygen emits OTLP traces to the minimal collector, which batches them and forwards them to Tempo. Grafana reads Tempo through its auto-provisioned datasource.
+Telemetry flows from the load generator to the custom collector and then to Tempo.
 
 ```text
 +--------------+   OTLP   +---------------+   OTLP   +-------+     +---------+
@@ -32,73 +24,155 @@ telemetrygen emits OTLP traces to the minimal collector, which batches them and 
 +--------------+          +---------------+          +-------+     +---------+
 ```
 
-- **minimal-otel** — the collector built from [`builder-config.yaml`](builder-config.yaml). Pipeline: OTLP receiver → `memory_limiter` → `batch` → OTLP exporter (to Tempo) + `debug`.
-- **Tempo** — stores the traces.
-- **Grafana** — views the traces. The Tempo datasource is auto-provisioned.
-- **telemetrygen** — the OpenTelemetry load generator, emits sample traces.
+- **minimal-otel:** Builds from `builder-config.yaml` and runs the pipeline in `config.yaml`.
+- **Tempo:** Stores traces and exposes search APIs.
+- **Grafana:** Auto provisions a Tempo data source and provides trace exploration.
+- **telemetrygen:** Sends sample traces with service name `minimal-demo`.
 
 ## Run the scenario
 
-From this directory:
+1. Clone the repository if you have not cloned it yet: `git clone https://github.com/grafana/alloy-scenarios.git`
 
-```sh
-docker compose up -d
-```
+2. Install the scenario with one of these options:
 
-The image versions in `docker-compose.yml` are pinned to the values in the repo-root `image-versions.env`. The first build runs OCB and compiles the collector, typically under a minute.
+   **Option 1: From the scenario directory**
+
+   Use default image tags in `docker-compose.yml`.
+
+   - Navigate to this scenario: `cd alloy-scenarios/custom-builds/minimal-otel`
+   - Deploy the scenario: `docker compose up -d`
+
+   **Option 2: From the repository root**
+
+   Use pinned image versions from `image-versions.env`.
+
+   - Deploy the scenario: `./run-example.sh custom-builds/minimal-otel`
+
+3. Confirm all containers are up: `cd alloy-scenarios/custom-builds/minimal-otel && docker compose ps`
+
+4. Check collector logs for active trace flow: `cd alloy-scenarios/custom-builds/minimal-otel && docker compose logs minimal-otel --tail=50`
 
 ## Explore the services
 
-- **Grafana** at [http://localhost:3000](http://localhost:3000). Anonymous access is enabled with the admin role, so you don't need to log in. Go to **Explore → Tempo** and run a **Search** for service name `minimal-demo`.
+Open Grafana at [http://localhost:3000](http://localhost:3000). Anonymous admin access is enabled, so you do not need to sign in.
 
-## Try it out
-
-- The collector logs each batch via the `debug` exporter:
-
-  ```text
-  info  Traces  {"otelcol.component.id": "debug", "otelcol.signal": "traces", "resource spans": 1, "spans": 2}
-  ```
-
-- Traces from service `minimal-demo` appear in Tempo. You can check from the CLI:
-
-  ```sh
-  curl -s "http://localhost:3200/api/search?tags=service.name%3Dminimal-demo&limit=3"
-  ```
-
-- See the size difference for yourself:
-
-  ```sh
-  docker images | grep -E "minimal-otel|grafana/alloy"
-  ```
-
-- Inspect exactly which components were compiled in:
-
-  ```sh
-  docker run --rm $(docker compose images -q minimal-otel) components
-  ```
+In Grafana, open **Explore**, choose **Tempo**, and search for service name `minimal-demo`.
 
 ## Understand the configuration
 
-[`Dockerfile`](Dockerfile) is a two-stage build:
+The scenario uses four configuration files in pipeline order.
 
-1. **build stage** (`golang:1.25` — OCB v0.147.0 requires Go ≥ 1.25): runs
-   `go run go.opentelemetry.io/collector/cmd/builder@<OCB_VERSION> --config builder-config.yaml`,
-   which generates the collector's `main` package and compiles a static binary.
-2. **runtime stage** (`distroless/static`): copies just the binary in.
+`config.yaml` defines an OpenTelemetry pipeline with:
 
-[`builder-config.yaml`](builder-config.yaml) is the manifest. To add a capability, add a `gomod` line under the right section and rebuild — for example, to also write metrics to Prometheus you'd add `go.opentelemetry.io/collector/exporter/otlphttpexporter` or a contrib exporter. Versions are pinned to the OpenTelemetry release that Alloy v1.17.0 ships (unstable `v0.147.0`, stable `v1.53.0`).
+- `otlp` receiver on `0.0.0.0:4317` and `0.0.0.0:4318`
+- `memory_limiter` and `batch` processors
+- `otlp` exporter to `tempo:4317`
+- `debug` exporter for local visibility
+
+`builder-config.yaml` is the OpenTelemetry Collector Builder manifest. It defines the distribution name, output path, and OpenTelemetry Collector version for the generated binary.
+
+This scenario manifest includes:
+
+- `receivers`: `otlpreceiver`
+- `processors`: `batchprocessor` and `memorylimiterprocessor`
+- `exporters`: `otlpexporter` and `debugexporter`
+- `providers`: `fileprovider` and `envprovider`
+
+It pins unstable modules to `v0.147.0` and stable config providers to `v1.53.0`.
+
+`Dockerfile` uses two stages:
+
+1. `build` stage: runs `go run go.opentelemetry.io/collector/cmd/builder@<OCB_VERSION> --config builder-config.yaml` in a Go image and produces the `minimal-otelcol` binary.
+2. `runtime` stage: copies only that binary into a distroless image and starts it with `--config=/etc/otelcol/config.yaml`.
+
+`tempo-config.yaml` configures a local Tempo instance with OTLP receivers and local block storage.
+
+## Try it out
+
+Use these checks to confirm data flow and inspect the custom build result.
+
+1. Query Tempo for traces from `minimal-demo`:
+
+   ```sh
+   curl -s "http://localhost:3200/api/search?tags=service.name%3Dminimal-demo&limit=3"
+   ```
+
+2. View debug exporter output in collector logs:
+
+	```sh
+	docker compose logs minimal-otel --tail=100
+	```
+
+	Example output:
+
+	```text
+	info  Traces  {"otelcol.component.id": "debug", "otelcol.signal": "traces", "resource spans": 1, "spans": 2}
+	```
+
+3. Compare image sizes:
+
+   Image size depends on version, platform, and base image.
+
+   ```sh
+   docker images | grep -E "minimal-otel|grafana/alloy"
+   ```
+
+4. List compiled components in the custom binary:
+
+   ```sh
+   docker run --rm $(docker compose images -q minimal-otel) components
+   ```
 
 ## Customize the scenario
 
-- **Different signals**: this manifest builds a traces pipeline, but the OTLP receiver and exporter handle metrics and logs too — add `metrics:` / `logs:` pipelines in [`config.yaml`](config.yaml).
-- **More components**: browse the [OpenTelemetry Collector](https://github.com/open-telemetry/opentelemetry-collector) and [collector-contrib](https://github.com/open-telemetry/opentelemetry-collector-contrib) repos, add the `gomod` to `builder-config.yaml`, and rebuild.
+Use these options to extend the scenario.
+
+- **Different signals:** Add `metrics` or `logs` pipelines to `config.yaml` when you need more than traces.
+- **More components:** Add a new `gomod` entry under the correct section in `builder-config.yaml`. For example, add `go.opentelemetry.io/collector/exporter/otlphttpexporter` when you need OTLP over HTTP export, or add a contrib exporter module when you need a non core backend.
+
+After changes, rebuild the image:
+
+```sh
+docker compose up -d --build
+```
+
+## Troubleshoot common problems
+
+Use these checks when startup or trace flow fails.
+
+### Resolve port conflicts
+
+Check whether another process uses required ports:
+
+```sh
+ss -ltnp | grep -E ":3000|:3200|:4317|:4318"
+```
+
+### Resolve missing traces in Grafana
+
+Check telemetrygen and collector logs:
+
+```sh
+docker compose ps telemetrygen minimal-otel tempo
+docker compose logs telemetrygen minimal-otel --tail=100
+```
+
+### Resolve build failures
+
+Rebuild without cache to inspect full builder output:
+
+```sh
+docker compose build --no-cache minimal-otel
+```
 
 ## Stop the scenario
 
-Run `docker compose down` from this directory.
+Run `docker compose down` from the `minimal-otel` directory.
 
 ## Next steps
 
-- [OpenTelemetry Collector Builder](https://github.com/open-telemetry/opentelemetry-collector/tree/main/cmd/builder): the tool this scenario uses to compile a minimal collector.
-- [Custom Alloy builds](../): the other build method, forking Alloy to add a Go component.
-- Grafana Alloy [custom components](https://grafana.com/docs/alloy/latest/get-started/components/custom-components/): the config-level `declare`/`import` feature, a different concept from the custom image this scenario builds.
+- [Custom Alloy builds](../)
+- [OpenTelemetry Collector Builder](https://github.com/open-telemetry/opentelemetry-collector/tree/main/cmd/builder)
+- [OpenTelemetry in Alloy](https://grafana.com/docs/alloy/latest/introduction/otel_alloy/)
+- [OpenTelemetry engine command reference](https://grafana.com/docs/alloy/latest/reference/cli/otel/)
+- [Custom components in Alloy](https://grafana.com/docs/alloy/latest/get-started/components/custom-components/)

--- a/custom-builds/minimal-otel/README.md
+++ b/custom-builds/minimal-otel/README.md
@@ -1,0 +1,74 @@
+# Build only what you need (minimal OTel Collector)
+
+Grafana Alloy is a distribution of the OpenTelemetry Collector. The full `grafana/alloy` image bundles every component Alloy ships — Prometheus pipelines, Loki pipelines, dozens of OTel components, the Alloy UI, and more. That's convenient, but if all you need is "receive OTLP, batch it, forward OTLP," you're shipping a lot of code you'll never run.
+
+This scenario shows how to build a collector that contains **only the parts you need**, using the [OpenTelemetry Collector Builder (OCB)](https://github.com/open-telemetry/opentelemetry-collector/tree/main/cmd/builder) — the same tool Alloy uses internally to generate its OTel engine.
+
+The payoff: the image in this scenario is about **41 MB**, versus **~670 MB** for full `grafana/alloy:v1.17.0`.
+
+## Why OCB and not "trim Alloy"
+
+There is no build flag that slims the full Alloy (River) binary down to "just the OTel parts" — Alloy's `GO_TAGS` only toggle a few platform features. The OTel-native way to get a minimal collector is OCB: you declare the components you want in a manifest, and OCB generates and compiles a collector with exactly those.
+
+Alloy does have an in-process, OCB-generated OTel engine you can run with `alloy otel`, but it is currently **experimental**, so this scenario uses standalone OCB. The result is a pure OpenTelemetry Collector — configured with an OTel **YAML** file, not Alloy River syntax.
+
+## Overview
+
+- **minimal-otel** — the collector built from [`builder-config.yaml`](builder-config.yaml). Pipeline: OTLP receiver → `memory_limiter` → `batch` → OTLP exporter (to Tempo) + `debug`.
+- **Tempo** — stores the traces.
+- **Grafana** — views the traces (Tempo datasource auto-provisioned).
+- **telemetrygen** — the OpenTelemetry load generator, emits sample traces.
+
+## Running the demo
+
+From this directory:
+
+```bash
+docker compose up -d
+```
+
+The image versions in `docker-compose.yml` are pinned to the values in the repo-root `image-versions.env`. The first build runs OCB and compiles the collector (typically under a minute — far quicker than the fork-based scenarios in this directory).
+
+Then open Grafana at [http://localhost:3000](http://localhost:3000), go to **Explore → Tempo**, and run a **Search** for service name `minimal-demo`.
+
+## What to expect
+
+- The collector logs each batch via the `debug` exporter:
+
+  ```
+  info  Traces  {"otelcol.component.id": "debug", "otelcol.signal": "traces", "resource spans": 1, "spans": 2}
+  ```
+
+- Traces from service `minimal-demo` appear in Tempo. You can confirm from the CLI:
+
+  ```bash
+  curl -s "http://localhost:3200/api/search?tags=service.name%3Dminimal-demo&limit=3"
+  ```
+
+- See the size difference for yourself:
+
+  ```bash
+  docker images | grep -E "minimal-otel|grafana/alloy"
+  ```
+
+- Inspect exactly which components were compiled in:
+
+  ```bash
+  docker run --rm $(docker compose images -q minimal-otel) components
+  ```
+
+## How the build works
+
+[`Dockerfile`](Dockerfile) is a two-stage build:
+
+1. **build stage** (`golang:1.25` — OCB v0.147.0 requires Go ≥ 1.25): runs
+   `go run go.opentelemetry.io/collector/cmd/builder@<OCB_VERSION> --config builder-config.yaml`,
+   which generates the collector's `main` package and compiles a static binary.
+2. **runtime stage** (`distroless/static`): copies just the binary in.
+
+[`builder-config.yaml`](builder-config.yaml) is the manifest. To add a capability, add a `gomod` line under the right section and rebuild — for example, to also write metrics to Prometheus you'd add `go.opentelemetry.io/collector/exporter/otlphttpexporter` or a contrib exporter. Versions are pinned to the OpenTelemetry release that Alloy v1.17.0 ships (unstable `v0.147.0`, stable `v1.53.0`).
+
+## Customizing
+
+- **Different signals**: this manifest builds a traces pipeline, but the OTLP receiver and exporter handle metrics and logs too — add `metrics:` / `logs:` pipelines in [`config.yaml`](config.yaml).
+- **More components**: browse the [OpenTelemetry Collector](https://github.com/open-telemetry/opentelemetry-collector) and [collector-contrib](https://github.com/open-telemetry/opentelemetry-collector-contrib) repos, add the `gomod` to `builder-config.yaml`, and rebuild.

--- a/custom-builds/minimal-otel/README.md
+++ b/custom-builds/minimal-otel/README.md
@@ -6,58 +6,78 @@ This scenario shows how to build a collector that contains **only the parts you 
 
 The payoff: the image in this scenario is about **41 MB**, versus **~670 MB** for full `grafana/alloy:v1.17.0`.
 
+## Before you begin
+
+Ensure you have the following:
+
+- [Docker][docker] and [Docker Compose][docker-compose].
+- Ports 3000 for Grafana, 3200 for Tempo, and 4317/4318 for the minimal collector's OTLP receiver free on the host.
+
+[docker]: https://docs.docker.com/get-docker/
+[docker-compose]: https://docs.docker.com/compose/install/
+
 ## Why OCB and not "trim Alloy"
 
 There is no build flag that slims the full Alloy (River) binary down to "just the OTel parts" — Alloy's `GO_TAGS` only toggle a few platform features. The OTel-native way to get a minimal collector is OCB: you declare the components you want in a manifest, and OCB generates and compiles a collector with exactly those.
 
 Alloy does have an in-process, OCB-generated OTel engine you can run with `alloy otel`, but it is currently **experimental**, so this scenario uses standalone OCB. The result is a pure OpenTelemetry Collector — configured with an OTel **YAML** file, not Alloy River syntax.
 
-## Overview
+## Understand the architecture
+
+telemetrygen emits OTLP traces to the minimal collector, which batches them and forwards them to Tempo. Grafana reads Tempo through its auto-provisioned datasource.
+
+```text
++--------------+   OTLP   +---------------+   OTLP   +-------+     +---------+
+| telemetrygen |--------->| minimal-otel  |--------->| Tempo |<----| Grafana |
++--------------+          +---------------+          +-------+     +---------+
+```
 
 - **minimal-otel** — the collector built from [`builder-config.yaml`](builder-config.yaml). Pipeline: OTLP receiver → `memory_limiter` → `batch` → OTLP exporter (to Tempo) + `debug`.
 - **Tempo** — stores the traces.
-- **Grafana** — views the traces (Tempo datasource auto-provisioned).
+- **Grafana** — views the traces. The Tempo datasource is auto-provisioned.
 - **telemetrygen** — the OpenTelemetry load generator, emits sample traces.
 
-## Running the demo
+## Run the scenario
 
 From this directory:
 
-```bash
+```sh
 docker compose up -d
 ```
 
-The image versions in `docker-compose.yml` are pinned to the values in the repo-root `image-versions.env`. The first build runs OCB and compiles the collector (typically under a minute — far quicker than the fork-based scenarios in this directory).
+The image versions in `docker-compose.yml` are pinned to the values in the repo-root `image-versions.env`. The first build runs OCB and compiles the collector, typically under a minute.
 
-Then open Grafana at [http://localhost:3000](http://localhost:3000), go to **Explore → Tempo**, and run a **Search** for service name `minimal-demo`.
+## Explore the services
 
-## What to expect
+- **Grafana** at [http://localhost:3000](http://localhost:3000). Anonymous access is enabled with the admin role, so you don't need to log in. Go to **Explore → Tempo** and run a **Search** for service name `minimal-demo`.
+
+## Try it out
 
 - The collector logs each batch via the `debug` exporter:
 
-  ```
+  ```text
   info  Traces  {"otelcol.component.id": "debug", "otelcol.signal": "traces", "resource spans": 1, "spans": 2}
   ```
 
-- Traces from service `minimal-demo` appear in Tempo. You can confirm from the CLI:
+- Traces from service `minimal-demo` appear in Tempo. You can check from the CLI:
 
-  ```bash
+  ```sh
   curl -s "http://localhost:3200/api/search?tags=service.name%3Dminimal-demo&limit=3"
   ```
 
 - See the size difference for yourself:
 
-  ```bash
+  ```sh
   docker images | grep -E "minimal-otel|grafana/alloy"
   ```
 
 - Inspect exactly which components were compiled in:
 
-  ```bash
+  ```sh
   docker run --rm $(docker compose images -q minimal-otel) components
   ```
 
-## How the build works
+## Understand the configuration
 
 [`Dockerfile`](Dockerfile) is a two-stage build:
 
@@ -68,7 +88,17 @@ Then open Grafana at [http://localhost:3000](http://localhost:3000), go to **Exp
 
 [`builder-config.yaml`](builder-config.yaml) is the manifest. To add a capability, add a `gomod` line under the right section and rebuild — for example, to also write metrics to Prometheus you'd add `go.opentelemetry.io/collector/exporter/otlphttpexporter` or a contrib exporter. Versions are pinned to the OpenTelemetry release that Alloy v1.17.0 ships (unstable `v0.147.0`, stable `v1.53.0`).
 
-## Customizing
+## Customize the scenario
 
 - **Different signals**: this manifest builds a traces pipeline, but the OTLP receiver and exporter handle metrics and logs too — add `metrics:` / `logs:` pipelines in [`config.yaml`](config.yaml).
 - **More components**: browse the [OpenTelemetry Collector](https://github.com/open-telemetry/opentelemetry-collector) and [collector-contrib](https://github.com/open-telemetry/opentelemetry-collector-contrib) repos, add the `gomod` to `builder-config.yaml`, and rebuild.
+
+## Stop the scenario
+
+Run `docker compose down` from this directory.
+
+## Next steps
+
+- [OpenTelemetry Collector Builder](https://github.com/open-telemetry/opentelemetry-collector/tree/main/cmd/builder): the tool this scenario uses to compile a minimal collector.
+- [Custom Alloy builds](../): the other build method, forking Alloy to add a Go component.
+- Grafana Alloy [custom components](https://grafana.com/docs/alloy/latest/get-started/components/custom-components/): the config-level `declare`/`import` feature, a different concept from the custom image this scenario builds.

--- a/custom-builds/minimal-otel/builder-config.yaml
+++ b/custom-builds/minimal-otel/builder-config.yaml
@@ -1,0 +1,34 @@
+# OpenTelemetry Collector Builder (OCB) manifest.
+#
+# This is the same kind of manifest Alloy uses internally to generate its OTel
+# engine (see collector/builder-config.yaml in the grafana/alloy repo). Here we
+# list ONLY the components a basic OTLP relay needs, so the resulting binary is
+# tiny compared to a full Alloy or a full collector-contrib distribution.
+#
+# Versions are pinned to the OpenTelemetry release that Grafana Alloy v1.17.0
+# ships (unstable modules v0.147.0, stable modules v1.53.0), so this minimal
+# build stays in lock-step with the rest of the repository.
+
+dist:
+  name: minimal-otelcol
+  description: Minimal OpenTelemetry Collector - OTLP in, batch + memory_limiter, OTLP/debug out
+  output_path: ./_build
+  version: 0.1.0
+  otelcol_version: 0.147.0
+
+receivers:
+  - gomod: go.opentelemetry.io/collector/receiver/otlpreceiver v0.147.0
+
+processors:
+  - gomod: go.opentelemetry.io/collector/processor/batchprocessor v0.147.0
+  - gomod: go.opentelemetry.io/collector/processor/memorylimiterprocessor v0.147.0
+
+exporters:
+  - gomod: go.opentelemetry.io/collector/exporter/otlpexporter v0.147.0
+  - gomod: go.opentelemetry.io/collector/exporter/debugexporter v0.147.0
+
+# Config providers. Even a minimal collector needs at least the file provider to
+# read its config; env lets you template values from environment variables.
+providers:
+  - gomod: go.opentelemetry.io/collector/confmap/provider/fileprovider v1.53.0
+  - gomod: go.opentelemetry.io/collector/confmap/provider/envprovider v1.53.0

--- a/custom-builds/minimal-otel/config.yaml
+++ b/custom-builds/minimal-otel/config.yaml
@@ -1,0 +1,38 @@
+# Standard OpenTelemetry Collector configuration (YAML, not Alloy River) - this
+# is a pure collector built with OCB, so it is configured the OTel-native way.
+#
+# Pipeline: receive OTLP -> protect memory -> batch -> forward OTLP to Tempo
+# (and log a sample to stdout via the debug exporter).
+
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+
+processors:
+  memory_limiter:
+    check_interval: 1s
+    limit_percentage: 80
+    spike_limit_percentage: 25
+  batch: {}
+
+exporters:
+  otlp:
+    endpoint: tempo:4317
+    tls:
+      insecure: true
+  debug:
+    verbosity: basic
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [memory_limiter, batch]
+      exporters: [otlp, debug]
+  telemetry:
+    logs:
+      level: info

--- a/custom-builds/minimal-otel/docker-compose.yml
+++ b/custom-builds/minimal-otel/docker-compose.yml
@@ -16,7 +16,7 @@ services:
 
   # Tempo stores the traces the collector forwards.
   tempo:
-    image: grafana/tempo:${GRAFANA_TEMPO_VERSION:-2.10.4}
+    image: grafana/tempo:${GRAFANA_TEMPO_VERSION:-2.10.7}
     command: ["-config.file=/etc/tempo.yaml"]
     ports:
       - 3200:3200/tcp

--- a/custom-builds/minimal-otel/docker-compose.yml
+++ b/custom-builds/minimal-otel/docker-compose.yml
@@ -1,0 +1,69 @@
+services:
+  # The minimal collector, built from builder-config.yaml with OCB.
+  minimal-otel:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        - OCB_VERSION=${OCB_VERSION:-v0.147.0}
+    ports:
+      - 4317:4317        # OTLP gRPC
+      - 4318:4318        # OTLP HTTP
+    volumes:
+      - ./config.yaml:/etc/otelcol/config.yaml
+    depends_on:
+      - tempo
+
+  # Tempo stores the traces the collector forwards.
+  tempo:
+    image: grafana/tempo:${GRAFANA_TEMPO_VERSION:-2.10.4}
+    command: ["-config.file=/etc/tempo.yaml"]
+    ports:
+      - 3200:3200/tcp
+    volumes:
+      - ./tempo-config.yaml:/etc/tempo.yaml
+
+  # Grafana to view the traces.
+  grafana:
+    image: grafana/grafana:${GRAFANA_VERSION:-13.0.2}
+    environment:
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_BASIC_ENABLED=false
+    ports:
+      - 3000:3000/tcp
+    entrypoint:
+      - sh
+      - -euc
+      - |
+        mkdir -p /etc/grafana/provisioning/datasources
+        cat <<EOF > /etc/grafana/provisioning/datasources/ds.yaml
+        apiVersion: 1
+        datasources:
+        - name: Tempo
+          type: tempo
+          access: proxy
+          orgId: 1
+          url: http://tempo:3200
+          basicAuth: false
+          isDefault: true
+          version: 1
+          editable: false
+        EOF
+        /run.sh
+    depends_on:
+      - tempo
+
+  # Generates OTLP traces so there is something to look at. telemetrygen is the
+  # OpenTelemetry project's load generator.
+  telemetrygen:
+    image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:${TELEMETRYGEN_VERSION:-v0.147.0}
+    command:
+      - traces
+      - --otlp-endpoint=minimal-otel:4317
+      - --otlp-insecure
+      - --rate=2
+      - --duration=3600s
+      - --service=minimal-demo
+    depends_on:
+      - minimal-otel

--- a/custom-builds/minimal-otel/tempo-config.yaml
+++ b/custom-builds/minimal-otel/tempo-config.yaml
@@ -1,0 +1,30 @@
+# Minimal single-binary Tempo for local trace storage. Receives OTLP from the
+# minimal collector and stores blocks on local disk. Not production config.
+stream_over_http_enabled: true
+server:
+  http_listen_port: 3200
+  log_level: info
+
+distributor:
+  receivers:
+    otlp:
+      protocols:
+        grpc:
+          endpoint: "tempo:4317"
+        http:
+          endpoint: "tempo:4318"
+
+ingester:
+  max_block_duration: 5m               # cut the headblock quickly so traces appear fast
+
+compactor:
+  compaction:
+    block_retention: 1h                # short retention for a demo
+
+storage:
+  trace:
+    backend: local
+    wal:
+      path: /var/tempo/wal
+    local:
+      path: /var/tempo/blocks

--- a/image-versions.env
+++ b/image-versions.env
@@ -52,10 +52,6 @@ RABBITMQ_PERF_TEST_VERSION=2.24.0
 # renovate: datasource=docker depName=hashicorp/vault
 VAULT_VERSION=2.0.2
 
-# cloudwatch-metrics scenario
-# renovate: datasource=docker depName=localstack/localstack
-LOCALSTACK_VERSION=4.14.0
-
 # custom-builds scenarios
 # renovate: datasource=docker depName=ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen
 TELEMETRYGEN_VERSION=v0.147.0
@@ -63,3 +59,15 @@ TELEMETRYGEN_VERSION=v0.147.0
 # OCB builds the minimal-otel collector; keep in step with the OpenTelemetry release
 # Alloy ships (see GRAFANA_ALLOY_VERSION above).
 OCB_VERSION=v0.147.0
+
+# cloudwatch-metrics scenario
+# renovate: datasource=docker depName=localstack/localstack
+LOCALSTACK_VERSION=4.14.0
+
+# snmp scenario (base image for the locally-built snmpd target)
+# renovate: datasource=docker depName=debian
+DEBIAN_VERSION=bookworm-slim
+
+# promtail-to-alloy-migration scenario
+# renovate: datasource=docker depName=grafana/promtail
+PROMTAIL_VERSION=3.6.11

--- a/image-versions.env
+++ b/image-versions.env
@@ -55,3 +55,11 @@ VAULT_VERSION=2.0.2
 # cloudwatch-metrics scenario
 # renovate: datasource=docker depName=localstack/localstack
 LOCALSTACK_VERSION=4.14.0
+
+# custom-builds scenarios
+# renovate: datasource=docker depName=ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen
+TELEMETRYGEN_VERSION=v0.147.0
+# custom-builds: build-time version (NOT a docker image, so no renovate datasource).
+# OCB builds the minimal-otel collector; keep in step with the OpenTelemetry release
+# Alloy ships (see GRAFANA_ALLOY_VERSION above).
+OCB_VERSION=v0.147.0


### PR DESCRIPTION
## What

Adds a new top-level `custom-builds/` directory for building **tailored Alloy / OpenTelemetry Collector images**. The first scenario, [`minimal-otel`](custom-builds/minimal-otel/), uses the [OpenTelemetry Collector Builder (OCB)](https://github.com/open-telemetry/opentelemetry-collector/tree/main/cmd/builder) — the same tool Alloy uses internally to generate its OTel engine — to build a collector containing **only the parts you need**:

- Pipeline: OTLP receiver → `memory_limiter` + `batch` → OTLP exporter (to Tempo) + `debug`.
- Result: a **~41 MB** image versus **~670 MB** for full `grafana/alloy:v1.17.0`.

The top-level README also documents the broader "custom builds" model — there's no runtime plugin loader, so anything custom is compiled in (OCB for minimal builds; fork + `make alloy` for adding new Go components) — and clarifies the naming distinction from Alloy's config-level [`declare`/`import` "custom components"](https://grafana.com/docs/alloy/latest/get-started/components/custom-components/) feature.

## Verification

Built and run end to end locally: OCB build succeeds (Go 1.25), the image is ~41 MB, and traces flow OTLP → minimal collector → Tempo (visible in Grafana Explore and via the Tempo search API).

## Notes for reviewers

- Like `otel-examples/`, this is nested under a grouping directory (not in `.github/scenario-list.txt`), so `validate-scenarios` skips it. It uses plain `docker compose up -d`, pinned via the compose `${VAR:-default}` defaults (kept in lockstep with `image-versions.env`).
- `image-versions.env` gains `TELEMETRYGEN_VERSION` (renovate-tracked image) and the build-time `OCB_VERSION` (not an image).

## Scope

Started as three scenarios (minimal build + a custom receiver + a custom exporter). Trimmed to just `minimal-otel` for now; the fork-based input/output examples will come later with a stronger design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)