### PR TITLE
docs: Update scenario README files otel-basic-tracing to otel-tracing-service-graphs

### DIFF
--- a/otel-basic-tracing/README.md
+++ b/otel-basic-tracing/README.md
@@ -1,89 +1,144 @@
-# OpenTelemetry Basic Tracing with Grafana Alloy
+# OpenTelemetry basic tracing
 
-This example demonstrates how to collect and visualize OpenTelemetry traces using Grafana Alloy and Tempo.
+This scenario shows how to collect and visualize OpenTelemetry traces with Grafana Alloy and Tempo.
+A Python Flask demo app generates traces with the OpenTelemetry SDK and sends them to Alloy over OTLP.
+Alloy batches spans and forwards them to Tempo, which generates service-graph and span metrics and remote-writes them to Prometheus for visualization in Grafana.
 
-## Overview
+## Before you begin
 
-The example includes:
+Ensure you have the following:
 
-- A sample Python Flask application that generates various types of traces
-- Grafana Alloy as the telemetry pipeline
-- Tempo for trace storage and querying
-- Prometheus for metrics collection (service graphs)
-- Grafana for visualization
+- [Docker][docker] and [Docker Compose][docker-compose].
+- Ports 8080 for the demo app, 3000 for Grafana, 3200 for Tempo, 9090 for Prometheus, and 12345 for the Alloy UI free on the host.
 
-## Running the Demo
+[docker]: https://docs.docker.com/get-docker/
+[docker-compose]: https://docs.docker.com/compose/install/
 
-1. Clone the repository:
-   ```
-   git clone https://github.com/grafana/alloy-scenarios.git
-   cd alloy-scenarios
-   ```
+## Understand the architecture
 
-2. Navigate to this example directory:
-   ```
-   cd otel-basic-tracing
-   ```
-
-3. Run using Docker Compose:
-   ```
-   docker compose up -d
-   ```
-   
-   Or use the centralized image management:
-   ```
-   cd ..
-   ./run-example.sh otel-basic-tracing
-   ```
-
-4. Access the demo application at http://localhost:8080
-5. Access Grafana at http://localhost:3000
-6. Access Prometheus at http://localhost:9090
-
-## What to Expect
-
-The demo application provides several endpoints that generate different types of traces:
-
-- **/simple**: Generates a simple trace with a single span
-- **/nested**: Generates a trace with nested spans (parent-child relationships)
-- **/error**: Generates a trace that includes an error
-- **/chain**: Simulates a chain of service calls to demonstrate distributed tracing
-
-After accessing these endpoints, you can view the traces in Grafana by:
-
-1. Opening http://localhost:3000
-2. Navigating to Explore
-3. Selecting the Tempo data source
-4. Using the Search tab to find and visualize traces
-
-## Service Graphs
-
-This example includes service graph visualization capabilities. As you generate traces with the demo app (especially with the `/chain` endpoint), Tempo will generate service graph metrics that are sent to Prometheus.
-
-To view the service graph:
-
-1. Open Grafana (http://localhost:3000)
-2. Navigate to Explore
-3. Select the Tempo data source
-4. Click on the "Service Graph" tab
-5. You should see a visual representation of the relationships between services
-
-## Architecture
-
-```
-┌────────────┐     ┌──────────┐      ┌───────┐      ┌─────────┐
-│ Demo App   │────▶│ Alloy    │─────▶│ Tempo │─────▶│ Grafana │
-│ (OTel SDK) │     │          │      │       │      │         │
-└────────────┘     └──────────┘      └───┬───┘      └─────────┘
-                                         │                ▲
-                                         ▼                │
-                                    ┌─────────┐           │
-                                    │Prometheus│───────────┘
-                                    └─────────┘
+```text
++------------------+       +-------+       +-------+         +---------+
+| demo-app         |       |       |       |       |         |         |
+| Flask + OTel SDK |------>| Alloy |------>| Tempo |-------->| Grafana |
+|                  | OTLP  |       | OTLP  |       |         |         |
++------------------+       +-------+       +---+---+         +---------+
+                                               | service graph    ^
+                                               v and span metrics |
+                                          +------------+          |
+                                          | Prometheus |----------+
+                                          +------------+
 ```
 
-The Demo App generates traces using the OpenTelemetry SDK and sends them to Alloy, which processes and forwards them to Tempo. Tempo generates service graph metrics and sends them to Prometheus. Grafana queries both Tempo and Prometheus to visualize traces and service graphs.
+- **demo-app**: Flask app on port 8080 that creates spans with the OpenTelemetry SDK and exports them to Alloy at `alloy:4317` over gRPC.
+- **Alloy**: Receives OTLP traces, batches them, and forwards them to Tempo.
+- **Tempo**: Stores traces and runs the metrics generator with service-graph, span-metrics, and local-blocks processors. Uses Memcached as a query cache.
+- **Prometheus**: Stores the metrics Tempo generates for service graphs and RED metrics.
+- **Grafana**: Explores traces through the provisioned Tempo data source and service graphs through Prometheus.
 
-## Customizing
+## Run the scenario
 
-The Alloy configuration is a simple placeholder. You can modify `config.alloy` to add processors, filters, or additional exporters to demonstrate more complex telemetry pipelines. 
+1. Clone the repository if you haven't already: `git clone https://github.com/grafana/alloy-scenarios.git`
+
+2. Install the scenario with one of these options:
+
+   **Option 1: From the scenario directory**
+
+   Use the default image tags in `docker-compose.yml`.
+
+   - Navigate to this scenario: `cd alloy-scenarios/otel-basic-tracing`
+   - Build and deploy the scenario: `docker compose up --build -d`
+
+   **Option 2: From the repository root**
+
+   Use pinned image versions from `image-versions.env` for Grafana, Tempo, Prometheus, and Alloy.
+
+   - Deploy the scenario: `./run-example.sh otel-basic-tracing`
+
+3. From the `otel-basic-tracing` directory, check that all containers are up: `docker compose ps`
+
+   You should see `demo-app`, `alloy`, `tempo`, `prometheus`, `memcached`, and `grafana`.
+
+## Explore the services
+
+- **Demo app** at http://localhost:8080: Home page with links to trace-generating endpoints.
+- **Grafana** at http://localhost:3000: **Explore** and the **Traces Drilldown** app, with no login required. Open **Traces Drilldown** at http://localhost:3000/a/grafana-exploretraces-app.
+- **Alloy UI** at http://localhost:12345: Pipeline graph and component health.
+- **Tempo** at http://localhost:3200: Trace storage backend.
+- **Prometheus** at http://localhost:9090: Stores service-graph and span metrics from Tempo.
+
+## Understand the Alloy pipeline
+
+The `config.alloy` pipeline has three components:
+
+1. **`otelcol.receiver.otlp.default`**: Listens for OTLP traces over gRPC and HTTP, then forwards spans to the batch processor.
+2. **`otelcol.processor.batch.default`**: Groups spans to reduce export requests, then forwards them to the Tempo exporter.
+3. **`otelcol.exporter.otlp.tempo`**: Sends spans to Tempo at `tempo:4317` with TLS disabled for the local demo.
+
+The `tempo-config.yaml` file enables the metrics generator with `service-graphs`, `span-metrics`, and `local-blocks` processors.
+Tempo remote-writes the generated metrics to Prometheus, which powers the service graph and request, error, and duration views in Grafana.
+
+## Try it out
+
+1. Open the demo app at http://localhost:8080 and call these endpoints to generate traces:
+
+   - `/simple`: A single-span trace
+   - `/nested`: Parent and child spans with a grandchild span
+   - `/error`: A trace that records an exception
+   - `/chain`: A chain of HTTP calls through simulated services B and C
+   - `/delayed-chain`: A longer chain where service D adds high latency
+
+2. Open Grafana at http://localhost:3000, go to **Explore**, select the **Tempo** data source, and open the **Search** tab.
+   Run these TraceQL queries:
+
+   - `{resource.service.name="trace-demo"}`: Traces from the demo app
+   - `{status=error}`: Traces that include an error status
+   - `{name="chain-root"}`: Traces from the `/chain` endpoint
+
+3. To view the service graph, select the **Tempo** data source in **Explore** and open the **Service Graph** tab.
+   Generate traffic with `/chain` or `/delayed-chain` first so Tempo has enough spans to build the graph.
+
+4. To inspect the Alloy pipeline, open the Alloy UI at http://localhost:12345 and select `otelcol.receiver.otlp.default`, `otelcol.processor.batch.default`, or `otelcol.exporter.otlp.tempo` from the component graph.
+
+## Customize the scenario
+
+- **Add processors or exporters**: Edit `config.alloy` to add sampling, attribute filtering, or additional exporters.
+- **Use the OTel Engine**: Run `docker compose -f docker-compose.yml -f docker-compose-otel.yml up -d` to load the equivalent pipeline from `config-otel.yaml` instead of River syntax.
+- **Change trace retention**: Edit `compactor.compaction.block_retention` in `tempo-config.yaml`.
+
+## Troubleshoot common problems
+
+Diagnose container startup failures, missing traces, an empty service graph, and port conflicts.
+
+### Containers didn't start or exited unexpectedly
+
+Run `docker compose ps` to check the status of each container.
+If any container has exited, run `docker compose logs <SERVICE_NAME>` to read the failure reason.
+Replace `<SERVICE_NAME>` with the name of the service that exited, such as `demo-app`, `alloy`, or `tempo`.
+For Alloy specifically, the most common cause is a syntax error in `config.alloy`.
+
+### No traces appear in Grafana after a few minutes
+
+Open the demo app at http://localhost:8080 and call `/simple` to generate a trace.
+Open the Alloy UI at http://localhost:12345 and check that `otelcol.receiver.otlp.default` and `otelcol.exporter.otlp.tempo` show a healthy status.
+In Grafana, select the **Tempo** data source in **Explore** and search for `{resource.service.name="trace-demo"}`.
+
+### Service graph is empty
+
+The service graph needs multiple spans across related operations.
+Call `/chain` or `/delayed-chain` several times, wait about a minute for Tempo to generate metrics, then open the **Service Graph** tab on the **Tempo** data source.
+
+### Port conflicts with other services
+
+Ports 8080 for the demo app, 3000 for Grafana, 3200 for Tempo, 9090 for Prometheus, and 12345 for Alloy must be free before you start the stack.
+If another service uses one of these ports, edit the port mapping in `docker-compose.yml` for the conflicting service before you run `docker compose up -d`.
+
+## Stop the scenario
+
+Run `docker compose down` from the `otel-basic-tracing` directory.
+
+## Next steps
+
+- Alloy components: https://grafana.com/docs/alloy/latest/reference/components/
+- `otelcol.receiver.otlp` reference: https://grafana.com/docs/alloy/latest/reference/components/otelcol/otelcol.receiver.otlp/
+- Tempo metrics generator: https://grafana.com/docs/tempo/latest/metrics-generator/
+- More examples: https://github.com/grafana/alloy-scenarios

--- a/otel-loadbalancing/README.md
+++ b/otel-loadbalancing/README.md
@@ -1,73 +1,164 @@
-# OpenTelemetry Trace-Aware Load Balancing with Grafana Alloy
+# OpenTelemetry trace-aware load balancing
 
-Tail sampling only works if a single instance sees *every* span of a trace — and a single instance is exactly what you don't want in a highly-available sampling tier. This scenario shows the standard answer: a load-balancer Alloy in front that shards traffic across two tail-sampling Alloys **by trace ID** with [`otelcol.exporter.loadbalancing`](https://grafana.com/docs/alloy/latest/reference/components/otelcol/otelcol.exporter.loadbalancing/).
+Tail sampling only works if a single instance sees every span of a trace — and a single instance is exactly what you don't want in a highly available sampling tier.
+This scenario shows the standard answer: a load-balancer Alloy in front that shards traffic across two tail-sampling Alloys by trace ID with [`otelcol.exporter.loadbalancing`](https://grafana.com/docs/alloy/latest/reference/components/otelcol/otelcol.exporter.loadbalancing/).
 
-```
-                                       ┌──> alloy-downstream-1 ──┐
-trace-generator ──OTLP──> alloy-lb ────┤    (tail sampling)      ├──> Tempo ──> Grafana
-                       routing_key =   └──> alloy-downstream-2 ──┘
-                         "traceID"          (tail sampling)
-```
+The generator makes the problem real: it exports every span in its own OTLP request.
+A round-robin balancer would scatter the four spans of each trace across both downstreams, and tail sampling would make contradictory half-trace decisions.
+`routing_key = "traceID"` reassembles the stream so each downstream sees whole traces.
 
-The generator makes the problem real: it exports **every span in its own OTLP request**. A round-robin balancer would scatter the four spans of each trace across both downstreams, and tail sampling would make contradictory half-trace decisions. `routing_key = "traceID"` reassembles the stream so each downstream sees whole traces.
+## Before you begin
 
-## Prerequisites
+Ensure you have the following:
 
-- Docker and Docker Compose installed
+- [Docker][docker] and [Docker Compose][docker-compose].
+- Ports 3000 for Grafana, 3200 for Tempo, 9090 for Prometheus, 12345 for the load-balancer Alloy UI, 12346 and 12347 for the downstream Alloy UIs, and 4317 and 4318 for OTLP on the load-balancer tier free on the host.
 
-## Getting Started
+[docker]: https://docs.docker.com/get-docker/
+[docker-compose]: https://docs.docker.com/compose/install/
 
-```bash
-git clone https://github.com/grafana/alloy-scenarios.git
-cd alloy-scenarios/otel-loadbalancing
-docker compose up -d --build
-```
+## Understand the architecture
 
-## Access Points
-
-| Service              | URL                    |
-|----------------------|------------------------|
-| Grafana              | http://localhost:3000  |
-| Alloy UI (LB tier)   | http://localhost:12345 |
-| Alloy UI (downstream 1) | http://localhost:12346 |
-| Alloy UI (downstream 2) | http://localhost:12347 |
-| Prometheus           | http://localhost:9090  |
-| Tempo                | http://localhost:3200  |
-
-## What to Expect
-
-The generator emits one `checkout` trace per second with exactly four spans. ~15% carry an error and ~18% are slower than 2 seconds; the downstream tail samplers keep only those (policies: `status_code` + `latency` — deliberately no probabilistic fallback, so every sampling decision is explainable).
-
-**See the split.** In Grafana **Explore → Prometheus**:
-
-```promql
-sum by (instance) (rate(otelcol_receiver_accepted_spans_total{job="alloy-downstream"}[2m]))
+```text
++------------------+       +----------+       +---------------------+       +-------+       +---------+
+| trace-generator  | OTLP  | alloy-lb |------>| alloy-downstream-1  |------>|       |       |         |
+| 1 trace / sec    |------>| traceID  |       | tail sampling       |       | Tempo |------>| Grafana |
+| 4 spans / trace  |       | routing  |------>| alloy-downstream-2  |------>|       |       |         |
++------------------+       +----------+       +---------------------+       +-------+       +---------+
 ```
 
-Both downstream instances receive a steady share of spans — that's the load balancer distributing traces.
+- **trace-generator**: Emits one `checkout` trace per second with exactly four spans and exports each span in its own OTLP request to `alloy-lb:4317`.
+- **alloy-lb**: Receives OTLP traces and forwards them with `otelcol.exporter.loadbalancing` using `routing_key = "traceID"` and a static resolver for the two downstream hosts.
+- **alloy-downstream-1** and **alloy-downstream-2**: Identical tail-sampling tiers that keep error traces and traces slower than 2 seconds, then forward sampled spans to Tempo.
+- **Tempo**: Shared trace backend for both downstream instances.
+- **Prometheus**: Scrapes all three Alloy instances so you can compare span rates per downstream.
+- **Grafana**: Queries Tempo for traces and Prometheus for Alloy metrics.
 
-**See the affinity.** In **Explore → Tempo**, search for traces of service `trace-generator` and open any of them: every sampled trace has all **4/4 spans**. Because each span travelled in its own OTLP request and the sampling policies are deterministic, a complete trace is only possible if the load balancer routed all of its spans to the same downstream instance.
+## Run the scenario
 
-**See the sampling.** Compare span rates entering the downstream tier with spans leaving it for Tempo:
+1. Clone the repository if you haven't already: `git clone https://github.com/grafana/alloy-scenarios.git`
 
-```promql
-sum(rate(otelcol_receiver_accepted_spans_total{job="alloy-downstream"}[2m]))
-```
+2. Install the scenario with one of these options:
 
-```promql
-sum(rate(otelcol_exporter_sent_spans_total{job="alloy-downstream"}[2m]))
-```
+   **Option 1: From the scenario directory**
 
-The gap is the healthy, fast traffic tail sampling dropped.
+   Use the default image tags in `docker-compose.yml`.
 
-## Scaling the Pattern
+   - Navigate to this scenario: `cd alloy-scenarios/otel-loadbalancing`
+   - Build and deploy the scenario: `docker compose up -d --build`
 
-* Add a third downstream: one more compose service plus one more hostname in `config-lb.alloy`'s `resolver.static.hostnames` — the consistent hash redistributes automatically.
-* On Kubernetes, swap the `static` resolver for the `dns` or `k8s` resolver so the downstream set tracks a headless Service or pod selector.
-* `routing_key = "service"` groups by service name instead — useful in front of `otelcol.connector.spanmetrics` rather than tail sampling.
+   **Option 2: From the repository root**
 
-## Stopping the Scenario
+   Use pinned image versions from `image-versions.env` for Grafana, Tempo, Prometheus, and Alloy.
 
-```bash
-docker compose down
-```
+   - Deploy the scenario: `./run-example.sh otel-loadbalancing`
+
+3. From the `otel-loadbalancing` directory, check that all containers are up: `docker compose ps`
+
+   You should see `trace-generator`, `alloy-lb`, `alloy-downstream-1`, `alloy-downstream-2`, `tempo`, `prometheus`, and `grafana`.
+
+## Explore the services
+
+- **Grafana** at http://localhost:3000: **Explore** with Tempo and Prometheus data sources, with no login required.
+- **Alloy UI, load-balancer tier** at http://localhost:12345: Pipeline for `config-lb.alloy`.
+- **Alloy UI, downstream 1** at http://localhost:12346: Tail-sampling pipeline for `config-downstream.alloy`.
+- **Alloy UI, downstream 2** at http://localhost:12347: Same downstream pipeline on the second instance.
+- **Prometheus** at http://localhost:9090: Alloy self-metrics scraped from each instance.
+- **Tempo** at http://localhost:3200: Trace storage backend.
+
+## Understand the Alloy pipeline
+
+This scenario uses two Alloy configurations.
+
+### Load-balancer tier
+
+`config-lb.alloy` defines:
+
+1. **`otelcol.receiver.otlp.default`**: Receives OTLP traces over gRPC and HTTP on the load-balancer tier.
+2. **`otelcol.exporter.loadbalancing.default`**: Routes spans to `alloy-downstream-1:4317` or `alloy-downstream-2:4317` using consistent hashing on `routing_key = "traceID"`.
+
+### Downstream tier
+
+Both downstream instances run `config-downstream.alloy`:
+
+1. **`otelcol.receiver.otlp.default`**: Receives the trace shard from the load balancer.
+2. **`otelcol.processor.tail_sampling.default`**: Buffers spans for `decision_wait = "5s"`, then keeps traces with an error status or end-to-end latency above 2000 ms. There is no probabilistic fallback, so every sampling decision is explainable.
+3. **`otelcol.processor.batch.default`**: Batches sampled spans before export.
+4. **`otelcol.exporter.otlp.tempo`**: Sends kept traces to Tempo at `tempo:4317`.
+
+`livedebugging` is enabled on both tiers.
+
+The generator emits about 15% error traces and about 18% slow traces among the remainder.
+Healthy fast traces are dropped by tail sampling.
+
+## Try it out
+
+The generator emits one `checkout` trace per second with exactly four spans: `checkout`, `auth`, `inventory`, and `payment`.
+
+1. Open Grafana at http://localhost:3000 and go to **Explore**.
+
+   Select the **Prometheus** data source and run these PromQL queries:
+
+   - `sum by (instance) (rate(otelcol_receiver_accepted_spans_total{job="alloy-downstream"}[2m]))`: Span intake split across downstream instances
+   - `sum(rate(otelcol_receiver_accepted_spans_total{job="alloy-downstream"}[2m]))`: Total spans entering the downstream tier
+   - `sum(rate(otelcol_exporter_sent_spans_total{job="alloy-downstream"}[2m]))`: Spans tail sampling forwarded to Tempo
+
+   Both downstream instances should receive a steady share of spans.
+   The gap between received and sent span rates is the healthy fast traffic tail sampling dropped.
+
+2. Select the **Tempo** data source in **Explore** and open the **Search** tab.
+
+   - `{resource.service.name="trace-generator"}`: Traces from the generator
+   - `{status=error}`: Error traces kept by the status-code policy
+
+   Open any sampled trace and check that it contains all four spans.
+   Because each span travels in its own OTLP request and the sampling policies are deterministic, a complete trace in Tempo means the load balancer routed all of its spans to the same downstream instance.
+
+3. To inspect the pipelines, open the Alloy UIs at http://localhost:12345, http://localhost:12346, and http://localhost:12347.
+   Select components such as `otelcol.exporter.loadbalancing.default` or `otelcol.processor.tail_sampling.default` to use live debug.
+
+## Customize the scenario
+
+- **Add a third downstream**: Add another compose service and append its hostname to `resolver.static.hostnames` in `config-lb.alloy`. The consistent hash redistributes automatically.
+- **Use Kubernetes service discovery**: Replace the `static` resolver with the `dns` or `k8s` resolver so the downstream set tracks a headless Service or pod selector.
+- **Route by service name**: Set `routing_key = "service"` to group spans by service name instead of trace ID. That pattern is useful in front of `otelcol.connector.spanmetrics` rather than tail sampling.
+- **Adjust sampling policies**: Edit `otelcol.processor.tail_sampling.default` in `config-downstream.alloy`.
+
+## Troubleshoot common problems
+
+Diagnose container startup failures, uneven downstream load, incomplete traces, and port conflicts.
+
+### Containers didn't start or exited unexpectedly
+
+Run `docker compose ps` to check the status of each container.
+If any container has exited, run `docker compose logs <SERVICE_NAME>` to read the failure reason.
+Replace `<SERVICE_NAME>` with the name of the service that exited, such as `trace-generator`, `alloy-lb`, or `alloy-downstream-1`.
+For Alloy specifically, the most common cause is a syntax error in `config-lb.alloy` or `config-downstream.alloy`.
+
+### Downstream span rates look uneven or zero
+
+Open the Alloy UI at http://localhost:12345 and check that `otelcol.exporter.loadbalancing.default` is healthy.
+Check that `trace-generator` is running and sending to `alloy-lb:4317`.
+In Grafana, run `sum by (instance) (rate(otelcol_receiver_accepted_spans_total{job="alloy-downstream"}[2m]))` on the **Prometheus** data source.
+
+### Sampled traces in Tempo are missing spans
+
+This usually means spans from one trace reached different downstream instances.
+Check that `routing_key = "traceID"` is set in `config-lb.alloy` and that both downstream hostnames in the static resolver are reachable.
+Open a trace in Tempo and check whether it has fewer than four spans.
+
+### Port conflicts with other services
+
+Ports 3000, 3200, 9090, 12345, 12346, 12347, 4317, and 4318 must be free before you start the stack.
+If another service uses one of these ports, edit the port mapping in `docker-compose.yml` for the conflicting service before you run `docker compose up -d --build`.
+
+## Stop the scenario
+
+Run `docker compose down` from the `otel-loadbalancing` directory.
+
+## Next steps
+
+- `otelcol.exporter.loadbalancing` reference: https://grafana.com/docs/alloy/latest/reference/components/otelcol/otelcol.exporter.loadbalancing/
+- `otelcol.processor.tail_sampling` reference: https://grafana.com/docs/alloy/latest/reference/components/otelcol/otelcol.processor.tail_sampling/
+- OpenTelemetry tail sampling scenario: https://github.com/grafana/alloy-scenarios/tree/main/otel-tail-sampling
+- More examples: https://github.com/grafana/alloy-scenarios

--- a/otel-metrics-pipeline/README.md
+++ b/otel-metrics-pipeline/README.md
@@ -1,73 +1,135 @@
-# OTel Metrics Pipeline
+# OpenTelemetry metrics pipeline
 
-Demonstrates a full OpenTelemetry metrics pipeline through Grafana Alloy: a Python application generates OTLP metrics which flow through Alloy (with batching and attribute transformation) into Prometheus, and are visualized in Grafana.
+This scenario shows a full OpenTelemetry metrics pipeline through Grafana Alloy.
+A Python app generates counters, histograms, and up-down counters with the OpenTelemetry SDK and sends them to Alloy over OTLP.
+Alloy batches the metrics, adds a `deployment.environment` resource attribute, and exports them to Prometheus over OTLP/HTTP for visualization in Grafana.
 
-## Overview
+## Before you begin
 
-The pipeline includes:
-- **Python demo app** -- generates counters, histograms, and up-down counters via the OpenTelemetry SDK, sending them as OTLP/gRPC to Alloy.
-- **Grafana Alloy** -- receives OTLP metrics, batches them, applies a transform processor (adds a `deployment.environment` resource attribute), and exports via OTLP/HTTP to Prometheus.
-- **Prometheus** -- ingests metrics through its native OTLP receiver with native histogram support enabled.
-- **Grafana** -- auto-provisioned with a Prometheus datasource for exploring the metrics.
+Ensure you have the following:
 
-## Running the Demo
+- [Docker][docker] and [Docker Compose][docker-compose].
+- Ports 3000 for Grafana, 9090 for Prometheus, 12345 for the Alloy UI, and 4317 and 4318 for OTLP free on the host.
 
-1. Clone the repository:
-   ```
-   git clone https://github.com/grafana/alloy-scenarios.git
-   cd alloy-scenarios
-   ```
+[docker]: https://docs.docker.com/get-docker/
+[docker-compose]: https://docs.docker.com/compose/install/
 
-2. Navigate to this example directory:
-   ```
-   cd otel-metrics-pipeline
-   ```
+## Understand the architecture
 
-3. Run using Docker Compose:
-   ```
-   docker compose up -d
-   ```
-
-   Or use the centralized image management:
-   ```
-   cd ..
-   ./run-example.sh otel-metrics-pipeline
-   ```
-
-4. Access the services:
-   - **Grafana**: http://localhost:3000
-   - **Alloy UI**: http://localhost:12345
-   - **Prometheus**: http://localhost:9090
-
-## What to Expect
-
-After a few seconds the demo app begins emitting metrics. You can explore them in several ways:
-
-- **Prometheus** -- navigate to http://localhost:9090 and query for metrics such as `app_requests_total`, `app_errors_total`, `app_request_duration_milliseconds`, or `app_active_users`. Note that OTLP metric names are translated to Prometheus conventions (dots become underscores, units are appended as suffixes).
-- **Grafana Explore** -- open http://localhost:3000/explore, select the Prometheus datasource, and build PromQL queries against the ingested metrics.
-- **Alloy pipeline UI** -- visit http://localhost:12345 to inspect the live component graph showing the receiver, batch processor, transform processor, and exporter.
-
-## Metrics Generated
-
-| Metric | Type | Description |
-|---|---|---|
-| `app.requests.total` | Counter | Total HTTP requests by endpoint, method, and status |
-| `app.errors.total` | Counter | Total errors by endpoint |
-| `app.request.duration` | Histogram | Request latency in milliseconds |
-| `app.active_users` | UpDownCounter | Current active users by region |
-
-## Architecture
-
+```text
++------------------+       +-------+       +-------------+       +---------+
+| app              | OTLP  | Alloy | OTLP  | Prometheus  |       |         |
+| demo-metrics-app |------>| batch | HTTP  | OTLP rcvr   |------>| Grafana |
+|                  | gRPC  | xform |       |             |       |         |
++------------------+       +-------+       +-------------+       +---------+
 ```
-┌─────────────┐  OTLP/gRPC   ┌───────────────┐  OTLP/HTTP  ┌────────────┐
-│  Python App  │─────────────▶│  Grafana Alloy │────────────▶│ Prometheus │
-│ (metrics gen)│   :4317      │  (batch +      │   :9090     │            │
-└─────────────┘               │   transform)   │             └─────┬──────┘
-                              └───────────────┘                    │
-                                   :12345                          │
-                                 (Alloy UI)                        ▼
-                                                             ┌──────────┐
-                                                             │ Grafana  │
-                                                             │  :3000   │
-                                                             └──────────┘
-```
+
+- **app**: Python container that emits OTLP metrics every second to `alloy:4317` over gRPC.
+- **Alloy**: Receives OTLP metrics, batches them, adds `deployment.environment = "demo"`, and exports to Prometheus at `http://prometheus:9090/api/v1/otlp`.
+- **Prometheus**: Ingests metrics through its native OTLP receiver with native histogram support enabled.
+- **Grafana**: Queries metrics through a provisioned Prometheus data source.
+
+## Run the scenario
+
+1. Clone the repository if you haven't already: `git clone https://github.com/grafana/alloy-scenarios.git`
+
+2. Install the scenario with one of these options:
+
+   **Option 1: From the scenario directory**
+
+   Use the default image tags in `docker-compose.yml`.
+
+   - Navigate to this scenario: `cd alloy-scenarios/otel-metrics-pipeline`
+   - Deploy the scenario: `docker compose up -d`
+
+   **Option 2: From the repository root**
+
+   Use pinned image versions from `image-versions.env` for Grafana, Prometheus, and Alloy.
+
+   - Deploy the scenario: `./run-example.sh otel-metrics-pipeline`
+
+3. From the `otel-metrics-pipeline` directory, check that all containers are up: `docker compose ps`
+
+   You should see `app`, `alloy`, `prometheus`, and `grafana`.
+
+   The `app` container installs Python dependencies on first start, so metrics may take a minute to appear.
+
+## Explore the services
+
+- **Grafana** at http://localhost:3000: Query metrics in **Explore** with the Prometheus data source, with no login required.
+- **Alloy UI** at http://localhost:12345: Pipeline graph, component health, and live debug views.
+- **Prometheus** at http://localhost:9090: Query ingested OTLP metrics directly.
+
+## Understand the Alloy pipeline
+
+The `config.alloy` pipeline has four components:
+
+1. **`otelcol.receiver.otlp.default`**: Receives OTLP metrics over gRPC and HTTP.
+2. **`otelcol.processor.batch.default`**: Batches metrics for efficient export.
+3. **`otelcol.processor.transform.default`**: Sets `deployment.environment = "demo"` on the resource.
+4. **`otelcol.exporter.otlphttp.prometheus`**: Sends metrics to Prometheus at `http://prometheus:9090/api/v1/otlp`.
+
+`livedebugging` is enabled so you can inspect the pipeline in the Alloy UI.
+
+The demo app emits these OTLP metrics:
+
+- `app.requests.total`: Counter of HTTP requests by endpoint, method, and status
+- `app.errors.total`: Counter of errors by endpoint
+- `app.request.duration`: Histogram of request latency in milliseconds
+- `app.active_users`: Up-down counter of active users by region
+
+Prometheus translates OTLP names to its naming conventions. Dots become underscores and units are appended as suffixes.
+
+## Try it out
+
+1. Open Grafana at http://localhost:3000 and go to **Explore**.
+   Select the **Prometheus** data source and run these PromQL queries:
+
+   - `app_requests_total`: Total requests by endpoint, method, and status
+   - `app_errors_total`: Total errors by endpoint
+   - `app_request_duration_milliseconds_bucket`: Request latency histogram buckets
+   - `app_active_users`: Current active users by region
+   - `app_requests_total{deployment_environment="demo"}`: Requests with the resource attribute added by Alloy
+
+2. To inspect the pipeline in real time, open the Alloy UI at http://localhost:12345.
+   Select `otelcol.receiver.otlp.default`, `otelcol.processor.batch.default`, `otelcol.processor.transform.default`, or `otelcol.exporter.otlphttp.prometheus` from the component graph to use live debug.
+
+## Customize the scenario
+
+- **Change attribute transforms**: Edit `otelcol.processor.transform.default` in `config.alloy`.
+- **Use the OTel Engine**: Run `docker compose -f docker-compose.yml -f docker-compose-otel.yml up -d` to load the equivalent pipeline from `config-otel.yaml` instead of River syntax.
+- **Promote more resource attributes**: Edit `otlp.promote_resource_attributes` in `prom-config.yaml`.
+
+## Troubleshoot common problems
+
+Diagnose container startup failures, missing metrics, and port conflicts.
+
+### Containers didn't start or exited unexpectedly
+
+Run `docker compose ps` to check the status of each container.
+If any container has exited, run `docker compose logs <SERVICE_NAME>` to read the failure reason.
+Replace `<SERVICE_NAME>` with the name of the service that exited, such as `app`, `alloy`, or `prometheus`.
+For Alloy specifically, the most common cause is a syntax error in `config.alloy`.
+
+### No metrics appear after a few minutes
+
+The `app` container runs `pip install` on first start, which can take up to a minute.
+Run `docker compose logs app` and check that you see `Starting OTLP metrics generator...`.
+Open the Alloy UI at http://localhost:12345 and check that all components show a healthy status.
+In Grafana, select the **Prometheus** data source in **Explore** and run `app_requests_total`.
+
+### Port conflicts with other services
+
+Ports 3000 for Grafana, 9090 for Prometheus, 12345 for Alloy, and 4317 and 4318 for OTLP must be free before you start the stack.
+If another service uses one of these ports, edit the port mapping in `docker-compose.yml` for the conflicting service before you run `docker compose up -d`.
+
+## Stop the scenario
+
+Run `docker compose down` from the `otel-metrics-pipeline` directory.
+
+## Next steps
+
+- Alloy components: https://grafana.com/docs/alloy/latest/reference/components/
+- `otelcol.processor.transform` reference: https://grafana.com/docs/alloy/latest/reference/components/otelcol/otelcol.processor.transform/
+- Prometheus OTLP receiver: https://prometheus.io/docs/guides/opentelemetry/
+- More examples: https://github.com/grafana/alloy-scenarios

--- a/otel-span-metrics/README.md
+++ b/otel-span-metrics/README.md
@@ -1,65 +1,137 @@
-# OTel Span Metrics (RED Metrics from Traces)
+# OpenTelemetry span metrics
 
-This scenario demonstrates how to generate **RED metrics** (Request rate, Error rate, Duration) from OpenTelemetry traces using Grafana Alloy's `otelcol.connector.spanmetrics` component.
+This scenario shows how to generate RED metrics — request rate, error rate, and duration — from OpenTelemetry traces with Grafana Alloy's `otelcol.connector.spanmetrics` component.
 
-## Overview
+Instead of relying on Tempo's built-in metrics generator, Alloy derives metrics directly from trace spans in the pipeline.
+That gives you control over which dimensions are extracted and how histograms are configured.
 
-Instead of relying on Tempo's built-in metrics generator, this approach uses Alloy's spanmetrics connector to derive metrics directly from trace spans in the telemetry pipeline. This gives you fine-grained control over which dimensions are extracted and how histograms are configured.
+## Before you begin
 
-### Architecture
+Ensure you have the following:
 
-```
-Flask App ---(OTLP/gRPC)---> Alloy ---> Tempo (traces)
-                                |
-                                +---> spanmetrics connector ---> Prometheus (RED metrics)
-```
+- [Docker][docker] and [Docker Compose][docker-compose].
+- Ports 5000 for the demo app, 3000 for Grafana, 3200 for Tempo, 9090 for Prometheus, 12345 for the Alloy UI, and 4317 and 4318 for OTLP free on the host.
 
-### What Gets Generated
+[docker]: https://docs.docker.com/get-docker/
+[docker-compose]: https://docs.docker.com/compose/install/
 
-The `otelcol.connector.spanmetrics` component produces the following metrics from every span:
+## Understand the architecture
 
-- **`duration_milliseconds`** - Histogram of span durations (for latency/duration analysis)
-- **`calls`** - Counter of span calls, with `status_code` label (for request rate and error rate)
-
-Additional dimensions extracted: `http.method`, `http.status_code`.
-
-## Running
-
-```bash
-# From repo root
-./run-example.sh otel-span-metrics
-
-# Or directly
-cd otel-span-metrics && docker compose up -d
+```text
++-------+       +-------+       +-------------+       +---------+
+| app   | OTLP  | Alloy | OTLP  | Prometheus  |       |         |
+| load  |------>| batch | HTTP  | RED metrics |------>| Grafana |
++-------+       |       |       +-------------+       |         |
+                |       |------>| Tempo       |------>|         |
+                |       | OTLP  | traces      |       |         |
+                +-------+       +-------------+       +---------+
 ```
 
-## Accessing the UIs
+- **app**: Flask demo app on port 5000 that creates spans and exports them to Alloy over OTLP.
+- **load**: Python script that continuously calls app endpoints to generate trace traffic.
+- **Alloy**: Receives traces, batches them, forwards spans to Tempo, and generates RED metrics with `otelcol.connector.spanmetrics`.
+- **Prometheus**: Ingests span metrics through its native OTLP receiver.
+- **Tempo**: Stores traces. This scenario does not enable Tempo's metrics generator.
+- **Grafana**: Queries Prometheus for RED metrics and Tempo for traces.
 
-| Service    | URL                        |
-|------------|----------------------------|
-| Grafana    | http://localhost:3000      |
-| Alloy      | http://localhost:12345     |
-| Prometheus | http://localhost:9090      |
-| Tempo      | http://localhost:3200      |
-| Demo App   | http://localhost:5000      |
+## Run the scenario
 
-## Exploring the Metrics
+1. Clone the repository if you haven't already: `git clone https://github.com/grafana/alloy-scenarios.git`
 
-Once the scenario is running and the load generator has been active for a minute or so, open Grafana and navigate to the **Explore** page with the **Prometheus** datasource. Try these queries:
+2. Install the scenario with one of these options:
 
-```promql
-# Request rate by service and span name
-rate(duration_milliseconds_count[5m])
+   **Option 1: From the scenario directory**
 
-# Error rate (spans with error status)
-rate(calls{status_code="STATUS_CODE_ERROR"}[5m])
+   Use the default image tags in `docker-compose.yml`.
 
-# P95 latency by span name
-histogram_quantile(0.95, rate(duration_milliseconds_bucket[5m]))
-```
+   - Navigate to this scenario: `cd alloy-scenarios/otel-span-metrics`
+   - Deploy the scenario: `docker compose up -d`
 
-## Stopping
+   **Option 2: From the repository root**
 
-```bash
-cd otel-span-metrics && docker compose down
-```
+   Use pinned image versions from `image-versions.env` for Grafana, Tempo, Prometheus, and Alloy.
+
+   - Deploy the scenario: `./run-example.sh otel-span-metrics`
+
+3. From the `otel-span-metrics` directory, check that all containers are up: `docker compose ps`
+
+   You should see `app`, `load`, `alloy`, `prometheus`, `tempo`, `memcached`, and `grafana`.
+
+   The `app` and `load` containers install Python dependencies on first start, so metrics may take a minute to appear.
+
+## Explore the services
+
+- **Demo app** at http://localhost:5000: Flask endpoints that generate traces.
+- **Grafana** at http://localhost:3000: **Explore** with Prometheus and Tempo data sources, with no login required.
+- **Alloy UI** at http://localhost:12345: Pipeline graph, component health, and live debug views.
+- **Prometheus** at http://localhost:9090: RED metrics from the spanmetrics connector.
+- **Tempo** at http://localhost:3200: Trace storage backend.
+
+## Understand the Alloy pipeline
+
+The `config.alloy` pipeline has these components:
+
+1. **`otelcol.receiver.otlp.default`**: Receives OTLP traces over gRPC and HTTP.
+2. **`otelcol.processor.batch.default`**: Batches traces and forwards them to both the spanmetrics connector and Tempo.
+3. **`otelcol.connector.spanmetrics.default`**: Derives RED metrics from spans with `http.method` and `http.status_code` dimensions and a 5-second flush interval.
+4. **`otelcol.exporter.otlphttp.prometheus`**: Sends metrics to Prometheus at `http://prometheus:9090/api/v1/otlp`.
+5. **`otelcol.exporter.otlp.tempo`**: Sends traces to Tempo at `tempo:4317`.
+
+`livedebugging` is enabled so you can inspect the pipeline in the Alloy UI.
+
+The spanmetrics connector produces these metrics from every span:
+
+- `duration_milliseconds`: Histogram of span durations
+- `calls`: Counter of span calls with a `status_code` label
+
+## Try it out
+
+Once the load generator has been active for about a minute, open Grafana at http://localhost:3000 and go to **Explore**.
+Select the **Prometheus** data source and run these PromQL queries:
+
+- `rate(duration_milliseconds_count[5m])`: Request rate by service and span name
+- `rate(calls{status_code="STATUS_CODE_ERROR"}[5m])`: Error rate for spans with error status
+- `histogram_quantile(0.95, rate(duration_milliseconds_bucket[5m]))`: P95 latency by span name
+
+To inspect traces, select the **Tempo** data source and search for `{resource.service.name="demo-app"}`.
+
+To inspect the pipeline in real time, open the Alloy UI at http://localhost:12345 and select `otelcol.connector.spanmetrics.default` or other components from the component graph to use live debug.
+
+## Customize the scenario
+
+- **Add span dimensions**: Add `dimension` blocks to `otelcol.connector.spanmetrics.default` in `config.alloy`.
+- **Change histogram buckets**: Edit the `histogram.explicit` block in `otelcol.connector.spanmetrics.default` in `config.alloy`.
+- **Use the OTel Engine**: Run `docker compose -f docker-compose.yml -f docker-compose-otel.yml up -d` to load the equivalent pipeline from `config-otel.yaml` instead of River syntax.
+
+## Troubleshoot common problems
+
+Diagnose container startup failures, missing metrics, and port conflicts.
+
+### Containers didn't start or exited unexpectedly
+
+Run `docker compose ps` to check the status of each container.
+If any container has exited, run `docker compose logs <SERVICE_NAME>` to read the failure reason.
+Replace `<SERVICE_NAME>` with the name of the service that exited, such as `app`, `load`, `alloy`, or `prometheus`.
+For Alloy specifically, the most common cause is a syntax error in `config.alloy`.
+
+### No metrics appear after a few minutes
+
+The `app` and `load` containers run `pip install` on first start, which can take up to a minute.
+Run `docker compose logs load` to check that the load generator is calling app endpoints.
+Open the Alloy UI at http://localhost:12345 and check that `otelcol.connector.spanmetrics.default` shows a healthy status.
+In Grafana, select the **Prometheus** data source in **Explore** and run `rate(duration_milliseconds_count[5m])`.
+
+### Port conflicts with other services
+
+Ports 5000 for the demo app, 3000 for Grafana, 3200 for Tempo, 9090 for Prometheus, 12345 for Alloy, and 4317 and 4318 for OTLP must be free before you start the stack.
+If another service uses one of these ports, edit the port mapping in `docker-compose.yml` for the conflicting service before you run `docker compose up -d`.
+
+## Stop the scenario
+
+Run `docker compose down` from the `otel-span-metrics` directory.
+
+## Next steps
+
+- `otelcol.connector.spanmetrics` reference: https://grafana.com/docs/alloy/latest/reference/components/otelcol/otelcol.connector.spanmetrics/
+- OpenTelemetry basic tracing scenario: https://github.com/grafana/alloy-scenarios/tree/main/otel-basic-tracing
+- More examples: https://github.com/grafana/alloy-scenarios

--- a/otel-tail-sampling/README.md
+++ b/otel-tail-sampling/README.md
@@ -1,235 +1,171 @@
-# OpenTelemetry Tail Sampling with Grafana Alloy
+# OpenTelemetry tail sampling
 
-This example demonstrates how to implement tail sampling for OpenTelemetry traces using Grafana Alloy, allowing you to intelligently filter and sample traces based on various criteria.
+This scenario shows how to filter OpenTelemetry traces with Grafana Alloy's `otelcol.processor.tail_sampling` component.
+A Python Flask demo app generates traces in the background and on demand, Alloy applies tail-sampling policies, and sampled traces are stored in Tempo for exploration in Grafana.
 
-## Overview
+Tail sampling decides whether to keep a trace only after Alloy has seen its spans.
+That lets you keep errors, slow requests, and traces with specific attributes while dropping most routine traffic.
 
-The example includes:
+## Before you begin
 
-- A Python Flask application that automatically generates different types of traces in the background
-- Grafana Alloy configured with tail sampling policies and transform processor
-- Tempo for trace storage and querying
-- Prometheus for metrics collection
-- Grafana for visualization
-- Live debugging for monitoring the sampling process
+Ensure you have the following:
 
-## Running the Demo
+- [Docker][docker] and [Docker Compose][docker-compose].
+- Ports 8080 for the demo app, 3000 for Grafana, 3200 for Tempo, 9090 for Prometheus, 12345 for the Alloy UI, and 4317 and 4318 for OTLP free on the host.
 
-1. Clone the repository:
-   ```
-   git clone https://github.com/grafana/alloy-scenarios.git
-   cd alloy-scenarios
-   ```
+[docker]: https://docs.docker.com/get-docker/
+[docker-compose]: https://docs.docker.com/compose/install/
 
-2. Navigate to this example directory:
-   ```
-   cd otel-tail-sampling
-   ```
+## Understand the architecture
 
-3. Run using Docker Compose:
-   ```
-   docker compose up -d
-   ```
-   
-   Or use the centralized image management:
-   ```
-   cd ..
-   ./run-example.sh otel-tail-sampling
-   ```
-
-4. Access the demo application at http://localhost:8080
-5. Access Grafana at http://localhost:3000
-6. Access Prometheus at http://localhost:9090
-7. Access Alloy's live debugging endpoint at http://localhost:12345/debug/livedebugging
-
-## What to Expect
-
-The demo application automatically generates various types of traces in the background:
-
-- **Simple Traces**: Basic single-span traces
-- **Nested Traces**: Traces with parent-child relationships
-- **Error Traces**: Traces containing errors
-- **High Latency Traces**: Traces with execution times over 5 seconds
-- **Delayed Chain Traces**: Service chains with Service D consistently having high latency (3-4 seconds)
-
-You can also manually trigger trace generation using the web UI. The application will continuously generate a mix of these trace types in the background at random intervals.
-
-## Processing Pipeline
-
-This example demonstrates a more complex trace processing pipeline with the following components:
-
-> Note: In the case of tail sampling, this ensures that trace spans are presented to the tail sampler as early as possible, to ensure that a decision period includes all relevant spans for a trace. Batch processing potentially prevents spans from arriving at the sampler before a sampling decision is made once the first span for a trace has been seen. This can lead to incorrect decisions being made, and starts to rely on a cache being enabled for future sampling decisions.
-
-1. **OTLP Receiver**: Receives traces from the application via gRPC or HTTP
-2. **Tail Sampling Processor**: Applies sampling policies based on trace properties
-3. **Batch Processor**: Groups spans for efficient processing
-4. **OTLP Exporter**: Sends sampled traces to Tempo
-
-## Tail Sampling Configuration
-
-This example uses Alloy's `otelcol.processor.tail_sampling` processor, which makes sampling decisions based on the entire trace, not just individual spans. This allows for more intelligent sampling based on trace-wide properties.
-
-> Note: Tempo indexes upon TraceID's and SpanID's not resource attributes.  Make sure you only send When requesting trace IDs or carrying out TraceQL queries, this will mean that returned traces will in fact consist of whichever duplicate span is encountered first. This will mean that subsequent queries will potentially not yield the same result, and that the service names for spans in the same trace could be comprised of both raw-traces and trace-demo-tail-sampled in the same trace, or appear to be from a sampled trace when it was in fact unsampled, or vice versa. To ensure consistency, only one set of spans with a unique ID and traceID should be emitted to Tempo. 
-
-The tail sampling configuration includes the following policies:
-
-1. **Attribute-Based Sampling**: Samples traces with a specific attribute value
-   ```
-   policy {
-     name = "test-attribute-policy"
-     type = "string_attribute"
-     
-     string_attribute {
-       key    = "test_attr_key_1"
-       values = ["test_attr_val_1"]
-     }
-   }
-   ```
-
-2. **Error Sampling**: Always samples traces with ERROR status
-   ```
-   policy {
-     name = "error-policy"
-     type = "status_code"
-     
-     status_code {
-       status_codes = ["ERROR"]
-     }
-   }
-   ```
-
-3. **Latency-Based Sampling**: Samples traces that exceed a latency threshold
-   ```
-   policy {
-     name = "latency-policy"
-     type = "latency"
-     
-     latency {
-       threshold_ms = 5000  // 5 seconds
-     }
-   }
-   ```
-
-4. **Numerical Range Sampling**: Samples traces with a numeric attribute in a specific range
-   ```
-   policy {
-     name = "numeric-policy"
-     type = "numeric_attribute"
-     
-     numeric_attribute {
-       key       = "key1"
-       min_value = 70
-       max_value = 100
-     }
-   }
-   ```
-
-5. **URL-Based Filtering**: Excludes health check and metrics endpoints
-   ```
-   policy {
-     name = "url-filter-policy"
-     type = "string_attribute"
-     
-     string_attribute {
-       key             = "http.url"
-       values          = ["/health", "/metrics"]
-       invert_match    = true
-     }
-   }
-   ```
-
-6. **Probabilistic Sampling**: Samples a percentage of remaining traces
-   ```
-   policy {
-     name = "probabilistic-policy"
-     type = "probabilistic"
-     
-     probabilistic {
-       sampling_percentage = 10
-     }
-   }
-   ```
-
-## Live Debugging
-
-This example enables Alloy's live debugging feature, which provides real-time insights into the sampling process:
-
-```
-livedebugging {
-  enabled = true
-}
+```text
++------------------+       +-------+       +-------+       +---------+
+| demo-app         | OTLP  | Alloy | OTLP  |       |       |         |
+| Flask + OTel SDK |------>| tail  |------>| Tempo |------>| Grafana |
+|                  |       | sample|       |       |       |         |
++------------------+       +-------+       +---+---+       +---------+
+                                               | service graph
+                                               v and span metrics
+                                          +------------+
+                                          | Prometheus |
+                                          +------------+
 ```
 
-Access the live debugging interface at http://localhost:12345 to see:
+- **demo-app**: Flask app on port 8080 that generates traces in a background thread and through HTTP endpoints.
+- **Alloy**: Receives OTLP traces, applies tail-sampling policies, batches sampled spans, and exports them to Tempo.
+- **Tempo**: Stores sampled traces and generates service-graph and span metrics that it remote-writes to Prometheus.
+- **Prometheus**: Stores metrics from Tempo's metrics generator.
+- **Grafana**: Explores traces through Tempo and service graphs through Prometheus.
 
-- Current processing pipeline state
-- Trace sampling decisions in real-time
-- Policy hit counts and performance metrics
-- Throughput statistics
+## Run the scenario
 
-## Sampling Implications
+1. Clone the repository if you haven't already: `git clone https://github.com/grafana/alloy-scenarios.git`
 
-With tail sampling enabled in this example:
+2. Install the scenario with one of these options:
 
-- All error traces are preserved for troubleshooting
-- High latency traces (>5s) are kept for performance analysis
-- Traces with specific attribute values used for monitoring are retained
-- Health check and metrics endpoints are filtered out to reduce noise
-- A small percentage of other traces are kept for baseline monitoring
-- Traces not matching any criteria are dropped, reducing storage needs
-- Raw traces are stored with a different service name for comparison
+   **Option 1: From the scenario directory**
 
-## Viewing Traces in Grafana
+   Use the default image tags in `docker-compose.yml`.
 
-To view the sampled traces:
+   - Navigate to this scenario: `cd alloy-scenarios/otel-tail-sampling`
+   - Build and deploy the scenario: `docker compose up -d --build`
 
-1. Open Grafana (http://localhost:3000)
-2. Navigate to Explore
-3. Select the Tempo data source
-4. Use the Search tab to find traces based on various criteria
+   **Option 2: From the repository root**
 
-## Sample Queries
+   Use pinned image versions from `image-versions.env` for Grafana, Tempo, Prometheus, and Alloy.
 
-Try these queries in Grafana's Tempo Explorer:
+   - Deploy the scenario: `./run-example.sh otel-tail-sampling`
 
-- Find all traces for the sampled service:
-  ```
-  {resource.service.name="trace-demo-tail-sampled"}
-  ```
+3. From the `otel-tail-sampling` directory, check that all containers are up: `docker compose ps`
 
-- Find error traces:
-  ```
-  {status=error}
-  ```
+   You should see `demo-app`, `alloy`, `tempo`, `prometheus`, and `grafana`.
 
-- Find high latency traces:
-  ```
-  {duration>5s}
-  ```
+## Explore the services
 
-- Find traces with a specific attribute:
-  ```
-  {span.test_attr_key_1="test_attr_val_1"}
-  ```
-  
-- Find traces with Service D bottleneck:
-  ```
-  {span.service.latency="high" && span.latency.category="bottleneck"}
-  ```
+- **Demo app** at http://localhost:8080: Home page with links to trace-generating endpoints. The app also generates traces automatically in the background.
+- **Grafana** at http://localhost:3000: **Explore** and **Traces Drilldown**, with no login required. Open **Traces Drilldown** at http://localhost:3000/a/grafana-exploretraces-app.
+- **Alloy UI** at http://localhost:12345: Pipeline graph, component health, and live debug views.
+- **Tempo** at http://localhost:3200: Trace storage backend.
+- **Prometheus** at http://localhost:9090: Service-graph and span metrics from Tempo.
 
-## Customizing
+## Understand the Alloy pipeline
 
-You can modify the `config.alloy` file to adjust the sampling policies:
+The `config.alloy` pipeline has four components in this order:
 
-- Change the decision wait time to balance memory usage vs. complete trace visibility
-- Adjust the sampling thresholds to capture more or fewer traces
-- Add additional sampling policies based on your specific needs
-- Modify the existing policies to match your application's attributes
-- Update the transform processor to add or modify different attributes
+1. **`otelcol.receiver.otlp.default`**: Receives OTLP traces over gRPC and HTTP.
+2. **`otelcol.processor.tail_sampling.default`**: Buffers spans per trace and applies sampling policies after `decision_wait = "10s"`.
+3. **`otelcol.processor.batch.default`**: Batches sampled spans before export.
+4. **`otelcol.exporter.otlp.tempo`**: Sends kept traces to Tempo at `tempo:4317`.
 
-## Further Resources
+Tail sampling runs before batching so spans reach the sampler as early as possible.
+If batching ran first, spans from the same trace could arrive too late for a correct decision.
 
-- [Grafana Alloy Tail Sampling Documentation](https://grafana.com/docs/alloy/latest/reference/components/otelcol.processor.tail_sampling/)
-- [Grafana Alloy Transform Processor Documentation](https://grafana.com/docs/alloy/latest/reference/components/otelcol.processor.transform/)
-- [OpenTelemetry Tail Sampling Processor](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/processor/tailsamplingprocessor)
-- [Live Debugging in Grafana Alloy](https://grafana.com/docs/alloy/latest/debug-alloy-flow/) 
+`livedebugging` is enabled so you can inspect sampling decisions in the Alloy UI.
+
+### Tail-sampling policies
+
+`otelcol.processor.tail_sampling.default` in `config.alloy` defines six policies:
+
+1. **test-attribute-policy**: Keeps traces with `test_attr_key_1 = test_attr_val_1`.
+2. **error-policy**: Keeps traces that contain a span with `ERROR` status.
+3. **latency-policy**: Keeps traces with end-to-end latency above 5000 ms.
+4. **numeric-policy**: Keeps traces where numeric attribute `key1` is between 70 and 100.
+5. **url-filter-policy**: Drops traces whose `http.url` is `/health` or `/metrics`. All other URLs pass through to later policies.
+6. **probabilistic-policy**: Keeps 10% of remaining traces as a baseline sample.
+
+The processor also sets `num_traces = 100` and `expected_new_traces_per_sec = 10` to size its in-memory trace buffer.
+
+### Trace types the demo app generates
+
+The background generator and HTTP endpoints produce:
+
+- Simple single-span traces
+- Nested parent-child traces
+- Error traces
+- High-latency traces with 3 to 10 second delays
+- Delayed-chain traces where service D adds 3 to 4 seconds of latency
+- Multi-service traces with distinct `service.name` values such as `web-ui` and `api-gateway`
+
+Manual endpoints include `/simple`, `/nested`, `/error`, `/high-latency`, `/chain`, `/delayed-chain`, `/multi-service`, and `/batch`.
+
+## Try it out
+
+1. Open the demo app at http://localhost:8080 and wait for background trace generation to start, or call an endpoint such as `/error` or `/high-latency`.
+
+2. Open Grafana at http://localhost:3000, go to **Explore**, select the **Tempo** data source, and open the **Search** tab.
+   Run these TraceQL queries:
+
+   - `{resource.service.name="trace-demo-tail-sampled"}`: Traces from the demo app
+   - `{status=error}`: Traces that include an error status
+   - `{duration>5s}`: Traces longer than five seconds
+   - `{span.test_attr_key_1="test_attr_val_1"}`: Traces matched by the attribute policy
+   - `{span.service.latency="high" && span.latency.category="bottleneck"}`: Traces with a high-latency service D bottleneck
+
+3. To view the service graph, select the **Tempo** data source in **Explore** and open the **Service Graph** tab after several minutes of background traffic.
+
+4. To inspect sampling in real time, open the Alloy UI at http://localhost:12345 and select `otelcol.processor.tail_sampling.default` to use live debug.
+
+## Customize the scenario
+
+- **Adjust policies**: Edit policy blocks in `otelcol.processor.tail_sampling.default` in `config.alloy`.
+- **Change decision timing**: Edit `decision_wait`, `num_traces`, or `expected_new_traces_per_sec` in `config.alloy` to balance memory use against complete trace visibility.
+- **Use the OTel Engine**: Run `docker compose -f docker-compose.yml -f docker-compose-otel.yml up -d --build` to load the equivalent pipeline from `config-otel.yaml` instead of River syntax.
+
+## Troubleshoot common problems
+
+Diagnose container startup failures, missing traces, and port conflicts.
+
+### Containers didn't start or exited unexpectedly
+
+Run `docker compose ps` to check the status of each container.
+If any container has exited, run `docker compose logs <SERVICE_NAME>` to read the failure reason.
+Replace `<SERVICE_NAME>` with the name of the service that exited, such as `demo-app`, `alloy`, or `tempo`.
+For Alloy specifically, the most common cause is a syntax error in `config.alloy`.
+
+### No traces appear in Grafana after a few minutes
+
+Open the demo app at http://localhost:8080 and call `/error` or `/high-latency` to generate a trace that tail sampling should keep.
+Tail sampling waits up to 10 seconds before deciding, so allow a short delay before searching.
+Open the Alloy UI at http://localhost:12345 and check that `otelcol.processor.tail_sampling.default` shows a healthy status.
+In Grafana, select the **Tempo** data source in **Explore** and search for `{resource.service.name="trace-demo-tail-sampled"}`.
+
+### Most traces seem to be missing
+
+That is expected. Tail sampling drops most routine traffic and keeps errors, slow traces, attribute matches, and about 10% of the remainder.
+Compare kept trace counts with the sampling policies in `config.alloy`.
+
+### Port conflicts with other services
+
+Ports 8080 for the demo app, 3000 for Grafana, 3200 for Tempo, 9090 for Prometheus, 12345 for Alloy, and 4317 and 4318 for OTLP must be free before you start the stack.
+If another service uses one of these ports, edit the port mapping in `docker-compose.yml` for the conflicting service before you run `docker compose up -d --build`.
+
+## Stop the scenario
+
+Run `docker compose down` from the `otel-tail-sampling` directory.
+
+## Next steps
+
+- `otelcol.processor.tail_sampling` reference: https://grafana.com/docs/alloy/latest/reference/components/otelcol/otelcol.processor.tail_sampling/
+- OpenTelemetry load balancing scenario: https://github.com/grafana/alloy-scenarios/tree/main/otel-loadbalancing
+- Live debugging in Alloy: https://grafana.com/docs/alloy/latest/troubleshoot/debug/
+- More examples: https://github.com/grafana/alloy-scenarios

--- a/otel-tracing-service-graphs/README.md
+++ b/otel-tracing-service-graphs/README.md
@@ -1,158 +1,168 @@
-# Alloy Service Graphs with OpenTelemetry
+# OpenTelemetry service graphs
 
-This example demonstrates how to use Grafana Alloy to generate service graphs from OpenTelemetry traces and send them to Prometheus via OTLP HTTP, instead of relying on Tempo's built-in metrics generator.
+This scenario shows how to generate service graphs from OpenTelemetry traces with Grafana Alloy's `otelcol.connector.servicegraph` component and send the metrics to Prometheus over OTLP/HTTP.
+A Python Flask demo app generates traces, Alloy derives service-graph metrics and forwards traces to Tempo, and Grafana visualizes both traces and the service map.
 
-## Overview
+This approach uses Alloy for service graph generation instead of the built-in service-graph metrics processor in Tempo.
 
-The example includes:
+## Before you begin
 
-- A sample Python Flask application that generates various types of traces
-- Grafana Alloy as the telemetry pipeline with service graph generation
-- Tempo for trace storage and querying (without metrics generation)
-- Prometheus with OTLP receiver enabled for metrics collection
-- Memcached for Tempo caching
-- Grafana for visualization
+Ensure you have the following:
 
-## Running the Demo
+- [Docker][docker] and [Docker Compose][docker-compose].
+- Ports 8080 for the demo app, 3000 for Grafana, 3200 for Tempo, 9090 for Prometheus, and 12345 for the Alloy UI free on the host.
 
-1. Clone the repository:
-   ```
-   git clone https://github.com/grafana/alloy-scenarios.git
-   cd alloy-scenarios
-   ```
+[docker]: https://docs.docker.com/get-docker/
+[docker-compose]: https://docs.docker.com/compose/install/
 
-2. Navigate to this example directory:
-   ```
-   cd otel-tracing-service-graphs
-   ```
+## Understand the architecture
 
-3. Run using Docker Compose:
-   ```
-   docker compose up -d
-   ```
-   
-   Or use the centralized image management:
-   ```
-   cd ..
-   ./run-example.sh otel-tracing-service-graphs
-   ```
-
-4. Access the demo application at http://localhost:8080
-5. Access Grafana at http://localhost:3000
-6. Access Prometheus at http://localhost:9090
-
-## What to Expect
-
-The demo application provides several endpoints that generate different types of traces:
-
-- **/simple**: Generates a simple trace with a single span
-- **/nested**: Generates a trace with nested spans (parent-child relationships)
-- **/error**: Generates a trace that includes an error
-- **/chain**: Simulates a chain of service calls to demonstrate distributed tracing
-
-After accessing these endpoints, you can view the traces and service graphs in Grafana.
-
-## Alloy Service Graph Generation
-
-This example demonstrates using Alloy's `otelcol.connector.servicegraph` component to generate service graphs from traces, which offers several advantages over using Tempo's built-in metrics generator:
-
-1. **More Flexibility**: Alloy's service graph connector allows for customization of dimensions and collection intervals
-2. **Pipeline Integration**: The service graph metrics can be part of a larger telemetry pipeline with additional processing
-3. **Reduced Load on Tempo**: By offloading the service graph generation to Alloy, Tempo can focus on trace storage and querying
-
-The key component in the Alloy configuration is:
-
-```
-otelcol.connector.servicegraph "default" {
-  metrics_flush_interval = "10s"
-  dimensions = ["http.method"]
-  
-  output {
-    metrics = [otelcol.exporter.otlphttp.prometheus.input]
-  }
-}
+```text
++------------------+       +----------------------+       +-------+       +---------+
+| demo-app         | OTLP  | Alloy                | OTLP  |       |       |         |
+| Flask + OTel SDK |------>| +------------------+ |------>| Tempo |------>| Grafana |
++------------------+       | | servicegraph     | |       |       |       |         |
+                           | +--------+---------+ |       +-------+       +---------+
+                           |          |           |                           ^
+                           +----------|-----------+                           |
+                                      | OTLP HTTP                             |
+                                      v                                       |
+                                 +------------+                               |
+                                 | Prometheus |-------------------------------+
+                                 +------------+
 ```
 
-## Prometheus OTLP Integration
+- **demo-app**: Flask app on port 8080 that creates spans and exports them to Alloy over OTLP.
+- **Alloy**: Batches traces, generates service-graph metrics with `otelcol.connector.servicegraph`, sends metrics to Prometheus, and forwards traces to Tempo.
+- **Prometheus**: Ingests service-graph metrics through its native OTLP receiver.
+- **Tempo**: Stores traces. The Tempo configuration enables only the `local-blocks` metrics processor, not service-graph generation.
+- **Memcached**: Query cache for Tempo.
+- **Grafana**: Queries Tempo for traces and Prometheus for the service graph through linked data sources.
 
-This example uses Prometheus's OTLP HTTP receiver endpoint. This approach has several benefits:
+## Run the scenario
 
-1. **Native OTLP Integration**: Uses the OpenTelemetry Protocol directly between Alloy and Prometheus
-2. **Simplified Configuration**: Uses Prometheus's built-in OTLP receiver without needing special ports
-3. **Better Metadata Handling**: Resource attributes from OTLP are properly promoted to Prometheus labels
+1. Clone the repository if you haven't already: `git clone https://github.com/grafana/alloy-scenarios.git`
 
-The OTLP HTTP exporter configuration in Alloy is:
+2. Install the scenario with one of these options:
 
-```
-otelcol.exporter.otlphttp "prometheus" {
-  client {
-    endpoint = "http://prometheus:9090/api/v1/otlp"
-    tls {
-      insecure = true
-    }
-  }
-}
-```
+   **Option 1: From the scenario directory**
 
-And in Prometheus, we've enabled the OTLP receiver and configured resource attributes to be promoted to labels:
+   Use the default image tags in `docker-compose.yml`.
 
-```
-otlp:
-  promote_resource_attributes:
-    - service.instance.id
-    - service.name
-    - service.namespace
-    - service.version
-    - deployment.environment
-    # ...and more relevant attributes
-```
+   - Navigate to this scenario: `cd alloy-scenarios/otel-tracing-service-graphs`
+   - Build and deploy the scenario: `docker compose up -d --build`
 
-## Viewing Service Graphs
+   **Option 2: From the repository root**
 
-To view the service graph:
+   Use pinned image versions from `image-versions.env` for Grafana, Tempo, Prometheus, and Alloy.
 
-1. Open Grafana (http://localhost:3000)
-2. Navigate to Explore
-3. Select the Tempo data source
-4. Click on the "Service Graph" tab
-5. You should see a visual representation of the relationships between services
+   - Deploy the scenario: `./run-example.sh otel-tracing-service-graphs`
 
-The service graph metrics are stored in Prometheus with the following metrics:
-- `calls_total`: Total number of calls between services
-- `calls_failed_total`: Total number of failed calls between services
+3. From the `otel-tracing-service-graphs` directory, check that all containers are up: `docker compose ps`
+
+   You should see `demo-app`, `alloy`, `tempo`, `prometheus`, `memcached`, and `grafana`.
+
+## Explore the services
+
+- **Demo app** at http://localhost:8080: Home page with links to trace-generating endpoints.
+- **Grafana** at http://localhost:3000: **Explore** and **Traces Drilldown**, with no login required. Open **Traces Drilldown** at http://localhost:3000/a/grafana-exploretraces-app.
+- **Alloy UI** at http://localhost:12345: Pipeline graph, component health, and live debug views.
+- **Tempo** at http://localhost:3200: Trace storage backend.
+- **Prometheus** at http://localhost:9090: Service-graph metrics from Alloy.
+
+## Understand the Alloy pipeline
+
+The `config.alloy` pipeline has these components:
+
+1. **`otelcol.receiver.otlp.default`**: Receives OTLP traces over gRPC and HTTP.
+2. **`otelcol.processor.batch.default`**: Batches traces and forwards them to the service graph connector and Tempo exporter.
+3. **`otelcol.connector.servicegraph.default`**: Derives service-graph metrics with `metrics_flush_interval = "10s"` and dimensions `service.name` and `http.method`.
+4. **`otelcol.exporter.otlphttp.prometheus`**: Sends metrics to Prometheus at `http://prometheus:9090/api/v1/otlp`.
+5. **`otelcol.exporter.otlp.tempo`**: Sends traces to Tempo at `tempo:4317`.
+
+The service graph connector stores recent spans in memory with `store.max_items = 5000` and `store.ttl = "30s"` to pair client and server spans.
+
+`livedebugging` is enabled so you can inspect the pipeline in the Alloy UI.
+
+Prometheus promotes selected resource attributes such as `service.name` and `deployment.environment` to labels through its OTLP configuration in `prom-config.yaml`.
+
+The connector produces metrics such as:
+
+- `calls_total`: Total calls between services
+- `calls_failed_total`: Failed calls between services
 - `latency`: Histogram of latencies between services
 
-The metrics are segmented by HTTP method, allowing you to see which endpoints are being called.
+## Try it out
 
-## Architecture
+1. Open the demo app at http://localhost:8080 and generate traffic that spans multiple services.
+   Call `/multi-service` or `/chain` several times to build edges in the graph.
 
-```
-┌────────────┐     ┌──────────────────────┐      ┌───────┐      ┌─────────┐
-│ Demo App   │────▶│ Alloy                │─────▶│ Tempo │─────▶│ Grafana │
-│ (OTel SDK) │     │ ┌──────────────────┐ │      │       │      │         │
-└────────────┘     │ │Service Graph Gen.│ │      └───────┘      └─────────┘
-                   │ └────────┬─────────┘ │                          ▲
-                   └──────────┼───────────┘                          │
-                              │                                      │
-                              ▼                                      │
-                        ┌─────────┐                                  │
-                        │Prometheus│──────────────────────────────────┘
-                        │  (OTLP)  │
-                        └─────────┘
-```
+2. Open Grafana at http://localhost:3000, select the **Tempo** data source in **Explore**, and open the **Service Graph** tab.
+   Wait about a minute after generating traffic for metrics to flush and appear.
 
-In this architecture:
-1. The Demo App generates traces using the OpenTelemetry SDK and sends them to Alloy
-2. Alloy processes the traces and:
-   - Generates service graph metrics using the servicegraph connector
-   - Forwards the raw traces to Tempo
-3. Service graph metrics are sent to Prometheus via OTLP HTTP
-4. Grafana queries both Tempo for traces and Prometheus for service graph metrics
+3. Select the **Prometheus** data source in **Explore** and run these PromQL queries:
 
-## Customizing
+   - `calls_total`: Total calls between services
+   - `calls_failed_total`: Failed calls between services
+   - `histogram_quantile(0.95, rate(latency_bucket[5m]))`: P95 latency between services
 
-The Alloy configuration can be further customized to add:
-- Additional processors for trace data
-- Filtering based on service names or other attributes
-- Custom dimensions for the service graph metrics (currently using HTTP method)
-- Additional metrics exporters for different backend systems 
+4. Select the **Tempo** data source and run these TraceQL queries in **Search**:
+
+   - `{resource.service.name="trace-demo"}`: Traces from the default demo app service
+   - `{status=error}`: Traces that include an error status
+
+5. To inspect the pipeline in real time, open the Alloy UI at http://localhost:12345 and select `otelcol.connector.servicegraph.default` from the component graph to use live debug.
+
+### Demo app endpoints
+
+- `/simple`: Single-span trace
+- `/nested`: Parent and child spans
+- `/error`: Trace that records an exception
+- `/chain`: HTTP chain through simulated services B and C
+- `/delayed-chain`: Longer chain with high-latency service D
+- `/multi-service`: Trace with distinct `service.name` values such as `web-ui` and `api-gateway`
+
+## Customize the scenario
+
+- **Add service graph dimensions**: Edit the `dimensions` list in `otelcol.connector.servicegraph.default` in `config.alloy`.
+- **Tune span pairing**: Edit `store.max_items` or `store.ttl` in `otelcol.connector.servicegraph.default` in `config.alloy`.
+- **Promote more resource attributes**: Edit `otlp.promote_resource_attributes` in `prom-config.yaml`.
+- **Use the OTel Engine**: Run `docker compose -f docker-compose.yml -f docker-compose-otel.yml up -d --build` to load the equivalent pipeline from `config-otel.yaml` instead of River syntax.
+
+## Troubleshoot common problems
+
+Diagnose container startup failures, an empty service graph, and port conflicts.
+
+### Containers didn't start or exited unexpectedly
+
+Run `docker compose ps` to check the status of each container.
+If any container has exited, run `docker compose logs <SERVICE_NAME>` to read the failure reason.
+Replace `<SERVICE_NAME>` with the name of the service that exited, such as `demo-app`, `alloy`, or `tempo`.
+For Alloy specifically, the most common cause is a syntax error in `config.alloy`.
+
+### Service graph is empty
+
+The service graph needs traces that span multiple services with paired client and server spans.
+Call `/multi-service` or `/chain` several times, wait at least 10 seconds for the connector flush interval, then open the **Service Graph** tab on the **Tempo** data source.
+In Grafana, select the **Prometheus** data source in **Explore** and run `calls_total` to check whether metrics arrived.
+
+### No traces appear in Tempo
+
+Open the Alloy UI at http://localhost:12345 and check that `otelcol.exporter.otlp.tempo` shows a healthy status.
+Call `/simple` on the demo app, then search Tempo for `{resource.service.name="trace-demo"}`.
+
+### Port conflicts with other services
+
+Ports 8080 for the demo app, 3000 for Grafana, 3200 for Tempo, 9090 for Prometheus, and 12345 for Alloy must be free before you start the stack.
+If another service uses one of these ports, edit the port mapping in `docker-compose.yml` for the conflicting service before you run `docker compose up -d --build`.
+
+## Stop the scenario
+
+Run `docker compose down` from the `otel-tracing-service-graphs` directory.
+
+## Next steps
+
+- `otelcol.connector.servicegraph` reference: https://grafana.com/docs/alloy/latest/reference/components/otelcol/otelcol.connector.servicegraph/
+- OpenTelemetry span metrics scenario: https://github.com/grafana/alloy-scenarios/tree/main/otel-span-metrics
+- Prometheus OTLP receiver: https://prometheus.io/docs/guides/opentelemetry/
+- More examples: https://github.com/grafana/alloy-scenarios


### PR DESCRIPTION
Update scenario README files otel-basic-tracing to otel-tracing-service-graphs

Does NOT include the Alloy Otel Engine scenarios under otel-examples