### PR TITLE
fix(tempo): drop removed opencensus receiver so tracing scenarios start

### DIFF
--- a/.cursor/docker-example.mdc
+++ b/.cursor/docker-example.mdc
@@ -294,8 +294,6 @@ distributor:
           endpoint: "tempo:4317"
         http:
           endpoint: "tempo:4318"
-    opencensus:
-      endpoint: "tempo:55678"
 
 ingester:
   max_block_duration: 5m               

--- a/.github/workflows/validate-scenarios.yml
+++ b/.github/workflows/validate-scenarios.yml
@@ -22,6 +22,14 @@ on:
       - '*/docker-compose.coda.yml'
       - '*/Dockerfile'
       - '*/config.alloy'
+      - '*/config-otel.yaml'
+      # Backend/pipeline configs: a broken tempo/loki/prometheus config
+      # crashes its container at boot and trips the smoke test, so a
+      # change to one must re-validate the scenario (see the opencensus
+      # receiver removal that this guard would have caught pre-merge).
+      - '*/tempo-config.yaml'
+      - '*/loki-config.yaml'
+      - '*/prom-config.yaml'
       - '*/app/**'
       - '*/*/Dockerfile'
       - '*/*/requirements.txt'

--- a/game-of-tracing/tempo-config.yaml
+++ b/game-of-tracing/tempo-config.yaml
@@ -48,8 +48,6 @@ distributor:
           endpoint: "tempo:4317"
         http:
           endpoint: "tempo:4318"
-    opencensus:
-      endpoint: "tempo:55678"
 
 ingester:
   max_block_duration: 5m               # cut the headblock when this much time passes. this is being set for demo purposes and should probably be left alone normally

--- a/otel-basic-tracing/tempo-config.yaml
+++ b/otel-basic-tracing/tempo-config.yaml
@@ -48,8 +48,6 @@ distributor:
           endpoint: "tempo:4317"
         http:
           endpoint: "tempo:4318"
-    opencensus:
-      endpoint: "tempo:55678"
 
 ingester:
   max_block_duration: 5m               # cut the headblock when this much time passes. this is being set for demo purposes and should probably be left alone normally

--- a/otel-span-metrics/tempo-config.yaml
+++ b/otel-span-metrics/tempo-config.yaml
@@ -47,8 +47,6 @@ distributor:
           endpoint: "tempo:4317"
         http:
           endpoint: "tempo:4318"
-    opencensus:
-      endpoint: "tempo:55678"
 
 ingester:
   max_block_duration: 5m

--- a/otel-tail-sampling/tempo-config.yaml
+++ b/otel-tail-sampling/tempo-config.yaml
@@ -48,8 +48,6 @@ distributor:
           endpoint: "tempo:4317"
         http:
           endpoint: "tempo:4318"
-    opencensus:
-      endpoint: "tempo:55678"
 
 ingester:
   max_block_duration: 5m               # cut the headblock when this much time passes. this is being set for demo purposes and should probably be left alone normally

--- a/otel-tracing-service-graphs/tempo-config.yaml
+++ b/otel-tracing-service-graphs/tempo-config.yaml
@@ -48,8 +48,6 @@ distributor:
           endpoint: "tempo:4317"
         http:
           endpoint: "tempo:4318"
-    opencensus:
-      endpoint: "tempo:55678"
 
 ingester:
   max_block_duration: 5m               # cut the headblock when this much time passes. this is being set for demo purposes and should probably be left alone normally

--- a/trace-delivery/tempo-config.yaml
+++ b/trace-delivery/tempo-config.yaml
@@ -48,8 +48,6 @@ distributor:
           endpoint: "tempo:4317"
         http:
           endpoint: "tempo:4318"
-    opencensus:
-      endpoint: "tempo:55678"
 
 ingester:
   max_block_duration: 5m               # cut the headblock when this much time passes. this is being set for demo purposes and should probably be left alone normally


### PR DESCRIPTION
## What

Removes the `opencensus` distributor receiver from every tracing scenario's `tempo-config.yaml` (and from the docker scenario template).

## Why

Tempo `2.10.7` dropped the `opencensus` receiver — its valid receivers are now `zipkin`, `otlp`, `kafka`, `jaeger`. Any config still declaring it makes Tempo refuse to boot:

```
error running Tempo ... failed to create distributor: cannot unmarshal the configuration:
'receivers' unknown type: "opencensus" for id: "opencensus" (valid values: [zipkin otlp kafka jaeger])
```

The crashed `tempo` container then trips the `validate-scenarios` **smoke test**, which fails on any exited container ("Exited containers detected: …-tempo-1").

This is the **common workflow-failure trend across the open PRs**: unrelated Renovate digest-bump PRs (#253 memcached, #254 memcached, #255 mysql, …) were all going red, but only on the *tracing* scenarios that happened to be in their smoke-test matrix — never on the image they actually bumped. Root cause was shared config, not the bumps.

## Affected scenarios

- `trace-delivery`
- `otel-basic-tracing`
- `otel-tail-sampling`
- `otel-span-metrics`
- `otel-tracing-service-graphs`
- `game-of-tracing`
- `.cursor/docker-example.mdc` (template — so new scenarios don't reintroduce it)

The `opencensus` receiver listened on port `55678`; nothing in any scenario sends to it (traces arrive via OTLP / Jaeger / Zipkin), so removal is safe and behaviour-preserving.

## Verification

Brought up `otel-basic-tracing` locally against `grafana/tempo:2.10.7` (the same image failing in CI):

- Tempo logs `"Tempo started"` — no opencensus error
- `/ready` returns `200`
- `docker compose ps --status exited` is empty → the exact smoke-test condition passes