### PR TITLE
feat: add otel-jaeger-zipkin-receiver scenario

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ These scenarios show distributed tracing with OpenTelemetry and Tempo.
 | [Game of tracing](game-of-tracing/) | Play an interactive strategy game that teaches distributed tracing, sampling, and service graphs. |
 | [OpenTelemetry basic tracing](otel-basic-tracing/) | Collect and visualize OpenTelemetry traces with Alloy and Tempo. |
 | [OpenTelemetry SDK traces across languages](app-instrumentation/traces/opentelemetry-sdk/) | Instrument five languages with the OpenTelemetry tracing SDK and collect standalone traces through Alloy into Tempo. |
+| [OpenTelemetry Jaeger and Zipkin receivers](otel-jaeger-zipkin-receiver/) | Ingest Jaeger and Zipkin trace formats with Alloy and forward them to Tempo over OTLP. |
 | [OpenTelemetry load balancing](otel-loadbalancing/) | Shard traces across two tail-sampling Alloy instances with `otelcol.exporter.loadbalancing` -- same trace ID, same backend. |
 | [OpenTelemetry service graphs](otel-tracing-service-graphs/) | Generate service graphs with the Alloy `servicegraph` connector. |
 | [OpenTelemetry span metrics](otel-span-metrics/) | Generate RED metrics from OpenTelemetry traces with the span metrics connector. Request rate, error rate, and duration. |

--- a/otel-jaeger-zipkin-receiver/README.md
+++ b/otel-jaeger-zipkin-receiver/README.md
@@ -1,0 +1,147 @@
+# Jaeger and Zipkin trace receivers
+
+This scenario shows how Alloy ingests traces from apps that speak the Jaeger or Zipkin wire protocols instead of OTLP.
+A Jaeger client sends Thrift-over-HTTP spans and a Zipkin client sends Zipkin v2 JSON spans, both straight to Alloy.
+`otelcol.receiver.jaeger` and `otelcol.receiver.zipkin` in `config.alloy` accept the native formats, batch the spans, and forward everything to Tempo over OTLP, so you don't have to touch the app's tracing code to point it at Alloy.
+
+## Before you begin
+
+Ensure you have the following:
+
+- [Docker][docker] and [Docker Compose][docker-compose].
+- Ports 3000 for Grafana, 3200 for Tempo, 9090 for Prometheus, 12345 for the Alloy UI, 14268 and 14250 for Jaeger, and 9411 for Zipkin free on the host.
+
+[docker]: https://docs.docker.com/get-docker/
+[docker-compose]: https://docs.docker.com/compose/install/
+
+## Understand the architecture
+
+```text
++----------------+      Thrift/HTTP       +-------+       +-------+         +---------+
+| jaeger-client  |----------------------->|       |       |       |         |         |
++----------------+                        | Alloy |------>| Tempo |-------->| Grafana |
++----------------+     Zipkin v2 JSON     |       | OTLP  |       |         |         |
+| zipkin-client  |----------------------->|       |       |       |         |         |
++----------------+                        +-------+       +-------+         +---------+
+                                               ^
+                                               |
+                                          +------------+
+                                          | Prometheus |
+                                          +------------+
+```
+
+- **jaeger-client**: Python script that creates spans with the OpenTelemetry SDK and exports them as Jaeger Thrift over HTTP to `alloy:14268/api/traces`.
+- **zipkin-client**: Python script that creates spans with the OpenTelemetry SDK and exports them as Zipkin v2 JSON to `alloy:9411/api/v2/spans`.
+- **Alloy**: Receives Jaeger and Zipkin spans, batches them, and forwards them to Tempo over OTLP.
+- **Tempo**: Stores traces. Only its OTLP receiver is enabled, because Alloy already normalizes both trace formats before they arrive.
+- **Prometheus**: Scrapes Alloy's own metrics, including per-receiver span counts.
+- **Grafana**: Explores traces through the provisioned Tempo data source.
+
+## Run the scenario
+
+1. Clone the repository if you haven't already: `git clone https://github.com/grafana/alloy-scenarios.git`
+
+2. Install the scenario with one of these options:
+
+   **Option 1: From the scenario directory**
+
+   Use the default image tags in `docker-compose.yml`.
+
+   - Navigate to this scenario: `cd alloy-scenarios/otel-jaeger-zipkin-receiver`
+   - Deploy the scenario: `docker compose up -d`
+
+   **Option 2: From the repository root**
+
+   Use pinned image versions from `image-versions.env` for Grafana, Tempo, Prometheus, and Alloy.
+
+   - Deploy the scenario: `./run-example.sh otel-jaeger-zipkin-receiver`
+
+3. From the `otel-jaeger-zipkin-receiver` directory, check that all containers are up: `docker compose ps`
+
+   You should see `jaeger-client`, `zipkin-client`, `alloy`, `tempo`, `prometheus`, and `grafana`.
+
+## Explore the services
+
+- **Grafana** at http://localhost:3000: **Explore** with the Tempo data source, with no login required.
+- **Alloy UI** at http://localhost:12345: Pipeline graph and component health.
+- **Tempo** at http://localhost:3200: Trace storage backend.
+- **Prometheus** at http://localhost:9090: Alloy self-metrics, including per-receiver span counts.
+
+## Understand the configuration
+
+The `config.alloy` pipeline has four components:
+
+1. **`otelcol.receiver.jaeger.default`**: Listens for Jaeger spans over Thrift HTTP and gRPC, then forwards them to the batch processor. The client in this scenario uses Thrift HTTP.
+2. **`otelcol.receiver.zipkin.default`**: Listens for Zipkin v2 JSON spans on its default endpoint, then forwards them to the batch processor.
+3. **`otelcol.processor.batch.default`**: Groups spans from both receivers to reduce export requests, then forwards them to the Tempo exporter.
+4. **`otelcol.exporter.otlp.tempo`**: Sends spans to Tempo at `tempo:4317` with TLS disabled for the local demo.
+
+`tempo-config.yaml` only enables the `otlp` receiver on `distributor.receivers`, because Alloy already converts Jaeger and Zipkin spans to OTLP before Tempo sees them.
+
+The `jaeger-client` and `zipkin-client` containers are self-contained Python scripts, not instrumented web apps.
+Each one builds a small trace with the OpenTelemetry SDK, exports it with a protocol-specific exporter, and repeats every 5 seconds:
+
+- `app/jaeger-client/client.py` uses `opentelemetry-exporter-jaeger-thrift`, pinned to version 1.21.0, to send a `place-order` trace with `charge-card` and `reserve-stock` child spans.
+- `app/zipkin-client/client.py` uses `opentelemetry-exporter-zipkin-json`, pinned to version 1.43.0, to send a `checkout` trace with `apply-discount` and `send-confirmation-email` child spans.
+
+Both exporter packages are deprecated in favor of native OTLP support, but they still emit correct Jaeger Thrift and Zipkin JSON on the wire, which is what this scenario needs to exercise Alloy's receivers.
+
+## Try it out
+
+1. Open Grafana at http://localhost:3000, go to **Explore**, select the **Tempo** data source, and open the **Search** tab.
+   Run these TraceQL queries:
+
+   - `{resource.service.name="jaeger-demo-client"}`: Traces that arrived over the Jaeger Thrift HTTP receiver
+   - `{resource.service.name="zipkin-demo-client"}`: Traces that arrived over the Zipkin receiver
+   - `{name="place-order"}`: The Jaeger client's root span
+   - `{name="checkout"}`: The Zipkin client's root span
+
+   Open a trace from each service and check that the root span has two child spans.
+
+2. Open Grafana's **Explore**, select the **Prometheus** data source, and run these PromQL queries:
+
+   - `otelcol_receiver_accepted_spans_total{component_id="otelcol.receiver.jaeger.default"}`: Spans accepted over Jaeger Thrift HTTP
+   - `otelcol_receiver_accepted_spans_total{component_id="otelcol.receiver.zipkin.default"}`: Spans accepted over Zipkin v2 JSON
+
+   Both counters should climb every 5 seconds as the clients emit new traces.
+
+3. To inspect the Alloy pipeline, open the Alloy UI at http://localhost:12345 and select `otelcol.receiver.jaeger.default`, `otelcol.receiver.zipkin.default`, `otelcol.processor.batch.default`, or `otelcol.exporter.otlp.tempo` from the component graph.
+
+## Customize the scenario
+
+- **Enable Jaeger's UDP protocols**: Add `thrift_binary {}` or `thrift_compact {}` inside the `protocols` block of `otelcol.receiver.jaeger` in `config.alloy`, then publish the matching UDP port in `docker-compose.yml`.
+- **Add attribute processing**: Insert an `otelcol.processor.attributes` or `otelcol.processor.transform` component between the receivers and `otelcol.processor.batch.default` to normalize resource attributes from legacy clients.
+- **Point a real Jaeger or Zipkin app at Alloy**: Replace `jaeger-client` or `zipkin-client` with your own service and set its collector endpoint to `http://alloy:14268/api/traces` or `http://alloy:9411/api/v2/spans`.
+
+## Troubleshoot common problems
+
+Diagnose container startup failures, missing traces, and port conflicts.
+
+### Containers didn't start or exited unexpectedly
+
+Run `docker compose ps` to check the status of each container.
+If any container has exited, run `docker compose logs <SERVICE_NAME>` to read the failure reason.
+Replace `<SERVICE_NAME>` with the name of the service that exited, such as `jaeger-client`, `zipkin-client`, or `alloy`.
+For Alloy specifically, the most common cause is a syntax error in `config.alloy`.
+
+### No traces appear in Grafana after a few minutes
+
+Open the Alloy UI at http://localhost:12345 and check that `otelcol.receiver.jaeger.default` and `otelcol.receiver.zipkin.default` show a healthy status.
+Run `docker compose logs jaeger-client` or `docker compose logs zipkin-client` to check that the client installed its dependencies and is running without errors.
+In Grafana, select the **Tempo** data source in **Explore** and search for `{resource.service.name="jaeger-demo-client"}` or `{resource.service.name="zipkin-demo-client"}`.
+
+### Port conflicts with other services
+
+Ports 3000, 3200, 9090, 12345, 14268, 14250, and 9411 must be free before you start the stack.
+If another service uses one of these ports, edit the port mapping in `docker-compose.yml` for the conflicting service before you run `docker compose up -d`.
+
+## Stop the scenario
+
+Run `docker compose down` from the `otel-jaeger-zipkin-receiver` directory.
+
+## Next steps
+
+- `otelcol.receiver.jaeger` reference: https://grafana.com/docs/alloy/latest/reference/components/otelcol/otelcol.receiver.jaeger/
+- `otelcol.receiver.zipkin` reference: https://grafana.com/docs/alloy/latest/reference/components/otelcol/otelcol.receiver.zipkin/
+- OpenTelemetry basic tracing scenario: https://github.com/grafana/alloy-scenarios/tree/main/otel-basic-tracing
+- More examples: https://github.com/grafana/alloy-scenarios

--- a/otel-jaeger-zipkin-receiver/app/jaeger-client/client.py
+++ b/otel-jaeger-zipkin-receiver/app/jaeger-client/client.py
@@ -1,0 +1,44 @@
+import os
+import random
+import time
+
+from opentelemetry import trace
+from opentelemetry.exporter.jaeger.thrift import JaegerExporter
+from opentelemetry.sdk.resources import SERVICE_NAME, Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+
+COLLECTOR_ENDPOINT = os.environ.get(
+    "JAEGER_COLLECTOR_ENDPOINT", "http://alloy:14268/api/traces"
+)
+
+resource = Resource.create({SERVICE_NAME: "jaeger-demo-client"})
+trace.set_tracer_provider(TracerProvider(resource=resource))
+
+jaeger_exporter = JaegerExporter(collector_endpoint=COLLECTOR_ENDPOINT)
+trace.get_tracer_provider().add_span_processor(
+    BatchSpanProcessor(jaeger_exporter, max_export_batch_size=1)
+)
+
+tracer = trace.get_tracer(__name__)
+
+
+def emit_order_trace():
+    with tracer.start_as_current_span("place-order") as parent:
+        parent.set_attribute("order.id", random.randint(1000, 9999))
+        time.sleep(0.05)
+
+        with tracer.start_as_current_span("charge-card") as child:
+            child.set_attribute("payment.provider", "jaeger-bank")
+            time.sleep(0.05)
+
+        with tracer.start_as_current_span("reserve-stock") as child:
+            child.set_attribute("warehouse.region", "eu-west")
+            time.sleep(0.05)
+
+
+if __name__ == "__main__":
+    print(f"Sending Jaeger Thrift spans to {COLLECTOR_ENDPOINT}")
+    while True:
+        emit_order_trace()
+        time.sleep(5)

--- a/otel-jaeger-zipkin-receiver/app/jaeger-client/requirements.txt
+++ b/otel-jaeger-zipkin-receiver/app/jaeger-client/requirements.txt
@@ -1,0 +1,3 @@
+opentelemetry-api==1.21.0
+opentelemetry-sdk==1.21.0
+opentelemetry-exporter-jaeger-thrift==1.21.0

--- a/otel-jaeger-zipkin-receiver/app/zipkin-client/client.py
+++ b/otel-jaeger-zipkin-receiver/app/zipkin-client/client.py
@@ -1,0 +1,42 @@
+import os
+import random
+import time
+
+from opentelemetry import trace
+from opentelemetry.exporter.zipkin.json import ZipkinExporter
+from opentelemetry.sdk.resources import SERVICE_NAME, Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+
+ZIPKIN_ENDPOINT = os.environ.get("ZIPKIN_ENDPOINT", "http://alloy:9411/api/v2/spans")
+
+resource = Resource.create({SERVICE_NAME: "zipkin-demo-client"})
+trace.set_tracer_provider(TracerProvider(resource=resource))
+
+zipkin_exporter = ZipkinExporter(endpoint=ZIPKIN_ENDPOINT)
+trace.get_tracer_provider().add_span_processor(
+    BatchSpanProcessor(zipkin_exporter, max_export_batch_size=1)
+)
+
+tracer = trace.get_tracer(__name__)
+
+
+def emit_checkout_trace():
+    with tracer.start_as_current_span("checkout") as parent:
+        parent.set_attribute("cart.id", random.randint(1000, 9999))
+        time.sleep(0.05)
+
+        with tracer.start_as_current_span("apply-discount") as child:
+            child.set_attribute("discount.code", "ZIPKIN10")
+            time.sleep(0.05)
+
+        with tracer.start_as_current_span("send-confirmation-email") as child:
+            child.set_attribute("email.provider", "zipkin-mailer")
+            time.sleep(0.05)
+
+
+if __name__ == "__main__":
+    print(f"Sending Zipkin v2 JSON spans to {ZIPKIN_ENDPOINT}")
+    while True:
+        emit_checkout_trace()
+        time.sleep(5)

--- a/otel-jaeger-zipkin-receiver/app/zipkin-client/requirements.txt
+++ b/otel-jaeger-zipkin-receiver/app/zipkin-client/requirements.txt
@@ -1,0 +1,3 @@
+opentelemetry-api==1.43.0
+opentelemetry-sdk==1.43.0
+opentelemetry-exporter-zipkin-json==1.43.0

--- a/otel-jaeger-zipkin-receiver/config.alloy
+++ b/otel-jaeger-zipkin-receiver/config.alloy
@@ -1,0 +1,39 @@
+/*
+ * Alloy Configuration for Jaeger and Zipkin Trace Ingestion
+ */
+
+// Receive Jaeger spans over Thrift HTTP and gRPC
+otelcol.receiver.jaeger "default" {
+  protocols {
+    thrift_http {}
+    grpc {}
+  }
+
+  output {
+    traces = [otelcol.processor.batch.default.input]
+  }
+}
+
+// Receive Zipkin v2 JSON spans
+otelcol.receiver.zipkin "default" {
+  output {
+    traces = [otelcol.processor.batch.default.input]
+  }
+}
+
+// Batch processor to improve performance
+otelcol.processor.batch "default" {
+  output {
+    traces = [otelcol.exporter.otlp.tempo.input]
+  }
+}
+
+// Send traces to Tempo for storage and visualization
+otelcol.exporter.otlp "tempo" {
+  client {
+    endpoint = "tempo:4317"
+    tls {
+      insecure = true
+    }
+  }
+}

--- a/otel-jaeger-zipkin-receiver/docker-compose.coda.yml
+++ b/otel-jaeger-zipkin-receiver/docker-compose.coda.yml
@@ -1,0 +1,22 @@
+services:
+  jaeger-client:
+    image: python:${PYTHON_VERSION:-3.11-slim}
+    volumes:
+      - ./app/jaeger-client:/app
+    working_dir: /app
+    command: sh -c "pip install -r requirements.txt && python client.py"
+    network_mode: host
+    restart: unless-stopped
+    environment:
+      - JAEGER_COLLECTOR_ENDPOINT=http://alloy:14268/api/traces
+
+  zipkin-client:
+    image: python:${PYTHON_VERSION:-3.11-slim}
+    volumes:
+      - ./app/zipkin-client:/app
+    working_dir: /app
+    command: sh -c "pip install -r requirements.txt && python client.py"
+    network_mode: host
+    restart: unless-stopped
+    environment:
+      - ZIPKIN_ENDPOINT=http://alloy:9411/api/v2/spans

--- a/otel-jaeger-zipkin-receiver/docker-compose.yml
+++ b/otel-jaeger-zipkin-receiver/docker-compose.yml
@@ -1,0 +1,98 @@
+services:
+  # Prometheus scrapes Alloy's own metrics
+  prometheus:
+    image: prom/prometheus:${PROMETHEUS_VERSION:-v3.11.3}
+    command:
+      - --config.file=/etc/prometheus/prometheus.yml
+    ports:
+      - 9090:9090/tcp
+    volumes:
+      - ./prom-config.yaml:/etc/prometheus/prometheus.yml
+
+  # Tempo for tracing
+  tempo:
+    image: grafana/tempo:${GRAFANA_TEMPO_VERSION:-2.10.7}
+    command: ["-config.file=/etc/tempo.yaml"]
+    ports:
+      - 3200:3200/tcp    # tempo
+    volumes:
+      - ./tempo-config.yaml:/etc/tempo.yaml
+
+  # Grafana for visualization
+  grafana:
+    image: grafana/grafana:${GRAFANA_VERSION:-13.0.2}
+    environment:
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_BASIC_ENABLED=false
+      - GF_INSTALL_PLUGINS=https://storage.googleapis.com/integration-artifacts/grafana-exploretraces-app/grafana-exploretraces-app-latest.zip;grafana-traces-app
+    ports:
+      - 3000:3000/tcp
+    entrypoint:
+      - sh
+      - -euc
+      - |
+        mkdir -p /etc/grafana/provisioning/datasources
+        cat <<EOF > /etc/grafana/provisioning/datasources/ds.yaml
+        apiVersion: 1
+        datasources:
+        - name: Prometheus
+          type: prometheus
+          orgId: 1
+          url: http://prometheus:9090
+          basicAuth: false
+          isDefault: false
+          version: 1
+          editable: false
+        - name: Tempo
+          type: tempo
+          access: proxy
+          orgId: 1
+          url: http://tempo:3200
+          basicAuth: false
+          isDefault: true
+          version: 1
+          editable: false
+        EOF
+        /run.sh
+    depends_on:
+      - prometheus
+      - tempo
+
+  # Alloy for telemetry pipeline
+  alloy:
+    image: grafana/alloy:${GRAFANA_ALLOY_VERSION:-v1.17.0}
+    ports:
+      - 12345:12345      # Alloy HTTP server
+      - 14268:14268      # Jaeger Thrift HTTP
+      - 14250:14250      # Jaeger gRPC
+      - 9411:9411        # Zipkin v2 JSON
+    volumes:
+      - ./config.alloy:/etc/alloy/config.alloy
+    command: run --server.http.listen-addr=0.0.0.0:12345 --storage.path=/var/lib/alloy/data /etc/alloy/config.alloy
+    depends_on:
+      - tempo
+
+  # Jaeger client that emits Thrift-over-HTTP spans
+  jaeger-client:
+    image: python:${PYTHON_VERSION:-3.11-slim}
+    volumes:
+      - ./app/jaeger-client:/app
+    working_dir: /app
+    command: sh -c "pip install -r requirements.txt && python client.py"
+    environment:
+      - JAEGER_COLLECTOR_ENDPOINT=http://alloy:14268/api/traces
+    depends_on:
+      - alloy
+
+  # Zipkin client that emits Zipkin v2 JSON spans
+  zipkin-client:
+    image: python:${PYTHON_VERSION:-3.11-slim}
+    volumes:
+      - ./app/zipkin-client:/app
+    working_dir: /app
+    command: sh -c "pip install -r requirements.txt && python client.py"
+    environment:
+      - ZIPKIN_ENDPOINT=http://alloy:9411/api/v2/spans
+    depends_on:
+      - alloy

--- a/otel-jaeger-zipkin-receiver/prom-config.yaml
+++ b/otel-jaeger-zipkin-receiver/prom-config.yaml
@@ -1,0 +1,10 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+# Scrape Alloy's own metrics, including the otelcol_receiver_accepted_spans
+# series that show spans arriving over the Jaeger and Zipkin protocols.
+scrape_configs:
+  - job_name: 'alloy'
+    static_configs:
+      - targets: ['alloy:12345']

--- a/otel-jaeger-zipkin-receiver/tempo-config.yaml
+++ b/otel-jaeger-zipkin-receiver/tempo-config.yaml
@@ -1,0 +1,26 @@
+stream_over_http_enabled: true
+server:
+  http_listen_port: 3200
+  log_level: info
+
+distributor:
+  receivers:
+    otlp:
+      protocols:
+        grpc:
+          endpoint: "tempo:4317"
+
+ingester:
+  max_block_duration: 5m               # cut the headblock when this much time passes. set for demo purposes
+
+compactor:
+  compaction:
+    block_retention: 720h              # overall Tempo trace retention. set for demo purposes
+
+storage:
+  trace:
+    backend: local
+    wal:
+      path: /var/tempo/wal
+    local:
+      path: /var/tempo/blocks


### PR DESCRIPTION
## Summary
- Adds a new scenario demonstrating `otelcol.receiver.jaeger` and `otelcol.receiver.zipkin` ingesting pre-OTel trace formats and forwarding them to Tempo over OTLP
- Bundles a Jaeger client (Thrift-over-HTTP, port 14268) and a Zipkin client (v2 JSON, port 9411) as self-contained Python scripts using the OpenTelemetry SDK with protocol-specific exporters
- Tempo only exposes its OTLP receiver, since Alloy does all the protocol translation before spans reach it
- Adds the scenario to the main README's tracing table

Closes #274

## Test plan
- [x] `docker compose up -d` from the scenario directory: all 6 containers (`jaeger-client`, `zipkin-client`, `alloy`, `tempo`, `prometheus`, `grafana`) start and stay healthy
- [x] `./run-example.sh otel-jaeger-zipkin-receiver` from the repo root also works with pinned image versions
- [x] All 4 Alloy components (`otelcol.receiver.jaeger.default`, `otelcol.receiver.zipkin.default`, `otelcol.processor.batch.default`, `otelcol.exporter.otlp.tempo`) report healthy via the Alloy API
- [x] Tempo search confirms traces from both `jaeger-demo-client` (root span `place-order`) and `zipkin-demo-client` (root span `checkout`), each with two child spans
- [x] Prometheus scrapes Alloy and exposes `otelcol_receiver_accepted_spans_total` split by `component_id` for both receivers
- [x] Grafana health check and datasource provisioning (Prometheus + Tempo) confirmed
- [x] README drafted and verified with the repo's `docs-review` skill against the scenario configs and the Alloy component reference docs