### PR TITLE
feat: add beyla-zero-code-instrumentation scenario

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ These scenarios show distributed tracing with OpenTelemetry and Tempo.
 | [OpenTelemetry basic tracing](otel-basic-tracing/) | Collect and visualize OpenTelemetry traces with Alloy and Tempo. |
 | [OpenTelemetry SDK traces across languages](app-instrumentation/traces/opentelemetry-sdk/) | Instrument five languages with the OpenTelemetry tracing SDK and collect standalone traces through Alloy into Tempo. |
 | [OpenTelemetry Jaeger and Zipkin receivers](otel-jaeger-zipkin-receiver/) | Ingest Jaeger and Zipkin trace formats with Alloy and forward them to Tempo over OTLP. |
+| [Zero-code eBPF instrumentation](beyla-zero-code-instrumentation/) | Auto-instrument an unmodified Go HTTP service with `beyla.ebpf` -- no OpenTelemetry SDK, no agent, no code changes. Produces RED metrics and traces from eBPF probes alone. |
 | [OpenTelemetry load balancing](otel-loadbalancing/) | Shard traces across two tail-sampling Alloy instances with `otelcol.exporter.loadbalancing` -- same trace ID, same backend. |
 | [OpenTelemetry service graphs](otel-tracing-service-graphs/) | Generate service graphs with the Alloy `servicegraph` connector. |
 | [OpenTelemetry span metrics](otel-span-metrics/) | Generate RED metrics from OpenTelemetry traces with the span metrics connector. Request rate, error rate, and duration. |

--- a/beyla-zero-code-instrumentation/README.md
+++ b/beyla-zero-code-instrumentation/README.md
@@ -1,0 +1,177 @@
+# Zero-code instrumentation with Beyla
+
+This scenario shows how Grafana Alloy uses `beyla.ebpf` to auto-instrument an HTTP service with eBPF.
+Alloy attaches eBPF probes to the compiled `demo-app` binary and its sockets, so the service needs no OpenTelemetry SDK, no agent, and no code change of any kind.
+Alloy forwards the RED metrics `beyla.ebpf` produces to Prometheus and the traces it produces to Tempo.
+The `config.alloy` file defines the pipeline.
+
+A `loadgen` container drives continuous traffic against `demo-app`, including a deliberate 404, so you have metrics and traces to explore as soon as the stack starts.
+
+## Before you begin
+
+Ensure you have the following:
+
+- [Docker][docker] and [Docker Compose][docker-compose].
+- A Linux host with kernel 5.8 or newer and BPF Type Format enabled, or Docker Desktop on macOS or Windows.
+  BTF is on by default on kernel 5.14 and newer.
+  The eBPF loader attaches to the Linux kernel that runs the Docker engine, so Docker Desktop's Linux VM works too.
+  Nested Docker isn't supported because an inner container can't load eBPF programs into the outer host's kernel.
+- Permission to start the `privileged` Alloy container.
+- Ports 3000 for Grafana, 9090 for Prometheus, 3200 for Tempo, 8080 for `demo-app`, and 12345 for Alloy free on the host.
+
+[docker]: https://docs.docker.com/get-docker/
+[docker-compose]: https://docs.docker.com/compose/install/
+
+## Compare with a related scenario
+
+| Aspect            | `beyla-zero-code-instrumentation/`             | [`app-instrumentation/traces/opentelemetry-sdk/`](../app-instrumentation/traces/opentelemetry-sdk/) |
+| ------------------ | ----------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| Code changes       | None                                             | Add the OpenTelemetry SDK to the application                                                          |
+| Collection         | eBPF probes on the compiled binary               | The SDK exports spans directly from the process                                                       |
+| Host requirements  | `privileged: true` and a shared PID namespace    | Standard container                                                                                    |
+| Span detail        | Generic RED metrics and transaction-level spans  | Full manual control over spans and attributes                                                         |
+
+Use this scenario when you can't or don't want to touch application code.
+Use the SDK scenario when you control the code and need fine-grained spans.
+
+## Understand the architecture
+
+`loadgen` sends HTTP traffic to `demo-app`.
+Alloy shares `demo-app`'s PID namespace, so `beyla.ebpf` attaches eBPF probes to the running binary, turns the observed requests into RED metrics and traces, and forwards both onward.
+
+```text
++---------+     +----------+
+| loadgen |---->| demo-app |
++---------+     +----------+
+                     ^
+                     | shared PID namespace, eBPF probes
+                     |
+                +----------+     +------------+     +---------+
+                |  alloy   |---->| Prometheus |---->|         |
+                | (beyla.  |     +------------+     | Grafana |
+                |  ebpf)   |---->|   Tempo    |---->|         |
+                +----------+     +------------+     +---------+
+```
+
+- **loadgen**: Curls `demo-app` in a loop, including a request to a missing order so you see a 404 alongside the healthy routes.
+- **demo-app**: A plain Go HTTP API with no instrumentation library of any kind.
+- **Alloy**: Runs with `privileged: true` and `pid: "service:demo-app"`, and uses `beyla.ebpf` to instrument `demo-app` from outside the process.
+- **Prometheus**: Stores the RED metrics `beyla.ebpf` produces.
+- **Tempo**: Stores the traces `beyla.ebpf` produces.
+- **Grafana**: Visualizes both through provisioned Prometheus and Tempo data sources.
+
+## Run the scenario
+
+1. Clone the repository if you haven't already: `git clone https://github.com/grafana/alloy-scenarios.git`
+
+2. Install the scenario with one of these options:
+
+   **Option 1: From the scenario directory**
+
+   Use the default image tags in `docker-compose.yml`.
+
+   - Navigate to this scenario: `cd alloy-scenarios/beyla-zero-code-instrumentation`
+   - Deploy the scenario: `docker compose up -d`
+
+   **Option 2: From the repository root**
+
+   Use pinned image versions from `image-versions.env`.
+
+   - Deploy the scenario: `./run-example.sh beyla-zero-code-instrumentation`
+
+3. Check that all containers are up: `cd alloy-scenarios/beyla-zero-code-instrumentation && docker compose ps`
+
+   Expect `alloy`, `demo-app`, `loadgen`, `prometheus`, `tempo`, and `grafana`.
+
+## Explore the services
+
+- **Grafana** at http://localhost:3000: Query metrics and traces in **Explore**, with no login required.
+- **Alloy UI** at http://localhost:12345: Pipeline graph, component health, and live debug views.
+- **Prometheus** at http://localhost:9090: Query the RED metrics directly.
+- **Tempo** at http://localhost:3200: Trace storage backend.
+- **demo-app** at http://localhost:8080: The uninstrumented target service. `curl http://localhost:8080/orders` to see it respond.
+
+## Understand the configuration
+
+The `config.alloy` pipeline has four components:
+
+1. **`beyla.ebpf "default"`**: Instruments any process listening on port `8080` inside Alloy's shared PID namespace, labels it `demo-app`, and enables `application` metrics.
+   It forwards the traces it generates to `otelcol.exporter.otlp.tempo`.
+2. **`prometheus.scrape "beyla"`**: `beyla.ebpf` exposes its RED metrics as a Prometheus scrape target rather than pushing them, so this component pulls them into the pipeline and forwards the samples to `prometheus.remote_write.default`.
+3. **`prometheus.remote_write "default"`**: Sends the scraped RED metrics to Prometheus at `http://prometheus:9090/api/v1/write`.
+4. **`otelcol.exporter.otlp "tempo"`**: Sends the traces `beyla.ebpf` generates to Tempo at `tempo:4317`.
+
+Two settings in `docker-compose.yml` are required for `beyla.ebpf` to work:
+
+- **`privileged: true`**: Lets Alloy load eBPF programs and read the kernel structures `beyla.ebpf` depends on.
+- **`pid: "service:demo-app"`**: Shares `demo-app`'s PID namespace with Alloy, the pattern Beyla's own Docker documentation recommends for instrumenting a single container.
+  Without it, `beyla.ebpf` can't see the `demo-app` process to attach probes to it.
+
+`livedebugging` is enabled.
+
+## Try it out
+
+Allow about 15 seconds after bring-up for `loadgen` to start sending traffic and for `beyla.ebpf` to attach to `demo-app`.
+
+1. Open Grafana at http://localhost:3000, open **Explore**, and select the **Tempo** data source.
+   Search for `service.name = demo-app` and open a trace.
+   Expect spans named `GET /`, `GET /orders`, `GET /orders/`, and `POST /checkout`, with some `POST /checkout` spans marked as errors.
+
+2. Switch to the **Prometheus** data source in **Explore** and run:
+
+   ```promql
+   sum by (http_route, http_response_status_code) (rate(http_server_request_duration_seconds_count{job="demo-app"}[1m]))
+   ```
+
+   Expect series for `/`, `/orders`, `/orders/`, and `/checkout` with a mix of `200`, `201`, `404`, and `500` status codes.
+   The `404` comes from `loadgen` requesting a nonexistent order at `/orders/99`, and the `500` comes from `demo-app`'s simulated checkout failures.
+
+3. Open the Alloy UI at http://localhost:12345 and select `beyla.ebpf.default` to check its health and the process it instruments.
+   Select `prometheus.scrape.beyla` and use live debug to watch the RED metrics pass through the pipeline.
+
+## Customize the scenario
+
+- **Instrument your own service**: Point `discovery.instrument.open_ports` and `discovery.instrument.name` in `beyla.ebpf "default"` at your service's port and name, then change `pid: "service:demo-app"` in `docker-compose.yml` to `pid: "service:<YOUR_SERVICE>"`.
+- **Add network-level metrics**: Add `"network"` to the `features` list in the `metrics` block of `beyla.ebpf "default"`.
+- **Sample traces**: Add a `traces` block with a `sampler` sub-block, for example `name = "traceidratio"` and `arg = "0.1"`, to keep 10% of traces.
+- **Group dynamic routes**: Add a `routes` block with `unmatched = "heuristic"` to `beyla.ebpf "default"` so paths such as `/orders/1` and `/orders/2` group into a single route instead of showing up as unmatched.
+
+## Troubleshoot common problems
+
+Use these steps when telemetry doesn't appear, `beyla.ebpf` fails to load, or ports conflict.
+
+### beyla.ebpf instruments the process but no traces or metrics appear
+
+This scenario pins `demo-app` to Go 1.24 for a reason.
+`beyla.ebpf` reads Go runtime-internal offsets to track goroutines across a request, and those offsets are specific to each Go version.
+When the target binary uses a Go version `beyla.ebpf` doesn't yet support, it still reports the process as instrumented and logs no fatal error, but every trace and RED metric silently drops.
+
+If you point this scenario at your own Go service and see the same symptom, set `debug = true` on `beyla.ebpf "default"` and run `docker compose logs alloy`.
+A repeating `can't read newproc1 invocation metadata` message confirms a Go version mismatch.
+Rebuild your service with an older, more established Go release and retry.
+
+### No data appears in Grafana after a few minutes
+
+Open the Alloy UI at http://localhost:12345 and check that `beyla.ebpf.default`, `prometheus.scrape.beyla`, and `otelcol.exporter.otlp.tempo` all show a healthy status.
+Check that `alloy` runs with `privileged: true` and `pid: "service:demo-app"` in `docker-compose.yml`.
+
+### eBPF fails inside nested Docker
+
+Run this scenario on the Docker host or in Docker Desktop, not inside another container.
+
+### Port conflicts with other services
+
+Ports 3000, 8080, 9090, 3200, and 12345 must be free before you start the stack.
+If another service uses one of these ports, edit the port mapping in `docker-compose.yml` before you run `docker compose up -d`.
+
+## Stop the scenario
+
+Run `docker compose down` from the scenario directory.
+
+## Next steps
+
+- `beyla.ebpf` reference: https://grafana.com/docs/alloy/latest/reference/components/beyla/beyla.ebpf/
+- Grafana Beyla documentation: https://grafana.com/docs/beyla/latest/
+- Beyla security, permissions, and capabilities: https://grafana.com/docs/beyla/latest/security/
+- SDK-based tracing scenario: [`app-instrumentation/traces/opentelemetry-sdk/`](../app-instrumentation/traces/opentelemetry-sdk/)
+- Related eBPF scenario: [`ebpf-host-profiling/`](../ebpf-host-profiling/)

--- a/beyla-zero-code-instrumentation/app/go.mod
+++ b/beyla-zero-code-instrumentation/app/go.mod
@@ -1,0 +1,3 @@
+module demo-app
+
+go 1.24

--- a/beyla-zero-code-instrumentation/app/main.go
+++ b/beyla-zero-code-instrumentation/app/main.go
@@ -1,0 +1,74 @@
+// Command demo-app is a plain Go HTTP API for the beyla-zero-code-instrumentation
+// scenario. It imports no OpenTelemetry SDK, no tracing agent, and no metrics
+// library of any kind — beyla.ebpf instruments it purely from the outside, by
+// attaching eBPF probes to the compiled binary and its sockets.
+package main
+
+import (
+	"encoding/json"
+	"log"
+	"math/rand"
+	"net/http"
+	"strings"
+	"time"
+)
+
+var knownOrders = map[string]bool{"1": true, "2": true, "3": true}
+
+// jitter sleeps for a random duration in [min, max) so request latency
+// varies enough to make the beyla.ebpf duration histograms interesting.
+func jitter(min, max time.Duration) {
+	time.Sleep(min + time.Duration(rand.Int63n(int64(max-min))))
+}
+
+func handleRoot(w http.ResponseWriter, r *http.Request) {
+	jitter(5*time.Millisecond, 20*time.Millisecond)
+	w.WriteHeader(http.StatusOK)
+	w.Write([]byte("ok"))
+}
+
+func handleOrders(w http.ResponseWriter, r *http.Request) {
+	jitter(10*time.Millisecond, 50*time.Millisecond)
+	id := strings.TrimPrefix(r.URL.Path, "/orders/")
+	if id == "" || id == r.URL.Path {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode([]string{"1", "2", "3"})
+		return
+	}
+	if !knownOrders[id] {
+		http.NotFound(w, r)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]string{"id": id, "status": "shipped"})
+}
+
+// handleCheckout fails roughly 15% of the time, so beyla.ebpf's RED metrics
+// show a non-zero error rate alongside the healthy routes.
+func handleCheckout(w http.ResponseWriter, r *http.Request) {
+	jitter(50*time.Millisecond, 150*time.Millisecond)
+	if rand.Intn(100) < 15 {
+		http.Error(w, "payment provider timeout", http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(http.StatusCreated)
+	w.Write([]byte(`{"status":"confirmed"}`))
+}
+
+func logged(name string, h http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		log.Printf("%s %s -> %s", r.Method, r.URL.Path, name)
+		h(w, r)
+	}
+}
+
+func main() {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", logged("root", handleRoot))
+	mux.HandleFunc("/orders", logged("orders", handleOrders))
+	mux.HandleFunc("/orders/", logged("orders", handleOrders))
+	mux.HandleFunc("/checkout", logged("checkout", handleCheckout))
+
+	log.Println("demo-app listening on :8080 (no instrumentation SDK loaded)")
+	log.Fatal(http.ListenAndServe(":8080", mux))
+}

--- a/beyla-zero-code-instrumentation/config.alloy
+++ b/beyla-zero-code-instrumentation/config.alloy
@@ -1,0 +1,50 @@
+livedebugging {
+	enabled = true
+}
+
+// Zero-code eBPF auto-instrumentation of the demo-app container. Alloy
+// shares demo-app's PID namespace (see `pid: "service:demo-app"` in
+// docker-compose.yml), so beyla.ebpf can attach eBPF probes to the Go
+// binary listening on port 8080 without any SDK, agent, or code change
+// in demo-app itself.
+beyla.ebpf "default" {
+	discovery {
+		instrument {
+			open_ports = "8080"
+			name       = "demo-app"
+		}
+	}
+
+	metrics {
+		features = ["application"]
+	}
+
+	output {
+		traces = [otelcol.exporter.otlp.tempo.input]
+	}
+}
+
+// beyla.ebpf exposes its RED metrics as a Prometheus scrape target rather
+// than pushing them directly. Pull them into the pipeline here.
+prometheus.scrape "beyla" {
+	targets      = beyla.ebpf.default.targets
+	honor_labels = true
+	forward_to   = [prometheus.remote_write.default.receiver]
+}
+
+// Send the scraped RED metrics to Prometheus.
+prometheus.remote_write "default" {
+	endpoint {
+		url = "http://prometheus:9090/api/v1/write"
+	}
+}
+
+// Send the auto-generated traces to Tempo for storage and visualization.
+otelcol.exporter.otlp "tempo" {
+	client {
+		endpoint = "tempo:4317"
+		tls {
+			insecure = true
+		}
+	}
+}

--- a/beyla-zero-code-instrumentation/docker-compose.coda.yml
+++ b/beyla-zero-code-instrumentation/docker-compose.coda.yml
@@ -9,7 +9,7 @@ services:
     restart: unless-stopped
 
   loadgen:
-    image: curlimages/curl:${CURL_VERSION:-8.20.0}
+    image: curlimages/curl:${CURL_VERSION:-8.21.0}
     entrypoint:
       - sh
       - -c

--- a/beyla-zero-code-instrumentation/docker-compose.coda.yml
+++ b/beyla-zero-code-instrumentation/docker-compose.coda.yml
@@ -1,0 +1,27 @@
+services:
+  demo-app:
+    image: golang:1.24@sha256:d2d2bc1c84f7e60d7d2438a3836ae7d0c847f4888464e7ec9ba3a1339a1ee804
+    volumes:
+      - ./app:/app
+    working_dir: /app
+    command: go run .
+    network_mode: host
+    restart: unless-stopped
+
+  loadgen:
+    image: curlimages/curl:${CURL_VERSION:-8.20.0}
+    entrypoint:
+      - sh
+      - -c
+      - |
+        until curl -s -o /dev/null --max-time 2 http://localhost:8080/; do sleep 1; done
+        while true; do
+          curl -s -o /dev/null http://localhost:8080/
+          curl -s -o /dev/null http://localhost:8080/orders
+          curl -s -o /dev/null http://localhost:8080/orders/1
+          curl -s -o /dev/null http://localhost:8080/orders/99
+          curl -s -o /dev/null -X POST http://localhost:8080/checkout
+          sleep 1
+        done
+    network_mode: host
+    restart: unless-stopped

--- a/beyla-zero-code-instrumentation/docker-compose.yml
+++ b/beyla-zero-code-instrumentation/docker-compose.yml
@@ -18,7 +18,7 @@ services:
   # Generates continuous HTTP traffic against demo-app so beyla.ebpf has
   # requests to turn into traces and RED metrics.
   loadgen:
-    image: curlimages/curl:${CURL_VERSION:-8.20.0}
+    image: curlimages/curl:${CURL_VERSION:-8.21.0}
     entrypoint:
       - sh
       - -c
@@ -39,7 +39,7 @@ services:
   # Alloy with beyla.ebpf. Needs privileged mode to load eBPF programs and
   # demo-app's PID namespace to see its process and attach probes to it.
   alloy:
-    image: grafana/alloy:${GRAFANA_ALLOY_VERSION:-v1.17.0}
+    image: grafana/alloy:${GRAFANA_ALLOY_VERSION:-v1.17.1}
     privileged: true
     pid: "service:demo-app"
     ports:
@@ -54,7 +54,7 @@ services:
 
   # Prometheus stores the RED metrics beyla.ebpf produces.
   prometheus:
-    image: prom/prometheus:${PROMETHEUS_VERSION:-v3.11.3}
+    image: prom/prometheus:${PROMETHEUS_VERSION:-v3.13.0}
     command:
       - --web.enable-remote-write-receiver
       - --config.file=/etc/prometheus/prometheus.yml
@@ -74,7 +74,7 @@ services:
 
   # Grafana for visualization
   grafana:
-    image: grafana/grafana:${GRAFANA_VERSION:-13.0.2}
+    image: grafana/grafana:${GRAFANA_VERSION:-13.1.0}
     environment:
       - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
       - GF_AUTH_ANONYMOUS_ENABLED=true

--- a/beyla-zero-code-instrumentation/docker-compose.yml
+++ b/beyla-zero-code-instrumentation/docker-compose.yml
@@ -1,0 +1,114 @@
+services:
+  # Target service for zero-code eBPF instrumentation. A plain Go HTTP API
+  # with no OpenTelemetry SDK, no agent, and no metrics library — beyla.ebpf
+  # instruments it entirely from the outside. Built from the official,
+  # multi-arch golang image so it runs natively on amd64 and arm64. Pinned
+  # to 1.24: the beyla.ebpf build in Alloy v1.17.0 can't yet read the Go
+  # runtime's internal goroutine offsets for 1.26, which silently drops
+  # every trace and RED metric with no attach errors surfaced.
+  demo-app:
+    image: golang:1.24@sha256:d2d2bc1c84f7e60d7d2438a3836ae7d0c847f4888464e7ec9ba3a1339a1ee804
+    volumes:
+      - ./app:/app
+    working_dir: /app
+    command: go run .
+    ports:
+      - 8080:8080
+
+  # Generates continuous HTTP traffic against demo-app so beyla.ebpf has
+  # requests to turn into traces and RED metrics.
+  loadgen:
+    image: curlimages/curl:${CURL_VERSION:-8.20.0}
+    entrypoint:
+      - sh
+      - -c
+      - |
+        until curl -s -o /dev/null --max-time 2 http://demo-app:8080/; do sleep 1; done
+        while true; do
+          curl -s -o /dev/null http://demo-app:8080/
+          curl -s -o /dev/null http://demo-app:8080/orders
+          curl -s -o /dev/null http://demo-app:8080/orders/1
+          curl -s -o /dev/null http://demo-app:8080/orders/99
+          curl -s -o /dev/null -X POST http://demo-app:8080/checkout
+          sleep 1
+        done
+    depends_on:
+      - demo-app
+    restart: unless-stopped
+
+  # Alloy with beyla.ebpf. Needs privileged mode to load eBPF programs and
+  # demo-app's PID namespace to see its process and attach probes to it.
+  alloy:
+    image: grafana/alloy:${GRAFANA_ALLOY_VERSION:-v1.17.0}
+    privileged: true
+    pid: "service:demo-app"
+    ports:
+      - 12345:12345
+    volumes:
+      - ./config.alloy:/etc/alloy/config.alloy
+    command: run --server.http.listen-addr=0.0.0.0:12345 --storage.path=/var/lib/alloy/data /etc/alloy/config.alloy
+    depends_on:
+      - demo-app
+      - prometheus
+      - tempo
+
+  # Prometheus stores the RED metrics beyla.ebpf produces.
+  prometheus:
+    image: prom/prometheus:${PROMETHEUS_VERSION:-v3.11.3}
+    command:
+      - --web.enable-remote-write-receiver
+      - --config.file=/etc/prometheus/prometheus.yml
+    ports:
+      - 9090:9090/tcp
+    volumes:
+      - ./prom-config.yaml:/etc/prometheus/prometheus.yml
+
+  # Tempo stores the traces beyla.ebpf produces.
+  tempo:
+    image: grafana/tempo:${GRAFANA_TEMPO_VERSION:-2.10.7}
+    command: ["-config.file=/etc/tempo.yaml"]
+    ports:
+      - 3200:3200/tcp
+    volumes:
+      - ./tempo-config.yaml:/etc/tempo.yaml
+
+  # Grafana for visualization
+  grafana:
+    image: grafana/grafana:${GRAFANA_VERSION:-13.0.2}
+    environment:
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_BASIC_ENABLED=false
+      - GF_INSTALL_PLUGINS=https://storage.googleapis.com/integration-artifacts/grafana-exploretraces-app/grafana-exploretraces-app-latest.zip;grafana-traces-app
+    ports:
+      - 3000:3000/tcp
+    entrypoint:
+      - sh
+      - -euc
+      - |
+        mkdir -p /etc/grafana/provisioning/datasources
+        cat <<EOF > /etc/grafana/provisioning/datasources/ds.yaml
+        apiVersion: 1
+        datasources:
+        - name: Prometheus
+          type: prometheus
+          orgId: 1
+          url: http://prometheus:9090
+          basicAuth: false
+          isDefault: true
+          version: 1
+          editable: false
+        - name: Tempo
+          type: tempo
+          access: proxy
+          orgId: 1
+          url: http://tempo:3200
+          basicAuth: false
+          isDefault: false
+          version: 1
+          editable: false
+        EOF
+        /run.sh
+    depends_on:
+      - prometheus
+      - tempo

--- a/beyla-zero-code-instrumentation/prom-config.yaml
+++ b/beyla-zero-code-instrumentation/prom-config.yaml
@@ -1,0 +1,9 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+# Scrape Alloy's own metrics for troubleshooting the beyla.ebpf pipeline.
+scrape_configs:
+  - job_name: 'alloy'
+    static_configs:
+      - targets: ['alloy:12345']

--- a/beyla-zero-code-instrumentation/tempo-config.yaml
+++ b/beyla-zero-code-instrumentation/tempo-config.yaml
@@ -1,0 +1,26 @@
+stream_over_http_enabled: true
+server:
+  http_listen_port: 3200
+  log_level: info
+
+distributor:
+  receivers:
+    otlp:
+      protocols:
+        grpc:
+          endpoint: "tempo:4317"
+
+ingester:
+  max_block_duration: 5m               # cut the headblock when this much time passes. set for demo purposes
+
+compactor:
+  compaction:
+    block_retention: 720h              # overall Tempo trace retention. set for demo purposes
+
+storage:
+  trace:
+    backend: local
+    wal:
+      path: /var/tempo/wal
+    local:
+      path: /var/tempo/blocks


### PR DESCRIPTION
## Summary

- Adds a new scenario demonstrating zero-code eBPF auto-instrumentation with `beyla.ebpf`: Alloy attaches eBPF probes to an unmodified Go HTTP service and produces RED metrics (Prometheus) and traces (Tempo) with no SDK, agent, or code change.
- Pins the demo app to Go 1.24. Live testing during development found that Go 1.26 binaries are silently unsupported by the OBI/Beyla build bundled in Alloy v1.17.0: `beyla.ebpf` reports the process as instrumented and logs no fatal error, but every trace and RED metric is dropped because it can't read that Go version's runtime-internal goroutine offsets (`can't read newproc1 invocation metadata` in debug logs). Go 1.22 and 1.24 were verified working end to end. This gotcha is documented in the README's troubleshoot section so anyone forking the scenario for their own service hits it faster.
- Adds the scenario to the root README's Tracing table.

Closes #273

## Test plan

- [x] `docker compose config -q` and `docker compose -f docker-compose.coda.yml config -q` validate
- [x] `docker compose up -d` brings up `alloy`, `demo-app`, `loadgen`, `prometheus`, `tempo`, `grafana` cleanly on Docker Desktop for Mac (Apple Silicon)
- [x] Verified live: `beyla.ebpf` attaches to `demo-app`, Tempo receives real spans (`GET /`, `GET /orders`, `GET /orders/`, `POST /checkout`, including error spans), Prometheus receives `http_server_request_duration_seconds` RED metrics with correct `http_route`/`http_response_status_code` labels including the deliberate 404 and simulated 500s
- [x] Grafana provisions Prometheus and Tempo data sources with no login required

🤖 Generated with [Claude Code](https://claude.com/claude-code)