### PR TITLE
New scenario: azure-event-hubs-logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ These scenarios focus on log collection, log parsing, log routing, and log redac
 | Scenario | Description |
 | -------- | ----------- |
 | [Amazon Data Firehose logs](aws-firehose-logs/) | Ingest Amazon Data Firehose deliveries with `loki.source.awsfirehose`. Uses a local sender. No AWS account required. |
+| [Azure Event Hubs logs](azure-event-hubs-logs/) | Ingest Azure Event Hubs messages with `loki.source.azure_event_hubs`. Uses a self-hosted broker speaking the same wire protocol. No Azure subscription required. |
 | [GELF log ingestion](gelf-log-ingestion/) | Ingest Graylog Extended Log Format logs over `UDP`. |
 | [Kafka logs](kafka/) | Consume and process logs from Apache Kafka topics. |
 | [Log API gateway](log-api-gateway/) | Use Alloy as a centralized log gateway that accepts logs via a Loki-compatible push API endpoint. |

--- a/azure-event-hubs-logs/README.md
+++ b/azure-event-hubs-logs/README.md
@@ -5,18 +5,6 @@ Azure Diagnostic Settings stream Activity Log records to an event hub in product
 You don't need an Azure subscription.
 Alloy consumes the event hub's Kafka-compatible endpoint and forwards each record to Loki as a log line.
 The `config.alloy` file defines the pipeline.
-Complexity: medium.
-
-## Why this scenario doesn't use the official emulator
-
-Microsoft ships an official Event Hubs emulator (`mcr.microsoft.com/azure-messaging/eventhubs-emulator`) for offline development, and this scenario originally tried it.
-`loki.source.azure_event_hubs` connects to Event Hubs over its Kafka-compatible endpoint, and both of the component's authentication mechanisms hardcode TLS on that Kafka connection.
-The official emulator's Kafka port only speaks plaintext `SASL_PLAINTEXT` — it doesn't terminate TLS at all.
-Pointing Alloy at the emulator fails immediately: Alloy's TLS handshake bytes reach a plaintext listener, and the emulator resets the connection.
-
-Since there's no way to disable TLS on `loki.source.azure_event_hubs`, this scenario runs a self-hosted single-node Kafka broker (the `eventhub` service) configured to speak the exact wire protocol Azure Event Hubs uses on its real Kafka endpoint: TLS with SASL PLAIN authentication, using the literal username `$ConnectionString` that real Event Hubs also expects.
-A `cert-init` step generates a throwaway CA and certificate so the broker has something to terminate TLS with, and Alloy trusts that CA before it starts.
-The result behaves identically to a real Event Hubs namespace's Kafka endpoint from Alloy's point of view, without needing an Azure subscription or the official emulator.
 
 ## Before you begin
 
@@ -33,18 +21,18 @@ Ensure you have the following:
 A generator script produces fake Azure Activity Log records and publishes them to a self-hosted broker that speaks the same protocol as Azure Event Hubs' Kafka endpoint. Alloy consumes them and forwards parsed log lines to Loki.
 
 ```text
-+--------------+  produce   +-----------+  consume   +----------------------------+  push  +------+  query  +---------+
-| log-producer |----------->| eventhub  |<-----------| loki.source.azure_event_hubs |------>| Loki |<--------| Grafana |
-+--------------+            +-----------+            +----------------------------+        +------+         +---------+
++--------------+  produce   +-----------+  consume   +------------------------------+  push  +------+  query  +---------+
+| log-producer |----------->| eventhub  |<-----------| loki.source.azure_event_hubs |------->| Loki |<--------| Grafana |
++--------------+            +-----------+            +------------------------------+        +------+         +---------+
 ```
 
-- **cert-init** generates a throwaway CA, a TLS certificate for the `eventhub` broker, and a truststore, then writes them to a shared volume. It runs once and exits.
-- **eventhub** is a single-node Kafka broker (KRaft mode) with a `SASL_SSL` listener. It requires SASL PLAIN authentication with username `$ConnectionString`, matching real Azure Event Hubs' Kafka endpoint.
-- **topic-init** pre-creates the `insights-activity-logs` topic with two partitions, then exits.
-- **log-producer** generates a fake Activity Log JSON record every three seconds and publishes it to `insights-activity-logs`.
-- **Alloy** trusts the `cert-init` CA, then runs `loki.source.azure_event_hubs` to consume `insights-activity-logs` and forward records to `loki.write.local`.
-- **Loki** stores the log lines.
-- **Grafana** queries logs with a provisioned Loki data source.
+- **cert-init**: Generates a throwaway CA, a TLS certificate for the `eventhub` broker, and a truststore, then writes them to a shared volume. It runs once and exits.
+- **eventhub**: A single-node Kafka broker (KRaft mode) with a `SASL_SSL` listener. It requires SASL PLAIN authentication with username `$ConnectionString`, matching real Azure Event Hubs' Kafka endpoint.
+- **topic-init**: Creates the `insights-activity-logs` topic with two partitions, then exits.
+- **log-producer**: Generates a fake Activity Log JSON record every three seconds and publishes it to `insights-activity-logs`.
+- **Alloy**: Trusts the `cert-init` CA, then runs `loki.source.azure_event_hubs` to consume `insights-activity-logs` and forward records to `loki.write.local`.
+- **Loki**: Stores the log lines.
+- **Grafana**: Queries logs with a provisioned Loki data source.
 
 Each Activity Log record carries `resourceId`, `operationName`, `category`, `resultType`, `level`, and `correlationId` fields, matching the shape of a real Azure Activity Log entry.
 
@@ -81,7 +69,7 @@ Each Activity Log record carries `resourceId`, `operationName`, `category`, `res
 
 The `eventhub` broker doesn't expose a host port. Only containers on the compose network talk to it.
 
-## Understand the configuration
+## Understand the Alloy pipeline
 
 The `config.alloy` pipeline has two components:
 
@@ -131,7 +119,7 @@ The `loki.write` block stays the same for the self-hosted broker and real Event 
 
 ## Troubleshoot common problems
 
-Use these steps when logs don't appear or ports conflict.
+Diagnose missing logs, container restarts, and port conflicts.
 
 ### No logs appear in Grafana after 30 seconds
 
@@ -161,7 +149,8 @@ A few things work differently from production:
 ## Stop the scenario
 
 Run `docker compose down` from the scenario directory.
-Run `docker compose down -v` to also remove the generated certificates, so the next `docker compose up` regenerates them.
+Run `docker compose down -v` to remove the generated certificates
+The next `docker compose up` regenerates the certificates.
 
 ## Next steps
 

--- a/azure-event-hubs-logs/README.md
+++ b/azure-event-hubs-logs/README.md
@@ -1,0 +1,170 @@
+# Azure Event Hubs logs
+
+This scenario shows how to ingest Azure Event Hubs messages with `loki.source.azure_event_hubs`.
+Azure Diagnostic Settings stream Activity Log records to an event hub in production, and this scenario emulates that producer with a small script.
+You don't need an Azure subscription.
+Alloy consumes the event hub's Kafka-compatible endpoint and forwards each record to Loki as a log line.
+The `config.alloy` file defines the pipeline.
+Complexity: medium.
+
+## Why this scenario doesn't use the official emulator
+
+Microsoft ships an official Event Hubs emulator (`mcr.microsoft.com/azure-messaging/eventhubs-emulator`) for offline development, and this scenario originally tried it.
+`loki.source.azure_event_hubs` connects to Event Hubs over its Kafka-compatible endpoint, and both of the component's authentication mechanisms hardcode TLS on that Kafka connection.
+The official emulator's Kafka port only speaks plaintext `SASL_PLAINTEXT` — it doesn't terminate TLS at all.
+Pointing Alloy at the emulator fails immediately: Alloy's TLS handshake bytes reach a plaintext listener, and the emulator resets the connection.
+
+Since there's no way to disable TLS on `loki.source.azure_event_hubs`, this scenario runs a self-hosted single-node Kafka broker (the `eventhub` service) configured to speak the exact wire protocol Azure Event Hubs uses on its real Kafka endpoint: TLS with SASL PLAIN authentication, using the literal username `$ConnectionString` that real Event Hubs also expects.
+A `cert-init` step generates a throwaway CA and certificate so the broker has something to terminate TLS with, and Alloy trusts that CA before it starts.
+The result behaves identically to a real Event Hubs namespace's Kafka endpoint from Alloy's point of view, without needing an Azure subscription or the official emulator.
+
+## Before you begin
+
+Ensure you have the following:
+
+- [Docker][docker] and [Docker Compose][docker-compose].
+- Ports 3000 for Grafana, 3100 for Loki, and 12345 for Alloy free on the host.
+
+[docker]: https://docs.docker.com/get-docker/
+[docker-compose]: https://docs.docker.com/compose/install/
+
+## Understand the architecture
+
+A generator script produces fake Azure Activity Log records and publishes them to a self-hosted broker that speaks the same protocol as Azure Event Hubs' Kafka endpoint. Alloy consumes them and forwards parsed log lines to Loki.
+
+```text
++--------------+  produce   +-----------+  consume   +----------------------------+  push  +------+  query  +---------+
+| log-producer |----------->| eventhub  |<-----------| loki.source.azure_event_hubs |------>| Loki |<--------| Grafana |
++--------------+            +-----------+            +----------------------------+        +------+         +---------+
+```
+
+- **cert-init** generates a throwaway CA, a TLS certificate for the `eventhub` broker, and a truststore, then writes them to a shared volume. It runs once and exits.
+- **eventhub** is a single-node Kafka broker (KRaft mode) with a `SASL_SSL` listener. It requires SASL PLAIN authentication with username `$ConnectionString`, matching real Azure Event Hubs' Kafka endpoint.
+- **topic-init** pre-creates the `insights-activity-logs` topic with two partitions, then exits.
+- **log-producer** generates a fake Activity Log JSON record every three seconds and publishes it to `insights-activity-logs`.
+- **Alloy** trusts the `cert-init` CA, then runs `loki.source.azure_event_hubs` to consume `insights-activity-logs` and forward records to `loki.write.local`.
+- **Loki** stores the log lines.
+- **Grafana** queries logs with a provisioned Loki data source.
+
+Each Activity Log record carries `resourceId`, `operationName`, `category`, `resultType`, `level`, and `correlationId` fields, matching the shape of a real Azure Activity Log entry.
+
+## Run the scenario
+
+1. Clone the repository if you haven't already: `git clone https://github.com/grafana/alloy-scenarios.git`
+
+2. Install the scenario with one of these options:
+
+   **Option 1: From the scenario directory**
+
+   Use the default image tags in `docker-compose.yml`.
+
+   - Navigate to this scenario: `cd alloy-scenarios/azure-event-hubs-logs`
+   - Deploy the scenario: `docker compose up -d`
+
+   **Option 2: From the repository root**
+
+   Use pinned image versions from `image-versions.env`.
+
+   - Deploy the scenario: `./run-example.sh azure-event-hubs-logs`
+
+3. Check that all containers are up: `cd alloy-scenarios/azure-event-hubs-logs && docker compose ps`
+
+   Expect `eventhub`, `log-producer`, `alloy`, `loki`, and `grafana` running, with `cert-init` and `topic-init` exited (they're one-shot setup steps).
+
+   If `eventhub` restarts once before it reports healthy, that's expected. Kafka's own SASL_SSL self-check occasionally races with KRaft's combined broker and controller bootstrap on a cold start, and it always succeeds on retry. The `restart: on-failure` policy handles this automatically.
+
+## Explore the services
+
+- **Grafana** at http://localhost:3000: Query logs in **Explore** with the Loki data source, with no login required.
+- **Alloy UI** at http://localhost:12345: Pipeline graph, component health, and live debug views.
+- **Loki** at http://localhost:3100: Log storage backend.
+
+The `eventhub` broker doesn't expose a host port. Only containers on the compose network talk to it.
+
+## Understand the configuration
+
+The `config.alloy` pipeline has two components:
+
+1. **`loki.source.azure_event_hubs "activity_logs"`**: Connects to `eventhub:9093`, consumes the `insights-activity-logs` event hub with consumer group `$Default`, authenticates with the `connection_string` mechanism, and forwards records to `loki.write.local`.
+2. **`loki.write "local"`**: Pushes log lines to Loki at `http://loki:3100/loki/api/v1/push`.
+
+The `connection_string` argument holds whatever value the broker's SASL PLAIN password check expects — in production, this is your real Event Hubs namespace connection string. Here it's a fixed placeholder value that the self-hosted broker matches.
+`livedebugging` is enabled.
+
+## Try it out
+
+1. Wait about ten seconds after bring-up for the producer to publish its first records and for Alloy to consume them.
+
+2. Open Grafana **Explore**, select the **Loki** data source, and try these LogQL queries:
+
+   - `{job="loki.source.azure_event_hubs"}`: all records consumed from the event hub
+   - `{job="loki.source.azure_event_hubs"} | json | category="Administrative"`: administrative operations only
+   - `{job="loki.source.azure_event_hubs"} | json | level="Error"`: error-level records
+   - `{job="loki.source.azure_event_hubs"} | json | resultType="Failure"`: failed operations
+
+3. Open the Alloy UI at http://localhost:12345 and use live debug on `loki.source.azure_event_hubs.activity_logs` to watch records flow through the pipeline.
+
+## Customize the scenario
+
+To point this scenario at a real Azure Event Hubs namespace instead of the self-hosted broker:
+
+1. Remove the `cert-init`, `eventhub`, `topic-init`, and `log-producer` services from `docker-compose.yml`, along with the `eh-certs` volume and the CA-trust step in the `alloy` service's entrypoint.
+2. Update `config.alloy`:
+
+   ```alloy
+   loki.source.azure_event_hubs "activity_logs" {
+   	fully_qualified_namespace = "<your-namespace>.servicebus.windows.net:9093"
+   	event_hubs                = ["<your-event-hub-name>"]
+   	forward_to                = [loki.write.local.receiver]
+
+   	authentication {
+   		mechanism = "oauth"
+   	}
+   }
+   ```
+
+   Use `mechanism = "connection_string"` with a real `connection_string` argument instead of `oauth` if you'd rather authenticate with a shared access key.
+
+3. If you use `oauth`, make sure the Alloy host has Azure AD credentials available, for example through a managed identity or `az login`.
+
+The `loki.write` block stays the same for the self-hosted broker and real Event Hubs.
+
+## Troubleshoot common problems
+
+Use these steps when logs don't appear or ports conflict.
+
+### No logs appear in Grafana after 30 seconds
+
+Check that `log-producer` is running with `docker compose ps`. Read its output with `docker compose logs log-producer` — it should print `>` prompts from `kafka-console-producer.sh` with no errors.
+Check that `eventhub` reports healthy with `docker compose ps`.
+Open the Alloy UI at http://localhost:12345 and check that `loki.source.azure_event_hubs.activity_logs` is healthy and consuming.
+
+### The eventhub container keeps restarting
+
+One restart on cold start is expected — refer to [Run the scenario](#run-the-scenario). If it restarts more than two or three times, check `docker compose logs eventhub` for the underlying error and check that `cert-init` exited successfully (`docker compose ps cert-init`) before `eventhub` started.
+
+### Port conflicts with other services
+
+Ports 3000, 3100, and 12345 must be free before you start the stack.
+If another service uses one of these ports, edit the port mapping in `docker-compose.yml` before you run `docker compose up -d`.
+
+## Differences from real Azure Event Hubs
+
+This scenario emulates Azure Event Hubs' Kafka wire protocol rather than using a real namespace.
+A few things work differently from production:
+
+- **Authentication**: Real Event Hubs validates the SAS key in your connection string against the namespace's actual access policy. The self-hosted broker only checks that the password matches a fixed placeholder value, so any connection string with the right shape "works."
+- **Single broker, single namespace**: Real Event Hubs runs as a managed, multi-tenant service with per-namespace throughput units and multiple partitions replicated across the service. The self-hosted broker is one container with one topic and two partitions.
+- **TLS trust**: Real Event Hubs presents a certificate signed by a public CA that your OS already trusts. This scenario generates its own CA and certificate on every `docker compose up`, and installs that CA into the Alloy container's trust store — that step isn't needed against real Event Hubs.
+- **Why any of this exists**: `loki.source.azure_event_hubs` hardcodes TLS with no argument to disable it. The official Azure Event Hubs emulator's Kafka listener doesn't support TLS, so it can't stand in for a real namespace with this component. The self-hosted broker exists specifically to give the component something that speaks Azure Event Hubs' actual wire protocol without needing a real Azure subscription.
+
+## Stop the scenario
+
+Run `docker compose down` from the scenario directory.
+Run `docker compose down -v` to also remove the generated certificates, so the next `docker compose up` regenerates them.
+
+## Next steps
+
+- `loki.source.azure_event_hubs` reference: https://grafana.com/docs/alloy/latest/reference/components/loki/loki.source.azure_event_hubs/
+- Amazon Data Firehose logs scenario: [../aws-firehose-logs/](../aws-firehose-logs/) — another scenario that emulates a cloud log-delivery producer without a real cloud account
+- Kafka logs scenario: [../kafka/](../kafka/) — a plaintext Kafka pipeline with `loki.source.kafka`

--- a/azure-event-hubs-logs/certgen/generate.sh
+++ b/azure-event-hubs-logs/certgen/generate.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Generates a throwaway CA + server certificate for the "eventhub" broker and a
+# PKCS12 truststore for clients, then writes a ready-to-use client.properties.
+#
+# loki.source.azure_event_hubs hardcodes TLS on its Kafka connection (see
+# README "Why a self-hosted broker"), so the broker needs a real TLS listener
+# -- these certs exist purely to satisfy that, not for any security purpose.
+set -euo pipefail
+cd /certs
+
+openssl genrsa -out ca.key 2048 2>/dev/null
+openssl req -x509 -new -nodes -key ca.key -sha256 -days 3650 -out ca.crt -subj "/CN=alloy-demo-ca"
+
+openssl genrsa -out broker.key 2048 2>/dev/null
+openssl req -new -key broker.key -out broker.csr -subj "/CN=eventhub" \
+  -addext "subjectAltName=DNS:eventhub,DNS:localhost"
+openssl x509 -req -in broker.csr -CA ca.crt -CAkey ca.key -CAcreateserial \
+  -out broker.crt -days 3650 -sha256 \
+  -extfile <(printf "subjectAltName=DNS:eventhub,DNS:localhost")
+
+cat broker.crt ca.crt > broker-chain.crt
+openssl pkcs12 -export -in broker-chain.crt -inkey broker.key \
+  -out broker.p12 -name eventhub -passout pass:brokerpass
+
+keytool -importcert -alias ca -keystore truststore.p12 -storetype PKCS12 \
+  -storepass trustpass -file ca.crt -noprompt
+
+printf "brokerpass" > keystore_creds
+printf "brokerpass" > key_creds
+
+cat > client.properties << 'EOF'
+security.protocol=SASL_SSL
+sasl.mechanism=PLAIN
+sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username="$ConnectionString" password="SAS_KEY_VALUE";
+ssl.truststore.location=/etc/kafka/secrets/truststore.p12
+ssl.truststore.password=trustpass
+ssl.truststore.type=PKCS12
+EOF
+
+chmod 644 /certs/*
+echo "certificates generated"

--- a/azure-event-hubs-logs/config.alloy
+++ b/azure-event-hubs-logs/config.alloy
@@ -1,0 +1,28 @@
+// Azure Event Hubs -> Loki, no Azure subscription required.
+//
+// loki.source.azure_event_hubs is a Kafka consumer pointed at Event Hubs'
+// Kafka-compatible endpoint. The "eventhub" service in this scenario is a
+// self-hosted broker speaking that same wire protocol (TLS + SASL PLAIN,
+// username "$ConnectionString") -- see the README for why the official
+// Microsoft emulator can't be used here. A small producer container fakes
+// Azure Activity Log records flowing in from Diagnostic Settings.
+
+livedebugging { enabled = true }
+
+loki.source.azure_event_hubs "activity_logs" {
+	fully_qualified_namespace = "eventhub:9093"
+	event_hubs                = ["insights-activity-logs"]
+	group_id                  = "$Default"
+	forward_to                = [loki.write.local.receiver]
+
+	authentication {
+		mechanism         = "connection_string"
+		connection_string = "SAS_KEY_VALUE"
+	}
+}
+
+loki.write "local" {
+	endpoint {
+		url = "http://loki:3100/loki/api/v1/push"
+	}
+}

--- a/azure-event-hubs-logs/docker-compose.yml
+++ b/azure-event-hubs-logs/docker-compose.yml
@@ -1,0 +1,157 @@
+services:
+  # One-shot: generates a throwaway CA + TLS cert for the eventhub broker.
+  # loki.source.azure_event_hubs hardcodes TLS, so the broker needs a real
+  # TLS listener even though this is a fully offline demo.
+  cert-init:
+    image: apache/kafka:${APACHE_KAFKA_VERSION:-4.3.1}
+    entrypoint: ["bash", "/certgen/generate.sh"]
+    volumes:
+      - ./certgen/generate.sh:/certgen/generate.sh:ro
+      - eh-certs:/certs
+
+  # A self-hosted Kafka broker configured to speak Azure Event Hubs' exact
+  # Kafka-endpoint wire protocol (TLS + SASL PLAIN, username
+  # "$ConnectionString"). See the README for why the official Microsoft
+  # emulator doesn't work with loki.source.azure_event_hubs.
+  eventhub:
+    image: apache/kafka:${APACHE_KAFKA_VERSION:-4.3.1}
+    volumes:
+      - eh-certs:/etc/kafka/secrets:ro
+    environment:
+      KAFKA_NODE_ID: "0"
+      KAFKA_PROCESS_ROLES: broker,controller
+      KAFKA_CONTROLLER_QUORUM_VOTERS: "0@eventhub:9094"
+      KAFKA_LISTENERS: SASL_SSL://:9093,CONTROLLER://:9094
+      KAFKA_ADVERTISED_LISTENERS: SASL_SSL://eventhub:9093
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: CONTROLLER:PLAINTEXT,SASL_SSL:SASL_SSL
+      KAFKA_CONTROLLER_LISTENER_NAMES: CONTROLLER
+      KAFKA_INTER_BROKER_LISTENER_NAME: SASL_SSL
+      KAFKA_SASL_ENABLED_MECHANISMS: PLAIN
+      KAFKA_SASL_MECHANISM_INTER_BROKER_PROTOCOL: PLAIN
+      # "SASL_SSL" is a listener *name* here, not the security protocol map
+      # key -- the doubled underscore keeps it from being read as a
+      # property-name separator when Kafka's docker image translates
+      # KAFKA_* env vars into server.properties.
+      KAFKA_LISTENER_NAME_SASL__SSL_SASL_ENABLED_MECHANISMS: PLAIN
+      KAFKA_LISTENER_NAME_SASL__SSL_PLAIN_SASL_JAAS_CONFIG: >-
+        org.apache.kafka.common.security.plain.PlainLoginModule required
+        username="admin"
+        password="admin-secret"
+        user_$$ConnectionString="SAS_KEY_VALUE";
+      KAFKA_SSL_KEYSTORE_FILENAME: broker.p12
+      KAFKA_SSL_KEYSTORE_CREDENTIALS: keystore_creds
+      KAFKA_SSL_KEY_CREDENTIALS: key_creds
+      KAFKA_SSL_KEYSTORE_TYPE: PKCS12
+      KAFKA_SSL_CLIENT_AUTH: none
+      KAFKA_SSL_TRUSTSTORE_LOCATION: /etc/kafka/secrets/truststore.p12
+      KAFKA_SSL_TRUSTSTORE_PASSWORD: trustpass
+      KAFKA_SSL_TRUSTSTORE_TYPE: PKCS12
+      KAFKA_OPTS: "-Dkafka.docker.demo=true"
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: "1"
+      KAFKA_LOG_DIRS: /var/lib/kafka/data
+      CLUSTER_ID: alloy-eventhub-logs-cluster-001
+    healthcheck:
+      test: ["CMD", "/opt/kafka/bin/kafka-broker-api-versions.sh", "--bootstrap-server", "localhost:9093", "--command-config", "/etc/kafka/secrets/client.properties"]
+      interval: 5s
+      timeout: 10s
+      retries: 20
+    # Kafka's SASL_SSL self-check occasionally races with KRaft's combined
+    # broker+controller bootstrap on first start; it always succeeds on retry.
+    restart: on-failure
+    depends_on:
+      cert-init:
+        condition: service_completed_successfully
+
+  # One-shot: pre-creates the "event hub" (Kafka topic) so Alloy's consumer
+  # group and the producer both have something to attach to immediately.
+  topic-init:
+    image: apache/kafka:${APACHE_KAFKA_VERSION:-4.3.1}
+    volumes:
+      - eh-certs:/etc/kafka/secrets:ro
+    entrypoint:
+      - bash
+      - -c
+      - |
+        /opt/kafka/bin/kafka-topics.sh --bootstrap-server eventhub:9093 \
+          --command-config /etc/kafka/secrets/client.properties \
+          --create --if-not-exists --topic insights-activity-logs --partitions 2 --replication-factor 1
+    depends_on:
+      eventhub:
+        condition: service_healthy
+
+  # Fakes Azure Diagnostic Settings streaming Activity Log records into the
+  # event hub.
+  log-producer:
+    image: apache/kafka:${APACHE_KAFKA_VERSION:-4.3.1}
+    volumes:
+      - eh-certs:/etc/kafka/secrets:ro
+      - ./gen_log.sh:/gen_log.sh:ro
+    entrypoint: ["bash", "/gen_log.sh"]
+    depends_on:
+      topic-init:
+        condition: service_completed_successfully
+    restart: unless-stopped
+
+  loki:
+    image: grafana/loki:${GRAFANA_LOKI_VERSION:-3.7.3}
+    ports:
+      - "3100:3100"
+    volumes:
+      - ./loki-config.yaml:/etc/loki/local-config.yaml
+    command: -config.file=/etc/loki/local-config.yaml
+
+  grafana:
+    image: grafana/grafana:${GRAFANA_VERSION:-13.1.0}
+    environment:
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_BASIC_ENABLED=false
+    ports:
+      - "3000:3000/tcp"
+    entrypoint:
+      - sh
+      - -euc
+      - |
+        mkdir -p /etc/grafana/provisioning/datasources
+        cat <<EOF > /etc/grafana/provisioning/datasources/ds.yaml
+        apiVersion: 1
+        datasources:
+        - name: Loki
+          type: loki
+          access: proxy
+          orgId: 1
+          url: http://loki:3100
+          basicAuth: false
+          isDefault: true
+          version: 1
+          editable: false
+        EOF
+        /run.sh
+    depends_on:
+      - loki
+
+  alloy:
+    image: grafana/alloy:${GRAFANA_ALLOY_VERSION:-v1.17.1}
+    # loki.source.azure_event_hubs hardcodes TLS with no way to supply a
+    # custom CA, so the eventhub broker's self-signed CA has to be trusted
+    # at the OS level before Alloy starts.
+    entrypoint:
+      - sh
+      - -euc
+      - |
+        cp /etc/kafka/secrets/ca.crt /usr/local/share/ca-certificates/eventhub-ca.crt
+        update-ca-certificates
+        exec alloy run --server.http.listen-addr=0.0.0.0:12345 --storage.path=/var/lib/alloy/data /etc/alloy/config.alloy
+    ports:
+      - "12345:12345"
+    volumes:
+      - ./config.alloy:/etc/alloy/config.alloy
+      - eh-certs:/etc/kafka/secrets:ro
+    depends_on:
+      topic-init:
+        condition: service_completed_successfully
+      loki:
+        condition: service_started
+
+volumes:
+  eh-certs:

--- a/azure-event-hubs-logs/gen_log.sh
+++ b/azure-event-hubs-logs/gen_log.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+RESOURCES=(
+  "/SUBSCRIPTIONS/0f1a2b3c-demo/RESOURCEGROUPS/rg-demo/PROVIDERS/MICROSOFT.COMPUTE/VIRTUALMACHINES/vm-web-01"
+  "/SUBSCRIPTIONS/0f1a2b3c-demo/RESOURCEGROUPS/rg-demo/PROVIDERS/MICROSOFT.STORAGE/STORAGEACCOUNTS/stdemo01"
+  "/SUBSCRIPTIONS/0f1a2b3c-demo/RESOURCEGROUPS/rg-demo/PROVIDERS/MICROSOFT.SQL/SERVERS/sql-demo-01/DATABASES/orders"
+)
+OPERATIONS=(
+  "MICROSOFT.COMPUTE/VIRTUALMACHINES/WRITE"
+  "MICROSOFT.COMPUTE/VIRTUALMACHINES/RESTART/ACTION"
+  "MICROSOFT.STORAGE/STORAGEACCOUNTS/LISTKEYS/ACTION"
+  "MICROSOFT.SQL/SERVERS/DATABASES/WRITE"
+)
+LEVELS=(Informational Warning Error)
+RESULTS=(Success Failure)
+CATEGORIES=(Administrative ServiceHealth Alert)
+
+# Always running, sending fake Azure Activity Log records to the eventhub
+# broker's Kafka endpoint every three seconds.
+while true; do
+  resource=${RESOURCES[RANDOM % ${#RESOURCES[@]}]}
+  operation=${OPERATIONS[RANDOM % ${#OPERATIONS[@]}]}
+  level=${LEVELS[RANDOM % ${#LEVELS[@]}]}
+  result=${RESULTS[RANDOM % ${#RESULTS[@]}]}
+  category=${CATEGORIES[RANDOM % ${#CATEGORIES[@]}]}
+  time=$(date -u +"%Y-%m-%dT%H:%M:%S.000Z")
+  correlation_id=$(cat /proc/sys/kernel/random/uuid 2>/dev/null || echo "00000000-0000-0000-0000-000000000000")
+
+  printf '{"time":"%s","resourceId":"%s","operationName":"%s","category":"%s","resultType":"%s","level":"%s","correlationId":"%s"}\n' \
+    "$time" "$resource" "$operation" "$category" "$result" "$level" "$correlation_id"
+  sleep 3
+done | /opt/kafka/bin/kafka-console-producer.sh \
+    --bootstrap-server eventhub:9093 \
+    --command-config /etc/kafka/secrets/client.properties \
+    --topic insights-activity-logs

--- a/azure-event-hubs-logs/loki-config.yaml
+++ b/azure-event-hubs-logs/loki-config.yaml
@@ -1,0 +1,39 @@
+auth_enabled: false
+
+limits_config:
+  allow_structured_metadata: true
+  volume_enabled: true
+
+server:
+  http_listen_port: 3100
+
+common:
+  ring:
+    instance_addr: 0.0.0.0
+    kvstore:
+      store: inmemory
+  replication_factor: 1
+  path_prefix: /tmp/loki
+
+schema_config:
+  configs:
+    - from: 2020-05-15
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
+storage_config:
+  tsdb_shipper:
+    active_index_directory: /tmp/loki/index
+    cache_location: /tmp/loki/index_cache
+  filesystem:
+    directory: /tmp/loki/chunks
+
+pattern_ingester:
+  enabled: true
+
+ingester:
+  max_chunk_age: 2h

--- a/image-versions.env
+++ b/image-versions.env
@@ -63,3 +63,7 @@ DEBIAN_VERSION=bookworm-slim
 # promtail-to-alloy-migration scenario
 # renovate: datasource=docker depName=grafana/promtail
 PROMTAIL_VERSION=3.6.11
+
+# azure-event-hubs-logs scenario
+# renovate: datasource=docker depName=apache/kafka
+APACHE_KAFKA_VERSION=4.3.1


### PR DESCRIPTION
## Summary

- Adds a new `azure-event-hubs-logs` scenario demonstrating `loki.source.azure_event_hubs` ingesting Azure Activity Log-style records into Loki, with no Azure subscription required.
- The official Microsoft Event Hubs emulator (`mcr.microsoft.com/azure-messaging/eventhubs-emulator`) can't be used here: `loki.source.azure_event_hubs` hardcodes TLS on its Kafka client (both its `connection_string` and `oauth` auth mechanisms), but the emulator's Kafka listener only speaks plaintext `SASL_PLAINTEXT`. I confirmed this live — pointing Alloy at the emulator gets the TLS handshake reset immediately.
- Instead, the scenario runs a self-hosted single-node Kafka broker (`eventhub`, via `apache/kafka`) configured to speak Event Hubs' exact wire protocol: TLS + SASL PLAIN with username `$ConnectionString`. A `cert-init` step generates a throwaway CA/cert/truststore at startup, and Alloy trusts that CA via a custom entrypoint before running.
- A `log-producer` service continuously publishes fake Azure Activity Log JSON records (`resourceId`, `operationName`, `category`, `resultType`, `level`, `correlationId`) into the event hub.
- Adds `APACHE_KAFKA_VERSION` to `image-versions.env` and a row to the main `README.md` Logs table.

## Test plan

- [x] Verified end-to-end multiple times via `docker compose up -d` and `./run-example.sh azure-event-hubs-logs`: all services (`cert-init`, `eventhub`, `topic-init`, `log-producer`, `alloy`, `loki`, `grafana`) come up cleanly.
- [x] Confirmed `loki.source.azure_event_hubs` connects to the self-hosted broker and consumes the `insights-activity-logs` topic (checked Alloy logs for `consuming topic`).
- [x] Queried Loki directly and confirmed Activity Log-style records land with the expected fields.
- [x] Verified every LogQL example in the README against the running stack (`{job="loki.source.azure_event_hubs"}`, `| json | category=...`, `| json | level=...`, `| json | resultType=...`).
- [x] Confirmed the Alloy UI, Grafana, and Loki all serve traffic on their documented ports.
- [x] Re-ran the stack cold multiple times to confirm the one-shot `cert-init`/`topic-init` steps and the `eventhub` health check + `restart: on-failure` policy reliably converge (Kafka's own SASL_SSL self-check occasionally races with KRaft combined-mode bootstrap on first start — documented in the README's troubleshooting section).

Closes #270

🤖 Generated with [Claude Code](https://claude.com/claude-code)