### PR TITLE
feat: add metric-cardinality-control scenario

### DIFF
--- a/.github/scenario-list.txt
+++ b/.github/scenario-list.txt
@@ -15,6 +15,7 @@ logs-file
 logs-tcp
 mail-house
 memcached-monitoring
+metric-cardinality-control
 mongodb-monitoring
 mssql-monitoring
 mysql-monitoring

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ These scenarios collect and forward metrics with Alloy.
 | -------- | ----------- |
 | [Alloy clustering](alloy-clustering/) | Run a three-node Alloy cluster that consistent-hashes `prometheus.scrape` targets across nodes. Stop a node and its targets redistribute to the survivors within seconds. |
 | [Blackbox probing](blackbox-probing/) | Monitor endpoint availability and response times with synthetic HTTP probes. |
+| [Metric cardinality control](metric-cardinality-control/) | Compare original Prometheus metrics with a cardinality-controlled `prometheus.relabel` path that drops noisy series and volatile labels and normalizes dynamic routes. |
 | [OpenTelemetry SDK metrics across languages](app-instrumentation/metrics/opentelemetry-sdk/) | Instrument five languages with the OpenTelemetry metrics SDK and push them through Alloy to Prometheus. |
 | [Prometheus client metrics across languages](app-instrumentation/metrics/prometheus-client/) | Expose `/metrics` with native Prometheus client libraries in five languages and scrape them with Alloy. The pull-model counterpart to the OpenTelemetry SDK scenario. |
 | [OTel metrics pipeline](otel-metrics-pipeline/) | Forward OpenTelemetry metrics from applications through Alloy. Alloy batches and transforms samples before it sends them to Prometheus. |

--- a/metric-cardinality-control/README.md
+++ b/metric-cardinality-control/README.md
@@ -1,0 +1,252 @@
+# Control Prometheus metric cardinality
+
+This scenario shows how Grafana Alloy uses `prometheus.relabel` to build a cardinality-controlled Prometheus path before remote write.
+A local exporter exposes an intentionally noisy metric family and a request metric with volatile labels.
+Alloy scrapes the exporter once, keeps an original comparison path, and applies `drop`, `labeldrop`, and `replace` rules to a cardinality-controlled path.
+Prometheus stores both paths, and a provisioned Grafana dashboard compares current series with distinct series observed over a rolling window.
+The `config.alloy` file defines the pipeline.
+
+## Before you begin
+
+Ensure you have the following:
+
+- [Docker][docker] and [Docker Compose][docker-compose].
+- Ports 3000 for Grafana, 9090 for Prometheus, and 12345 for the Alloy UI free on the host.
+
+[docker]: https://docs.docker.com/get-docker/
+[docker-compose]: https://docs.docker.com/compose/install/
+
+## Compare with a related scenario
+
+The OpenTelemetry [cost control](../otel-examples/cost-control/) scenario reduces telemetry with OpenTelemetry Collector processors.
+This scenario uses the Prometheus pull model and applies native Prometheus relabel actions between scrape and remote write.
+
+## Understand the architecture
+
+Alloy scrapes one exporter and fans every sample into two labeled paths.
+
+```text
+                                         +-------------------------------+
+                                         | prometheus.relabel "before"   |
+                                      +->| add pipeline="before"         |-+
+                                      |  +-------------------------------+ |
++----------+     +------------------+ |                                    |     +------------+     +---------+
+| exporter |<----| prometheus.scrape|-+                                    +---->| Prometheus |---->| Grafana |
++----------+     +------------------+ |                                    |     +------------+     +---------+
+                                      |  +-------------------------------+ |
+                                      +->| prometheus.relabel "after"    |-+
+                                         | drop, labeldrop, and replace  |
+                                         | add pipeline="after"         |
+                                         +-------------------------------+
+```
+
+- **Exporter**: Exposes 200 stable noisy series and, after one startup gap, one request series every scrape.
+  The request's ID, query value, and numeric route value change on each scrape.
+- **Alloy**: Scrapes once and forwards each sample to both relabel components.
+  The `pipeline` label keeps the stored comparison paths distinct.
+- **Prometheus**: Receives both paths through one remote-write endpoint.
+- **Grafana**: Provides the **Metric cardinality control** dashboard with current and rolling comparisons.
+
+The exporter leaves the request family absent for its first scrape after startup so Alloy can mark any request series retained across an exporter restart as stale before a new series appears.
+It then alternates between the retained `checkout` and `search` operations.
+Their `/orders/<ID>` and `/users/<ID>` routes normalize to different route templates.
+This keeps each current sample distinct from the previous raw series' stale marker after relabeling.
+Relabeling rewrites labels but doesn't aggregate samples, so this fixture avoids producing duplicate output label sets at one scrape timestamp.
+
+## Run the scenario
+
+1. Clone the repository if you haven't already, then enter its root directory:
+
+   ```sh
+   git clone https://github.com/grafana/alloy-scenarios.git
+   cd alloy-scenarios
+   ```
+
+2. Install the scenario with one of these options:
+
+   **Option 1: From the scenario directory**
+
+   Use the default image tags in `docker-compose.yml`.
+
+   ```sh
+   cd metric-cardinality-control
+   docker compose up -d
+   ```
+
+   **Option 2: From the repository root**
+
+   Use pinned image versions from `image-versions.env`.
+
+   ```sh
+   ./run-example.sh metric-cardinality-control
+   cd metric-cardinality-control
+   ```
+
+3. Check that all containers are running:
+
+   ```sh
+   docker compose ps
+   ```
+
+   Expect `exporter`, `alloy`, `prometheus`, and `grafana`.
+
+## Explore the services
+
+- **Grafana** at http://localhost:3000: Open **Dashboards**, then open **Metric cardinality control**. No login is required.
+- **Prometheus** at http://localhost:9090: Run the comparison queries directly.
+- **Alloy UI** at http://localhost:12345: Inspect the component graph and live-debug the two relabel paths.
+
+After three successful scrapes, the dashboard should show these patterns:
+
+- **Current demo series**: 201 series in `before` and one series in `after`.
+  The `drop` rule removes all 200 noisy series from `after`.
+- **Unique demo series observed over 5m**: The `before` value grows as volatile request labels create new identities.
+  The `after` request identities remain bounded by the two normalized operations and routes.
+- **Current request labels**: The before table includes raw `request_id`, `query`, and route values.
+  The after table omits `request_id` and `query` and shows `/orders/:id` or `/users/:id`.
+
+## Understand the configuration
+
+The Alloy pipeline contains four components:
+
+1. **`prometheus.scrape "cardinality_demo"`**: Scrapes `exporter:8000` every five seconds and forwards each sample to both relabel receivers.
+2. **`prometheus.relabel "before"`**: Preserves every scraped sample and adds `pipeline="before"`.
+3. **`prometheus.relabel "after"`**: Applies these rules in order:
+
+   - `drop` removes the entire `cardinality_demo_noisy_series` family.
+   - `labeldrop` removes the `request_id` and `query` labels.
+   - `replace` rewrites numeric `/orders/<ID>` and `/users/<ID>` routes to bounded templates.
+   - A final rule adds `pipeline="after"` to every surviving series.
+
+4. **`prometheus.remote_write "local"`**: Sends both distinct paths to Prometheus at `http://prometheus:9090/api/v1/write`.
+
+The generated `scrape_samples_post_metric_relabeling` metric isn't used for the comparison.
+The scrape component calculates it before samples enter the separate downstream relabel components, so it has the same value in both paths.
+
+## Try it out
+
+1. Open the **Metric cardinality control** dashboard in Grafana.
+
+2. Run this instant query in Grafana **Explore** or Prometheus to count the current demo series:
+
+   ```promql
+   count by (pipeline) (
+     cardinality_demo_noisy_series{
+       job="metric-cardinality-control",
+       pipeline=~"before|after"
+     }
+     or
+     topk by (pipeline) (
+       1,
+       timestamp(
+         cardinality_demo_request_value{
+           job="metric-cardinality-control",
+           pipeline=~"before|after"
+         }
+       )
+     )
+   )
+   ```
+
+   The noisy family is emitted continuously, while `topk` selects the newest request identity in each pipeline.
+   Selecting the newest request prevents an older identity that remains query-visible after an Alloy restart from temporarily inflating the current count.
+   This query describes the demo's intended active identities; it doesn't report the total number of series in the TSDB head.
+
+3. Count distinct demo series that have a real sample in the previous five minutes:
+
+   ```promql
+   count by (pipeline) (
+     present_over_time(
+       {job="metric-cardinality-control", pipeline=~"before|after", __name__=~"cardinality_demo_.+"}[5m]
+     )
+   )
+   ```
+
+   The result ramps up after startup.
+   It measures rolling observed identities rather than all-time cardinality.
+
+4. Compare the newest request labels directly:
+
+   ```promql
+   cardinality_demo_request_value{job="metric-cardinality-control", pipeline="before"}
+   and
+   topk(
+     1,
+     timestamp(
+       cardinality_demo_request_value{job="metric-cardinality-control", pipeline="before"}
+     )
+   )
+   ```
+
+   ```promql
+   cardinality_demo_request_value{job="metric-cardinality-control", pipeline="after"}
+   and
+   topk(
+     1,
+     timestamp(
+       cardinality_demo_request_value{job="metric-cardinality-control", pipeline="after"}
+     )
+   )
+   ```
+
+5. Open the Alloy UI and select `prometheus.relabel.before` and `prometheus.relabel.after` to inspect the two paths.
+
+## Customize the scenario
+
+- **Change the noisy series count**: Edit `NOISY_SERIES_COUNT` in `app/exporter.py`, then restart the exporter.
+- **Change the rolling window**: Replace `[5m]` in the dashboard and example query with a window that covers several scrapes.
+- **Try another relabel rule**: Add a rule to `prometheus.relabel "after"`, validate the file with the same Alloy version used by the scenario, and reload the stack.
+
+Every kept sample must still have a unique final label set at each scrape timestamp.
+If a rule removes the labels that distinguish simultaneous samples or a current sample from a stale marker, Prometheus receives duplicates rather than an aggregate.
+
+The `before` path exists only for this demonstration and intentionally increases total ingestion.
+In a production cardinality-control pipeline, forward only the controlled path to remote write.
+
+## Troubleshoot common problems
+
+Use these steps when data or the dashboard doesn't look as expected.
+
+### The dashboard is empty
+
+Run `docker compose ps` and check that all four services are running.
+Open the Alloy UI and check that `prometheus.scrape.cardinality_demo` reports successful scrapes.
+Run `up{job="metric-cardinality-control"}` in Prometheus and expect one series in each pipeline.
+
+### The after route is not normalized
+
+Run the two request queries from **Try it out** and compare their `route` labels.
+Check that the exporter still emits `/orders/<ID>` and `/users/<ID>` values that match the replace rule in `config.alloy`.
+
+### Prometheus reports duplicate or out-of-order samples
+
+Check that the exporter emits only one request sample per scrape and continues to alternate its retained operation and route family.
+Don't emit multiple raw series that become the same final label set after `labeldrop` and `replace`.
+
+### A simple current-series count is temporarily high
+
+If Alloy restarts while Prometheus keeps its data, request identities from the previous scrape cache can remain query-visible for up to five minutes.
+A plain `count` over all demo series can therefore temporarily include both the old and new identities.
+The dashboard's current query avoids this by selecting the newest request identity with `topk` and `timestamp`.
+The rolling query intentionally continues to include identities observed during its five-minute window.
+
+### Port conflicts with other services
+
+Ports 3000, 9090, and 12345 must be free before you start the stack.
+If another service uses one of these ports, edit the mapping in `docker-compose.yml` before you run `docker compose up -d`.
+
+## Stop the scenario
+
+Run this command from the scenario directory:
+
+```sh
+docker compose down
+```
+
+## Next steps
+
+- `prometheus.scrape` reference: https://grafana.com/docs/alloy/latest/reference/components/prometheus/prometheus.scrape/
+- `prometheus.relabel` reference: https://grafana.com/docs/alloy/latest/reference/components/prometheus/prometheus.relabel/
+- `prometheus.remote_write` reference: https://grafana.com/docs/alloy/latest/reference/components/prometheus/prometheus.remote_write/
+- Prometheus relabel configuration: https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config
+- Related OpenTelemetry scenario: [Cost control](../otel-examples/cost-control/)

--- a/metric-cardinality-control/app/exporter.py
+++ b/metric-cardinality-control/app/exporter.py
@@ -1,0 +1,76 @@
+"""Expose deterministic metrics that demonstrate cardinality controls."""
+
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+
+NOISY_SERIES_COUNT = 200
+STARTUP_GAP_SCRAPES = 1
+
+
+class MetricsHandler(BaseHTTPRequestHandler):
+    scrape_number = 0
+
+    def do_GET(self):
+        if self.path != "/metrics":
+            self.send_error(404)
+            return
+
+        scrape_number = type(self).scrape_number
+        type(self).scrape_number += 1
+
+        lines = [
+            "# HELP cardinality_demo_noisy_series Stable noisy series dropped by the after pipeline.",
+            "# TYPE cardinality_demo_noisy_series gauge",
+        ]
+        lines.extend(
+            f'cardinality_demo_noisy_series{{series_id="series-{index:03d}"}} 1'
+            for index in range(NOISY_SERIES_COUNT)
+        )
+        lines.extend(
+            [
+                "# HELP cardinality_demo_request_value A request metric with intentionally volatile labels.",
+                "# TYPE cardinality_demo_request_value gauge",
+            ]
+        )
+
+        # Leave one successful scrape without the request family after each
+        # exporter start. If Alloy retained a raw request series across an
+        # exporter restart, this scrape carries its stale marker before a new
+        # normalized request series is introduced.
+        if scrape_number >= STARTUP_GAP_SCRAPES:
+            request_number = scrape_number - STARTUP_GAP_SCRAPES
+
+            # Alternating the retained operation and route family prevents the
+            # current sample and the previous scrape's stale marker from
+            # collapsing after request_id/query are dropped and route is
+            # normalized.
+            if request_number % 2 == 0:
+                operation = "checkout"
+                route_family = "orders"
+            else:
+                operation = "search"
+                route_family = "users"
+
+            dynamic_id = 100_000 + request_number
+            lines.append(
+                "cardinality_demo_request_value{"
+                f'operation="{operation}",'
+                f'route="/{route_family}/{dynamic_id}",'
+                f'request_id="req-{request_number:08d}",'
+                f'query="term-{request_number:08d}"'
+                "} 1"
+            )
+
+        body = ("\n".join(lines) + "\n").encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, format, *args):
+        return
+
+
+if __name__ == "__main__":
+    HTTPServer(("0.0.0.0", 8000), MetricsHandler).serve_forever()

--- a/metric-cardinality-control/config.alloy
+++ b/metric-cardinality-control/config.alloy
@@ -1,0 +1,65 @@
+livedebugging {
+	enabled = true
+}
+
+// Scrape the demo exporter once, then fan each sample into an unchanged
+// comparison branch and a cardinality-controlled branch.
+prometheus.scrape "cardinality_demo" {
+	targets = [
+		{"__address__" = "exporter:8000"},
+	]
+
+	forward_to = [
+		prometheus.relabel.before.receiver,
+		prometheus.relabel.after.receiver,
+	]
+
+	job_name        = "metric-cardinality-control"
+	scrape_interval = "5s"
+	scrape_timeout  = "4s"
+}
+
+// Keep the original demo series, adding only the comparison label.
+prometheus.relabel "before" {
+	forward_to = [prometheus.remote_write.local.receiver]
+
+	rule {
+		target_label = "pipeline"
+		replacement  = "before"
+	}
+}
+
+// Apply representative cardinality controls before remote writing the samples.
+prometheus.relabel "after" {
+	forward_to = [prometheus.remote_write.local.receiver]
+
+	rule {
+		source_labels = ["__name__"]
+		regex         = "cardinality_demo_noisy_series"
+		action        = "drop"
+	}
+
+	rule {
+		regex  = "request_id|query"
+		action = "labeldrop"
+	}
+
+	rule {
+		source_labels = ["route"]
+		regex         = "(/(orders|users))/[0-9]+"
+		target_label  = "route"
+		replacement   = "$1/:id"
+		action        = "replace"
+	}
+
+	rule {
+		target_label = "pipeline"
+		replacement  = "after"
+	}
+}
+
+prometheus.remote_write "local" {
+	endpoint {
+		url = "http://prometheus:9090/api/v1/write"
+	}
+}

--- a/metric-cardinality-control/docker-compose.coda.yml
+++ b/metric-cardinality-control/docker-compose.coda.yml
@@ -1,0 +1,9 @@
+services:
+  exporter:
+    image: python:${PYTHON_VERSION:-3.11-slim}
+    ports:
+      - 8000:8000/tcp
+    volumes:
+      - ./app/exporter.py:/app/exporter.py:ro
+    command: python3 /app/exporter.py
+    restart: unless-stopped

--- a/metric-cardinality-control/docker-compose.yml
+++ b/metric-cardinality-control/docker-compose.yml
@@ -1,0 +1,43 @@
+services:
+  # A dependency-free exporter that emits stable noisy series and, after one
+  # startup gap, a request series whose volatile labels change on every scrape.
+  exporter:
+    image: python:${PYTHON_VERSION:-3.11-slim}
+    volumes:
+      - ./app/exporter.py:/app/exporter.py:ro
+    command: python3 /app/exporter.py
+    restart: unless-stopped
+
+  alloy:
+    image: grafana/alloy:${GRAFANA_ALLOY_VERSION:-v1.17.1}
+    ports:
+      - 12345:12345/tcp
+    volumes:
+      - ./config.alloy:/etc/alloy/config.alloy:ro
+    command: run --server.http.listen-addr=0.0.0.0:12345 --storage.path=/var/lib/alloy/data /etc/alloy/config.alloy
+    depends_on:
+      - exporter
+      - prometheus
+
+  prometheus:
+    image: prom/prometheus:${PROMETHEUS_VERSION:-v3.13.0}
+    command:
+      - --web.enable-remote-write-receiver
+      - --config.file=/etc/prometheus/prometheus.yml
+    ports:
+      - 9090:9090/tcp
+    volumes:
+      - ./prom-config.yaml:/etc/prometheus/prometheus.yml:ro
+
+  grafana:
+    image: grafana/grafana:${GRAFANA_VERSION:-13.1.0}
+    environment:
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_BASIC_ENABLED=false
+    ports:
+      - 3000:3000/tcp
+    volumes:
+      - ./grafana:/etc/grafana/provisioning:ro
+    depends_on:
+      - prometheus

--- a/metric-cardinality-control/grafana/dashboards/dashboards.yaml
+++ b/metric-cardinality-control/grafana/dashboards/dashboards.yaml
@@ -1,0 +1,12 @@
+apiVersion: 1
+providers:
+  - name: 'metric-cardinality-control'
+    orgId: 1
+    folder: ''
+    type: file
+    disableDeletion: true
+    updateIntervalSeconds: 10
+    allowUiUpdates: false
+    options:
+      path: /etc/grafana/provisioning/dashboards
+      foldersFromFilesStructure: false

--- a/metric-cardinality-control/grafana/dashboards/metric-cardinality-control.json
+++ b/metric-cardinality-control/grafana/dashboards/metric-cardinality-control.json
@@ -1,0 +1,248 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": { "type": "grafana", "uid": "-- Grafana --" },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "description": "Current demo series. The query counts the continuously emitted noisy family and selects the newest request identity per pipeline so an older identity retained after an Alloy restart cannot inflate the result.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "mappings": [],
+          "min": 0,
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "before" },
+            "properties": [{ "id": "color", "value": { "fixedColor": "red", "mode": "fixed" } }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "after" },
+            "properties": [{ "id": "color", "value": { "fixedColor": "green", "mode": "fixed" } }]
+          }
+        ]
+      },
+      "gridPos": { "h": 7, "w": 12, "x": 0, "y": 0 },
+      "id": 1,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "editorMode": "code",
+          "expr": "count by (pipeline) (cardinality_demo_noisy_series{job=\"metric-cardinality-control\", pipeline=~\"before|after\"} or topk by (pipeline) (1, timestamp(cardinality_demo_request_value{job=\"metric-cardinality-control\", pipeline=~\"before|after\"})))",
+          "instant": true,
+          "legendFormat": "{{pipeline}}",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Current demo series",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "description": "Distinct demo label sets with at least one real sample in the last five minutes. This measures rolling observed cardinality, not all-time or TSDB head-series cardinality.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "mappings": [],
+          "min": 0,
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "before" },
+            "properties": [{ "id": "color", "value": { "fixedColor": "red", "mode": "fixed" } }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "after" },
+            "properties": [{ "id": "color", "value": { "fixedColor": "green", "mode": "fixed" } }]
+          }
+        ]
+      },
+      "gridPos": { "h": 7, "w": 12, "x": 12, "y": 0 },
+      "id": 2,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "editorMode": "code",
+          "expr": "count by (pipeline) (present_over_time({job=\"metric-cardinality-control\", pipeline=~\"before|after\", __name__=~\"cardinality_demo_.+\"}[5m]))",
+          "instant": true,
+          "legendFormat": "{{pipeline}}",
+          "range": false,
+          "refId": "A"
+        }
+      ],
+      "title": "Unique demo series observed over 5m",
+      "type": "stat"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "description": "Rolling request-series identities only. Dynamic request IDs, query values, and raw routes make the before path grow; label removal and route normalization keep the after path bounded.",
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "series observed over 5m",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "lineInterpolation": "stepAfter",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "min": 0,
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": { "id": "byName", "options": "before" },
+            "properties": [{ "id": "color", "value": { "fixedColor": "red", "mode": "fixed" } }]
+          },
+          {
+            "matcher": { "id": "byName", "options": "after" },
+            "properties": [{ "id": "color", "value": { "fixedColor": "green", "mode": "fixed" } }]
+          }
+        ]
+      },
+      "gridPos": { "h": 9, "w": 24, "x": 0, "y": 7 },
+      "id": 3,
+      "options": {
+        "legend": { "calcs": ["lastNotNull"], "displayMode": "table", "placement": "right", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "editorMode": "code",
+          "expr": "count by (pipeline) (present_over_time(cardinality_demo_request_value{job=\"metric-cardinality-control\", pipeline=~\"before|after\"}[5m]))",
+          "legendFormat": "{{pipeline}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Request-series churn",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "description": "The newest request sample before relabeling. Its request_id, query, and raw route values change on every scrape.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": { "align": "auto", "cellOptions": { "type": "auto" }, "filterable": true, "inspect": false },
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] }
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 16 },
+      "id": 4,
+      "options": {
+        "cellHeight": "sm",
+        "footer": { "countRows": false, "fields": "", "reducer": ["sum"], "show": false },
+        "showHeader": true
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "editorMode": "code",
+          "expr": "cardinality_demo_request_value{job=\"metric-cardinality-control\", pipeline=\"before\"} and topk(1, timestamp(cardinality_demo_request_value{job=\"metric-cardinality-control\", pipeline=\"before\"}))",
+          "format": "table",
+          "instant": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Current request labels: before",
+      "type": "table"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "description": "The newest request sample after relabeling. request_id and query are absent, and route contains a bounded template.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": { "align": "auto", "cellOptions": { "type": "auto" }, "filterable": true, "inspect": false },
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] }
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 16 },
+      "id": 5,
+      "options": {
+        "cellHeight": "sm",
+        "footer": { "countRows": false, "fields": "", "reducer": ["sum"], "show": false },
+        "showHeader": true
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "editorMode": "code",
+          "expr": "cardinality_demo_request_value{job=\"metric-cardinality-control\", pipeline=\"after\"} and topk(1, timestamp(cardinality_demo_request_value{job=\"metric-cardinality-control\", pipeline=\"after\"}))",
+          "format": "table",
+          "instant": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Current request labels: after",
+      "type": "table"
+    }
+  ],
+  "refresh": "5s",
+  "schemaVersion": 39,
+  "tags": ["alloy", "prometheus", "cardinality", "relabeling"],
+  "templating": { "list": [] },
+  "time": { "from": "now-15m", "to": "now" },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Metric cardinality control",
+  "uid": "metric-cardinality-control",
+  "version": 1,
+  "weekStart": ""
+}

--- a/metric-cardinality-control/grafana/datasources/datasources.yaml
+++ b/metric-cardinality-control/grafana/datasources/datasources.yaml
@@ -1,0 +1,11 @@
+apiVersion: 1
+datasources:
+  - name: Prometheus
+    uid: prometheus
+    type: prometheus
+    access: proxy
+    orgId: 1
+    url: http://prometheus:9090
+    isDefault: true
+    version: 1
+    editable: false

--- a/metric-cardinality-control/prom-config.yaml
+++ b/metric-cardinality-control/prom-config.yaml
@@ -1,0 +1,4 @@
+# Alloy owns scraping and sends both comparison branches to this receiver.
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s


### PR DESCRIPTION
## Summary

- Add a self-contained `metric-cardinality-control` scenario as the Prometheus-native counterpart to `otel-examples/cost-control`.
- Scrape one deterministic exporter and fan samples into labeled `before` and `after` paths. The controlled path uses `drop`, `labeldrop`, and `replace` to remove a 200-series noisy family, drop volatile labels, and normalize numeric routes before remote write.
- Design the exporter so relabeled samples retain unique output label sets; `prometheus.relabel` rewrites labels but does not aggregate samples.
- Provision local Prometheus and a Grafana dashboard comparing current series, rolling observed cardinality, request-series churn, and request label sets.
- Use scoped PromQL for the comparison because `scrape_samples_post_metric_relabeling` is produced before the downstream relabel branches and cannot show their reduction.
- Document the pipeline, expected results, customization, and troubleshooting; include full-stack and app-only Coda Compose definitions; and register the scenario in the root README and CI scenario list.

Closes #265

## Test plan

- [x] Validate `docker-compose.yml` and `docker-compose.coda.yml`, including fallbacks matching `image-versions.env`.
- [x] Run Alloy formatting and configuration validation; `config.alloy` is 65 lines.
- [x] Validate the Prometheus configuration with `promtool` and parse the dashboard JSON.
- [x] Start the full stack with `./run-example.sh metric-cardinality-control`; confirm all four services remain running and no containers exit.
- [x] Exercise the app-only workflow with `./coda start`, `./coda status`, and `./coda stop`.
- [x] Verify live PromQL results: current series are `before=201` and `after=1`; rolling request identities grow in `before` and remain bounded at `after=2`.
- [x] Verify the `after` path drops the 200-series noisy family and volatile labels and normalizes routes to `/orders/:id` or `/users/:id`.
- [x] Restart the exporter and Alloy; confirm the current comparison returns to `201/1` with zero duplicate, out-of-order, or failed remote-write samples.
- [x] Verify the Prometheus datasource and five-panel Grafana dashboard are provisioned and all panel queries return the expected results.