### PR TITLE
chore: bump OpenTelemetry JS SDK to v2 and migrate Resource API

### DIFF
--- a/app-instrumentation/metrics/opentelemetry-sdk/node/app.js
+++ b/app-instrumentation/metrics/opentelemetry-sdk/node/app.js
@@ -13,13 +13,13 @@
 const { metrics } = require('@opentelemetry/api');
 const { MeterProvider, PeriodicExportingMetricReader } = require('@opentelemetry/sdk-metrics');
 const { OTLPMetricExporter } = require('@opentelemetry/exporter-metrics-otlp-http');
-const { Resource } = require('@opentelemetry/resources');
+const { resourceFromAttributes, defaultResource } = require('@opentelemetry/resources');
 
 // Export every ~5s. docker-compose sets OTEL_METRIC_EXPORT_INTERVAL=5000 so the
 // data shows up quickly instead of waiting for the 60s SDK default.
 const exportIntervalMillis = parseInt(process.env.OTEL_METRIC_EXPORT_INTERVAL || '5000', 10);
 
-// Build the Resource from the OTEL_* environment variables. Resource.default()
+// Build the Resource from the OTEL_* environment variables. defaultResource()
 // on its own reports service.name=unknown_service, so we merge in the
 // service.name (OTEL_SERVICE_NAME) and attributes (OTEL_RESOURCE_ATTRIBUTES,
 // e.g. language=javascript) that docker-compose provides. Nothing is hardcoded.
@@ -30,7 +30,7 @@ function resourceFromEnv() {
     const idx = pair.indexOf('=');
     if (idx > 0) attrs[pair.slice(0, idx).trim()] = pair.slice(idx + 1).trim();
   }
-  return Resource.default().merge(new Resource(attrs));
+  return defaultResource().merge(resourceFromAttributes(attrs));
 }
 
 // The OTLP/HTTP exporter reads OTEL_EXPORTER_OTLP_ENDPOINT itself (e.g.

--- a/app-instrumentation/metrics/opentelemetry-sdk/node/package.json
+++ b/app-instrumentation/metrics/opentelemetry-sdk/node/package.json
@@ -8,9 +8,9 @@
   },
   "dependencies": {
     "@opentelemetry/api": "1.9.1",
-    "@opentelemetry/sdk-metrics": "1.30.1",
+    "@opentelemetry/sdk-metrics": "2.9.0",
     "@opentelemetry/exporter-metrics-otlp-http": "0.219.0",
-    "@opentelemetry/resources": "1.30.1",
+    "@opentelemetry/resources": "2.9.0",
     "@opentelemetry/semantic-conventions": "1.41.1"
   }
 }

--- a/app-instrumentation/traces/opentelemetry-sdk/node/app.js
+++ b/app-instrumentation/traces/opentelemetry-sdk/node/app.js
@@ -13,9 +13,9 @@
 const { trace, SpanStatusCode } = require('@opentelemetry/api');
 const { NodeTracerProvider, BatchSpanProcessor } = require('@opentelemetry/sdk-trace-node');
 const { OTLPTraceExporter } = require('@opentelemetry/exporter-trace-otlp-http');
-const { Resource } = require('@opentelemetry/resources');
+const { resourceFromAttributes, defaultResource } = require('@opentelemetry/resources');
 
-// Build the Resource from the OTEL_* environment variables. Resource.default()
+// Build the Resource from the OTEL_* environment variables. defaultResource()
 // on its own reports service.name=unknown_service, so we merge in the
 // service.name (OTEL_SERVICE_NAME) and attributes (OTEL_RESOURCE_ATTRIBUTES,
 // e.g. language=javascript) that docker-compose provides. Nothing is hardcoded.
@@ -26,7 +26,7 @@ function resourceFromEnv() {
     const idx = pair.indexOf('=');
     if (idx > 0) attrs[pair.slice(0, idx).trim()] = pair.slice(idx + 1).trim();
   }
-  return Resource.default().merge(new Resource(attrs));
+  return defaultResource().merge(resourceFromAttributes(attrs));
 }
 
 // The OTLP/HTTP exporter reads OTEL_EXPORTER_OTLP_ENDPOINT itself (e.g.

--- a/app-instrumentation/traces/opentelemetry-sdk/node/package.json
+++ b/app-instrumentation/traces/opentelemetry-sdk/node/package.json
@@ -8,9 +8,9 @@
   },
   "dependencies": {
     "@opentelemetry/api": "1.9.1",
-    "@opentelemetry/sdk-trace-node": "1.30.1",
+    "@opentelemetry/sdk-trace-node": "2.9.0",
     "@opentelemetry/exporter-trace-otlp-http": "0.219.0",
-    "@opentelemetry/resources": "1.30.1",
+    "@opentelemetry/resources": "2.9.0",
     "@opentelemetry/semantic-conventions": "1.41.1"
   }
 }


### PR DESCRIPTION
## Summary
- Bumps `@opentelemetry/resources`, `@opentelemetry/sdk-metrics`, and `@opentelemetry/sdk-trace-node` from `1.30.1` → `2.9.0` in the two Node.js OTel SDK demo apps (`app-instrumentation/metrics/opentelemetry-sdk/node`, `app-instrumentation/traces/opentelemetry-sdk/node`), as originally proposed by Renovate in #323.
- Renovate's PR alone breaks both apps: OTel JS v2 removed the `Resource` class entirely (`Resource.default()` / `new Resource(...)`) in favor of the functional API (`defaultResource()`, `resourceFromAttributes()`). This PR updates the `resourceFromEnv()` helper in both `app.js` files to use the new API.
- Closes/supersedes #323 — that PR should be closed without merging since it only bumps versions and does not fix the resulting crash.

## Test plan
- [x] Dry-ran the version bump in isolation: confirmed `npm install` succeeds but both apps crash at startup with `TypeError: Cannot read properties of undefined (reading 'default')` on the old `Resource` API.
- [x] Applied the `resourceFromAttributes`/`defaultResource` migration and re-ran both apps standalone (`node app.js` with `OTEL_SERVICE_NAME`/`OTEL_RESOURCE_ATTRIBUTES`/`OTEL_EXPORTER_OTLP_ENDPOINT` set) — both start cleanly and emit metrics/traces without the `Resource` crash.
- [ ] Run the full scenario via `docker compose up -d` in both `app-instrumentation/metrics/opentelemetry-sdk` and `app-instrumentation/traces/opentelemetry-sdk` and confirm data lands in Grafana.

🤖 Generated with [Claude Code](https://claude.com/claude-code)