### PR TITLE
chore: bump OpenTelemetry Python SDK to 1.44.0 in otel-loadbalancing

### DIFF
--- a/otel-loadbalancing/app/requirements.txt
+++ b/otel-loadbalancing/app/requirements.txt
@@ -1,2 +1,2 @@
-opentelemetry-sdk==1.43.0
-opentelemetry-exporter-otlp-proto-grpc==1.43.0
+opentelemetry-sdk==1.44.0
+opentelemetry-exporter-otlp-proto-grpc==1.44.0


### PR DESCRIPTION
## Summary
- Bumps `opentelemetry-sdk` and `opentelemetry-exporter-otlp-proto-grpc` from 1.43.0 to 1.44.0 in `otel-loadbalancing/app/requirements.txt` to keep the demo app's OTel Python SDK current.
- Part of a parallel pass of OTel SDK freshness bumps across scenarios, sibling to PR #340 which did the same for the Node.js SDK examples.

## Test plan
- [x] Created a fresh venv and ran `pip install -r requirements.txt` in `otel-loadbalancing/app` — installed cleanly with no errors.
- [x] Ran `main.py` with `OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317` under a timeout wrapper — process ran and was killed by the timeout with no traceback; only expected "connection refused" export warnings for the unreachable OTLP endpoint were logged.
- [ ] Did not run the full docker-compose stack (Grafana/Loki/Tempo/Alloy), per instructions to avoid port collisions with other parallel test units.

🤖 Generated with [Claude Code](https://claude.com/claude-code)