### PR TITLE
chore: bump OpenTelemetry Python SDK to 1.44.0

### DIFF
--- a/app-instrumentation/metrics/opentelemetry-sdk/python/requirements.txt
+++ b/app-instrumentation/metrics/opentelemetry-sdk/python/requirements.txt
@@ -1,3 +1,3 @@
-opentelemetry-api==1.43.0
-opentelemetry-sdk==1.43.0
-opentelemetry-exporter-otlp-proto-grpc==1.43.0
+opentelemetry-api==1.44.0
+opentelemetry-sdk==1.44.0
+opentelemetry-exporter-otlp-proto-grpc==1.44.0

--- a/app-instrumentation/traces/opentelemetry-sdk/python/requirements.txt
+++ b/app-instrumentation/traces/opentelemetry-sdk/python/requirements.txt
@@ -1,3 +1,3 @@
-opentelemetry-api==1.43.0
-opentelemetry-sdk==1.43.0
-opentelemetry-exporter-otlp-proto-grpc==1.43.0
+opentelemetry-api==1.44.0
+opentelemetry-sdk==1.44.0
+opentelemetry-exporter-otlp-proto-grpc==1.44.0


### PR DESCRIPTION
## Summary
- Bumps `opentelemetry-api`, `opentelemetry-sdk`, and `opentelemetry-exporter-otlp-proto-grpc` from 1.43.0 to 1.44.0 in both the metrics and traces Python OTel SDK demo apps (`app-instrumentation/metrics/opentelemetry-sdk/python` and `app-instrumentation/traces/opentelemetry-sdk/python`).
- No code changes required — pin bump only.
- Part of the same OTel-freshness pass as #340 (which did the Node.js SDK examples).

## Test plan
- [x] `pip install -r requirements.txt` succeeds cleanly in a fresh venv for both dirs
- [x] Ran `app.py` in both dirs with `OTEL_SERVICE_NAME=test`, `OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317`, `OTEL_EXPORTER_OTLP_PROTOCOL=grpc` for ~10s — both loop cleanly, only expected "connection refused" export retry logs (no listener on 4317), no tracebacks/exceptions
- [ ] Full docker-compose scenario stack (not run, per task instructions, to avoid port collisions with other parallel test units)

🤖 Generated with [Claude Code](https://claude.com/claude-code)