### PR TITLE
chore: bump OpenTelemetry Python SDK to 1.44.0 in trace-log-correlation-exemplars

### DIFF
--- a/trace-log-correlation-exemplars/app/requirements.txt
+++ b/trace-log-correlation-exemplars/app/requirements.txt
@@ -1,7 +1,7 @@
 flask==3.1.3
 requests==2.34.2
 prometheus-client==0.25.0
-opentelemetry-api==1.43.0
-opentelemetry-sdk==1.43.0
-opentelemetry-exporter-otlp-proto-grpc==1.43.0
-opentelemetry-instrumentation-flask==0.63b1
+opentelemetry-api==1.44.0
+opentelemetry-sdk==1.44.0
+opentelemetry-exporter-otlp-proto-grpc==1.44.0
+opentelemetry-instrumentation-flask==0.65b0


### PR DESCRIPTION
## Summary
- Bumps `opentelemetry-api`, `opentelemetry-sdk`, and `opentelemetry-exporter-otlp-proto-grpc` from `1.43.0` → `1.44.0`, and `opentelemetry-instrumentation-flask` from `0.63b1` → `0.65b0` in `trace-log-correlation-exemplars/app/requirements.txt`.
- This is one of several parallel OTel SDK freshness bumps, sibling to #340 which did the same for the Node.js SDK examples in this repo.
- Supersedes #313 ("fix: resolve pip dependency conflict in trace-log-correlation-exemplars smoke test"). That PR bumped `opentelemetry-instrumentation-flask` to `0.64b0` to resolve a `ResolutionImpossible` error caused by a semconv version mismatch with `opentelemetry-sdk==1.43.0`. Since this PR also bumps the core SDK to `1.44.0` (which requires `opentelemetry-semantic-conventions==0.65b0`), the correct instrumentation-flask version is `0.65b0`, not `0.64b0`. #313 should be closed without merging in favor of this PR.

## Test plan
- [x] Created a fresh venv and ran `pip install -r requirements.txt` in `trace-log-correlation-exemplars/app` — installs cleanly with no `ResolutionImpossible` error.
- [x] Smoke-ran the app standalone (`python app.py`, `OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317` placeholder) — Flask server starts, `/checkout` requests return 200, and the only error is the expected `UNAVAILABLE`/connection-refused on OTLP export (no endpoint listening), with no tracebacks or import errors.
- [ ] Full `docker compose up -d` stack run (skipped per instructions — other units test in parallel on this host and full-stack compose files hardcode host ports).

🤖 Generated with [Claude Code](https://claude.com/claude-code)