### PR TITLE
chore: bump OpenTelemetry Python SDK to 1.44.0 in game-of-tracing

### DIFF
--- a/game-of-tracing/ai_opponent/requirements.txt
+++ b/game-of-tracing/ai_opponent/requirements.txt
@@ -1,7 +1,7 @@
 flask==3.1.3
 requests==2.34.2
-opentelemetry-api==1.43.0
-opentelemetry-sdk==1.43.0
-opentelemetry-exporter-otlp==1.43.0
+opentelemetry-api==1.44.0
+opentelemetry-sdk==1.44.0
+opentelemetry-exporter-otlp==1.44.0
 pyroscope-io==1.1.0
 pyroscope-otel==1.1.0

--- a/game-of-tracing/app/requirements.txt
+++ b/game-of-tracing/app/requirements.txt
@@ -1,7 +1,7 @@
 flask==3.1.3
 requests==2.34.2
-opentelemetry-api==1.43.0
-opentelemetry-sdk==1.43.0
-opentelemetry-exporter-otlp==1.43.0
+opentelemetry-api==1.44.0
+opentelemetry-sdk==1.44.0
+opentelemetry-exporter-otlp==1.44.0
 pyroscope-io==1.1.0
 pyroscope-otel==1.1.0

--- a/game-of-tracing/war_map/requirements.txt
+++ b/game-of-tracing/war_map/requirements.txt
@@ -1,8 +1,8 @@
 flask==3.1.3
 requests==2.34.2
 python-dotenv==1.2.2
-opentelemetry-api==1.43.0
-opentelemetry-sdk==1.43.0
-opentelemetry-exporter-otlp==1.43.0
+opentelemetry-api==1.44.0
+opentelemetry-sdk==1.44.0
+opentelemetry-exporter-otlp==1.44.0
 pyroscope-io==1.1.0
 pyroscope-otel==1.1.0


### PR DESCRIPTION
## Summary
- Bumps `opentelemetry-api`, `opentelemetry-sdk`, and `opentelemetry-exporter-otlp` from `1.43.0` to `1.44.0` in `game-of-tracing/app/requirements.txt`, `game-of-tracing/war_map/requirements.txt`, and `game-of-tracing/ai_opponent/requirements.txt`.
- All three services (`app`, `war_map`, `ai_opponent`) share identical OTel pins and were bumped together since they make up one scenario.
- Part of the same OTel-freshness pass as #340, which did the equivalent bump for the Node.js SDK examples.

## Test plan
- [x] For each of the three dirs (`app`, `war_map`, `ai_opponent`): created a fresh venv and ran `pip install -r requirements.txt` — installed cleanly with no errors.
- [x] Ran a module-level import smoke test in each dir to exercise the full OTel TracerProvider/exporter/LoggerProvider + Pyroscope span-processor init path (pointed `OTEL_EXPORTER_OTLP_ENDPOINT` at a harmless placeholder):
  - `war_map`: `python -c "import app"` — exit 0, no output/traceback.
  - `app`: `python -c "import location_server"` (with `SLOT_ID=slot_1`) — exit 0, no output/traceback.
  - `ai_opponent`: `python -c "import ai_server"` — exit 0, no output/traceback.
- [x] Confirmed the diff only touches the three targeted OTel version lines in each requirements.txt (flask, requests, python-dotenv, pyroscope-io, pyroscope-otel left untouched).
- [ ] Did not run the full docker-compose stack (Grafana/Loki/Tempo/Alloy) to avoid port collisions with other units testing in parallel on this host, per task instructions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)