### PR TITLE
chore: bump OpenTelemetry Python SDK to 1.44.0 in otel-jaeger-zipkin-receiver (zipkin-client)

### DIFF
--- a/otel-jaeger-zipkin-receiver/app/zipkin-client/requirements.txt
+++ b/otel-jaeger-zipkin-receiver/app/zipkin-client/requirements.txt
@@ -1,3 +1,3 @@
-opentelemetry-api==1.43.0
-opentelemetry-sdk==1.43.0
-opentelemetry-exporter-zipkin-json==1.43.0
+opentelemetry-api==1.44.0
+opentelemetry-sdk==1.44.0
+opentelemetry-exporter-zipkin-json==1.44.0


### PR DESCRIPTION
## Summary
- Bumps `opentelemetry-api`, `opentelemetry-sdk`, and `opentelemetry-exporter-zipkin-json` from 1.43.0 to 1.44.0 in `otel-jaeger-zipkin-receiver/app/zipkin-client/requirements.txt`.
- This is one of several parallel OTel SDK freshness bumps across the repo's demo apps, sibling to PR #340 which did the same for the Node.js SDK examples.
- `otel-jaeger-zipkin-receiver/app/jaeger-client/` is intentionally **not** touched in this PR. It pins `opentelemetry-exporter-jaeger-thrift==1.21.0`, a package upstream deprecated back in 2023 ("Jaeger supports OTLP natively, use OTLP exporter instead"; "no longer being tested"). There has been no release since, and there will not be one, so there is nothing newer to bump it to. Leaving it pinned as-is is a deliberate scope boundary, not an oversight — bumping the core API/SDK there risks breaking it against versions it was never tested against, for a package with no path forward anyway.

## Test plan
- [x] Created a fresh venv in `otel-jaeger-zipkin-receiver/app/zipkin-client` and ran `pip install -r requirements.txt` — installed cleanly (opentelemetry-api/sdk/exporter-zipkin-json 1.44.0 + opentelemetry-semantic-conventions 0.65b0).
- [x] Ran `client.py` for 10s with `ZIPKIN_ENDPOINT=http://localhost:4317` (unreachable on purpose) and killed it — process stayed alive the whole time (no self-crash), only logging the expected "Exception while exporting Span" / `ConnectionRefusedError` from the SDK's internal batch-export error handling, which is expected against an unreachable endpoint. No unhandled exception or traceback from the app's own code.
- [ ] Did not run the full docker-compose stack (Grafana/Loki/Tempo/Alloy), per parallel-testing constraints on this host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)