### PR TITLE
chore: bump OpenTelemetry .NET SDK to 1.17.0

### DIFF
--- a/app-instrumentation/metrics/opentelemetry-sdk/csharp/App.csproj
+++ b/app-instrumentation/metrics/opentelemetry-sdk/csharp/App.csproj
@@ -11,8 +11,8 @@
   <ItemGroup>
     <!-- OpenTelemetry SDK + OTLP exporter. AddOtlpExporter reads
          OTEL_EXPORTER_OTLP_ENDPOINT / OTEL_EXPORTER_OTLP_PROTOCOL from the env. -->
-    <PackageReference Include="OpenTelemetry" Version="1.16.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.16.0" />
+    <PackageReference Include="OpenTelemetry" Version="1.17.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.17.0" />
   </ItemGroup>
 
 </Project>

--- a/app-instrumentation/traces/opentelemetry-sdk/csharp/App.csproj
+++ b/app-instrumentation/traces/opentelemetry-sdk/csharp/App.csproj
@@ -11,8 +11,8 @@
   <ItemGroup>
     <!-- OpenTelemetry SDK + OTLP exporter. AddOtlpExporter reads
          OTEL_EXPORTER_OTLP_ENDPOINT / OTEL_EXPORTER_OTLP_PROTOCOL from the env. -->
-    <PackageReference Include="OpenTelemetry" Version="1.16.0" />
-    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.16.0" />
+    <PackageReference Include="OpenTelemetry" Version="1.17.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.17.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- Bumps the C# OpenTelemetry SDK demo apps from 1.16.0 to 1.17.0 for both `OpenTelemetry` and `OpenTelemetry.Exporter.OpenTelemetryProtocol` NuGet packages.
- Affects both the metrics and traces demo apps under `app-instrumentation/{metrics,traces}/opentelemetry-sdk/csharp/App.csproj`.
- No code changes required — this is a version-only dependency bump.
- Part of the same OTel-freshness pass as #340, which did the equivalent bump for the Node.js SDK examples.

## Test plan
- [x] `docker build` succeeded for both the metrics and traces `csharp` apps (multi-stage build restores 1.17.0 packages and publishes cleanly).
- [x] Ran each built image for ~10s with `OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317` — both apps looped emitting metrics/traces respectively with clean stdout/stderr and no exceptions (connection-refused export errors are expected/not present here since the SDK doesn't log connection failures at this test duration).
- [x] Confirmed `git diff` only touches the two `App.csproj` version lines as specified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)