### PR TITLE
chore: bump OpenTelemetry Java BOM to 1.64.0

### DIFF
--- a/app-instrumentation/metrics/opentelemetry-sdk/java/pom.xml
+++ b/app-instrumentation/metrics/opentelemetry-sdk/java/pom.xml
@@ -12,7 +12,7 @@
     <properties>
         <maven.compiler.release>21</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <!-- OpenTelemetry Java BOM. 1.43.0 is a recent stable release. -->
+        <!-- OpenTelemetry Java BOM. 1.64.0 is a recent stable release. -->
         <otel.version>1.64.0</otel.version>
     </properties>
 

--- a/app-instrumentation/traces/opentelemetry-sdk/java/pom.xml
+++ b/app-instrumentation/traces/opentelemetry-sdk/java/pom.xml
@@ -12,7 +12,7 @@
     <properties>
         <maven.compiler.release>21</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <!-- OpenTelemetry Java BOM. 1.43.0 is a recent stable release. -->
+        <!-- OpenTelemetry Java BOM. 1.64.0 is a recent stable release. -->
         <otel.version>1.64.0</otel.version>
     </properties>
 


### PR DESCRIPTION
## Summary

- Bumps the shared `otel.version` BOM property from 1.63.0 to 1.64.0 in both the metrics and traces Java OTel SDK demo apps (`app-instrumentation/metrics/opentelemetry-sdk/java/pom.xml` and `app-instrumentation/traces/opentelemetry-sdk/java/pom.xml`). All artifact versions are BOM-managed, so no per-artifact version changes were needed.
- Note: while preparing this change, Renovate had already merged the `otel.version` bump to 1.64.0 on `main` in #337, so that part of the change was already present. This PR's actual diff fixes the stale comment above the property that still referenced the old `1.43.0` placeholder, updating it to say `1.64.0` so the comment matches reality.
- No application code changes required.
- Part of the same OTel-freshness pass as #340 (which did the equivalent for the Node.js SDK examples).

## Test plan

- [x] `docker build -t otel-sdk-java-metrics-test app-instrumentation/metrics/opentelemetry-sdk/java` — succeeds (BOM resolves, app compiles).
- [x] `docker build -t otel-sdk-java-traces-test app-instrumentation/traces/opentelemetry-sdk/java` — succeeds (BOM resolves, app compiles).
- [x] Smoke-ran `otel-sdk-java-metrics-test` against a placeholder OTLP endpoint (`http://localhost:4317`) — container stays up, no unhandled exceptions in logs.
- [x] Smoke-ran `otel-sdk-java-traces-test` the same way — container stays up; logs show only the expected `ConnectException` (connection refused) from the SDK's export throttling logger, no application crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)