### PR TITLE
fix: remove obsolete --stability.level=experimental flag

### DIFF
--- a/faro-frontend-observability/README.md
+++ b/faro-frontend-observability/README.md
@@ -74,7 +74,6 @@ The `config.alloy` pipeline has two components:
 2. **`loki.write "local"`**: Pushes log lines to Loki at `http://loki:3100/loki/api/v1/push`.
 
 The demo page in `app/index.html` initializes the SDK with `url: 'http://localhost:12347/collect'` and `app.name: 'faro-demo'`.
-The Alloy container runs with `--stability.level=experimental` because `faro.receiver` requires experimental stability.
 `livedebugging` is enabled.
 
 ## Try it out

--- a/faro-frontend-observability/docker-compose.yml
+++ b/faro-frontend-observability/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       - 12347:12347
     volumes:
       - ./config.alloy:/etc/alloy/config.alloy
-    command: run --server.http.listen-addr=0.0.0.0:12345 --storage.path=/var/lib/alloy/data --stability.level=experimental /etc/alloy/config.alloy
+    command: run --server.http.listen-addr=0.0.0.0:12345 --storage.path=/var/lib/alloy/data /etc/alloy/config.alloy
     depends_on:
       - loki
 

--- a/gelf-log-ingestion/README.md
+++ b/gelf-log-ingestion/README.md
@@ -71,7 +71,6 @@ The `config.alloy` pipeline has three components:
 3. **`loki.write "local"`**: Pushes log lines to Loki at `http://loki:3100/loki/api/v1/push`.
 
 The demo app in `app/main.py` sends logs to `alloy:12201` with structured fields such as `user_id`, `order_id`, and `gateway`.
-The Alloy container runs with `--stability.level=experimental` because `loki.source.gelf` requires experimental stability.
 `livedebugging` is enabled.
 
 ## GELF level mapping

--- a/gelf-log-ingestion/docker-compose.yml
+++ b/gelf-log-ingestion/docker-compose.yml
@@ -18,7 +18,7 @@ services:
       - 12201:12201/udp
     volumes:
       - ./config.alloy:/etc/alloy/config.alloy
-    command: run --server.http.listen-addr=0.0.0.0:12345 --stability.level=experimental --storage.path=/var/lib/alloy/data /etc/alloy/config.alloy
+    command: run --server.http.listen-addr=0.0.0.0:12345 --storage.path=/var/lib/alloy/data /etc/alloy/config.alloy
     depends_on:
       - loki
 

--- a/kafka/docker-compose.yml
+++ b/kafka/docker-compose.yml
@@ -46,7 +46,7 @@ services:
     volumes:
       - ./config.alloy:/etc/alloy/config.alloy
       - ./logs:/temp/logs
-    command: run --server.http.listen-addr=0.0.0.0:12345 --stability.level=experimental  --storage.path=/var/lib/alloy/data /etc/alloy/config.alloy
+    command: run --server.http.listen-addr=0.0.0.0:12345 --storage.path=/var/lib/alloy/data /etc/alloy/config.alloy
     depends_on:
       loki:
         condition: service_started

--- a/log-api-gateway/README.md
+++ b/log-api-gateway/README.md
@@ -94,7 +94,6 @@ The `config.alloy` pipeline in this scenario has a single logs path with three s
 3. **`loki.write.local`**: Forwards enriched logs to Loki at `http://loki:3100/loki/api/v1/push`.
 
 `livedebugging` is enabled so you can inspect the pipeline in the Alloy UI.
-This scenario runs Alloy with `--stability.level=experimental` because `loki.source.api` requires it.
 
 The demo producer sends logs in Loki push API format.
 Each request includes a `streams` array with label sets and timestamped log lines:
@@ -149,7 +148,6 @@ Run `docker compose ps` to check the status of each container.
 If any container has exited, run `docker compose logs <SERVICE_NAME>` to read the failure reason.
 Replace `<SERVICE_NAME>` with the name of the service that exited.
 For Alloy specifically, the most common cause is a syntax error in `config.alloy`.
-This scenario runs Alloy with `--stability.level=experimental` because `loki.source.api` requires it.
 
 ### No data appears in Grafana after a few minutes
 

--- a/log-api-gateway/docker-compose.yml
+++ b/log-api-gateway/docker-compose.yml
@@ -18,7 +18,7 @@ services:
       - 3500:3500
     volumes:
       - ./config.alloy:/etc/alloy/config.alloy
-    command: run --server.http.listen-addr=0.0.0.0:12345 --stability.level=experimental --storage.path=/var/lib/alloy/data /etc/alloy/config.alloy
+    command: run --server.http.listen-addr=0.0.0.0:12345 --storage.path=/var/lib/alloy/data /etc/alloy/config.alloy
     depends_on:
       - loki
 

--- a/logs-file/docker-compose.yml
+++ b/logs-file/docker-compose.yml
@@ -21,7 +21,7 @@ services:
     volumes:
       - ./config.alloy:/etc/alloy/config.alloy
       - ./logs:/temp/logs
-    command: run --server.http.listen-addr=0.0.0.0:12345 --stability.level=experimental  --storage.path=/var/lib/alloy/data /etc/alloy/config.alloy
+    command: run --server.http.listen-addr=0.0.0.0:12345 --storage.path=/var/lib/alloy/data /etc/alloy/config.alloy
     depends_on:
       - loki
 

--- a/logs-tcp/README.md
+++ b/logs-tcp/README.md
@@ -44,7 +44,6 @@ For Loki push API JSON with stream labels, see [`log-api-gateway/`](../log-api-g
 - **simulator**: A Python script in `simulator.py` that opens a TCP socket to `alloy:9999` and sends HTTP POST requests with JSON bodies to `/loki/api/v1/raw`.
   Each payload includes `service_name`, `severity`, `body`, `code_line`, `server_id`, and `region`.
 - **Alloy**: Receives raw JSON log lines through `loki.source.api`, parses them with `loki.process.labels`, and forwards entries to Loki.
-  Runs with `--stability.level=experimental` because `loki.source.api` requires it.
 - **Loki**: Stores the processed log entries.
 - **Grafana**: Visualizes logs from the provisioned Loki data source.
 
@@ -93,7 +92,6 @@ The `config.alloy` pipeline has four components:
 3. **`loki.write.local`**: Forwards processed logs to Loki at `http://loki:3100/loki/api/v1/push`.
 
 `livedebugging` is enabled so you can inspect the pipeline in the Alloy UI.
-This scenario runs Alloy with `--stability.level=experimental` because `loki.source.api` requires it.
 
 The simulator sends JSON log lines like this:
 
@@ -147,7 +145,6 @@ Run `docker compose ps` to check the status of each container.
 If any container has exited, run `docker compose logs <SERVICE_NAME>` to read the failure reason.
 Replace `<SERVICE_NAME>` with the name of the service that exited, such as `simulator`, `alloy`, or `loki`.
 For Alloy specifically, the most common cause is a syntax error in `config.alloy`.
-This scenario runs Alloy with `--stability.level=experimental` because `loki.source.api` requires it.
 
 ### No data appears in Grafana after a few minutes
 

--- a/logs-tcp/docker-compose.yml
+++ b/logs-tcp/docker-compose.yml
@@ -24,7 +24,7 @@ services:
     volumes:
       - ./config.alloy:/etc/alloy/config.alloy
       - ./logs:/tmp/app-logs/
-    command: run --server.http.listen-addr=0.0.0.0:12345 --stability.level=experimental  --storage.path=/var/lib/alloy/data /etc/alloy/config.alloy
+    command: run --server.http.listen-addr=0.0.0.0:12345 --storage.path=/var/lib/alloy/data /etc/alloy/config.alloy
     depends_on:
       - loki
 

--- a/mail-house/README.md
+++ b/mail-house/README.md
@@ -44,7 +44,6 @@ Use `logs-tcp/` for a simpler JSON-over-TCP pipeline with fewer processing stage
 - **mail-house simulators**: Python apps in `main.py` that POST JSON delivery events to `alloy:9999/loki/api/v1/raw` over TCP.
   Each container sets `MAIL_HOUSE_ID` to `DEPOT-01`, `DEPOT-02`, or `DEPOT-03`.
 - **Alloy**: Receives raw JSON through `loki.source.api`, parses timestamps and fields with `loki.process.labels`, and forwards entries to Loki.
-  Runs with `--stability.level=experimental` because `loki.source.api` requires it.
 - **Loki**: Stores entries with indexed labels and structured metadata.
   `loki-config.yaml` sets `allow_structured_metadata: true` so Loki accepts metadata from the pipeline.
 - **Grafana**: Visualizes logs from the provisioned Loki data source.
@@ -91,15 +90,13 @@ The `config.alloy` pipeline shows how to separate indexed labels from structured
    - `stage.labels` promotes `state`, `package_size`, and `mail_house_id` to indexed Loki labels for fast filtering.
    - `stage.structured_metadata` stores `package_status` and `package_id` as structured metadata to limit label cardinality.
    - `stage.static_labels` adds `service_name="Delivery World"` to every entry.
-   - `stage.output` sets the final log line from the `message` field.
 3. **`loki.write.local`**: Forwards processed logs to Loki at `http://loki:3100/loki/api/v1/push`.
 
 `livedebugging` is enabled so you can inspect the pipeline in the Alloy UI.
-This scenario runs Alloy with `--stability.level=experimental` because `loki.source.api` requires it.
 
 Indexed labels are `service_name`, `state`, `package_size`, and `mail_house_id`.
 Structured metadata includes `package_status` and `package_id`.
-Other JSON fields such as `city`, `note`, and nested `sender` or `receiver` objects remain in the raw payload before `stage.output` runs.
+Other JSON fields such as `city`, `note`, and nested `sender` or `receiver` objects remain in the raw payload and are not promoted to labels or structured metadata.
 
 The simulators send JSON like this:
 
@@ -150,7 +147,6 @@ Run `docker compose ps` to check the status of each container.
 If any container has exited, run `docker compose logs <SERVICE_NAME>` to read the failure reason.
 Replace `<SERVICE_NAME>` with the name of the service that exited, such as `mail-house-01`, `alloy`, or `loki`.
 For Alloy specifically, the most common cause is a syntax error in `config.alloy`.
-This scenario runs Alloy with `--stability.level=experimental` because `loki.source.api` requires it.
 
 ### No data appears in Grafana after a few minutes
 

--- a/mail-house/config.alloy
+++ b/mail-house/config.alloy
@@ -52,12 +52,6 @@ loki.process "labels" {
     }
   }
 
-  stage.output {
-    source = "message"
-}
-  
-
-
 forward_to = [loki.write.local.receiver]
 
 }

--- a/mail-house/docker-compose.yml
+++ b/mail-house/docker-compose.yml
@@ -41,7 +41,7 @@ services:
       - 4318:4318
     volumes:
       - ./config.alloy:/etc/alloy/config.alloy
-    command: run --server.http.listen-addr=0.0.0.0:12345 --stability.level=experimental  --storage.path=/var/lib/alloy/data /etc/alloy/config.alloy
+    command: run --server.http.listen-addr=0.0.0.0:12345 --storage.path=/var/lib/alloy/data /etc/alloy/config.alloy
     depends_on:
       - loki
 

--- a/syslog/docker-compose.yml
+++ b/syslog/docker-compose.yml
@@ -36,7 +36,7 @@ services:
     volumes:
       - ./config.alloy:/etc/alloy/config.alloy
       - ./logs:/tmp/app-logs/
-    command: run --server.http.listen-addr=0.0.0.0:12345 --stability.level=experimental  --storage.path=/var/lib/alloy/data /etc/alloy/config.alloy
+    command: run --server.http.listen-addr=0.0.0.0:12345 --storage.path=/var/lib/alloy/data /etc/alloy/config.alloy
     depends_on:
       - loki
 


### PR DESCRIPTION
## Summary
- Removes the now-unnecessary `--stability.level=experimental` flag (and its README mentions) from 8 scenarios whose experimental-requiring components have since gone GA: `logs-file`, `syslog`, `kafka`, `gelf-log-ingestion`, `faro-frontend-observability`, `log-api-gateway`, `mail-house`, and `logs-tcp`.
- Also fixes an unrelated `mail-house` doc/config bug: the README described a `stage.output` step that set the log line from a `message` field, but no upstream stage ever creates a `message` field. Removed the dead `stage.output { source = "message" }` block from `config.alloy` and corrected the README description.
- `log-secret-filtering` intentionally still keeps the flag — `loki.secretfilter` remains genuinely experimental — and was left untouched.

## Test plan
- [x] Verified via `grep -rn "stability.level=experimental"` that only `log-secret-filtering` (out of scope, still experimental) retains the flag.
- [x] Confirmed no docker-compose `command:` line was left with a stray double space after flag removal.
- [x] Confirmed `mail-house/config.alloy` still parses as a well-formed pipeline after removing the dead `stage.output` block.

Closes #360, #356, #355, #354, #353, #352, #351, #359, #350

🤖 Generated with [Claude Code](https://claude.com/claude-code)