### PR TITLE
fix: bump k8s/events Alloy image to v1.17.1

### DIFF
--- a/k8s/events/alloy-deployment.yaml
+++ b/k8s/events/alloy-deployment.yaml
@@ -23,7 +23,7 @@ spec:
       serviceAccountName: alloy
       containers:
         - name: alloy
-          image: grafana/alloy:v1.16.0
+          image: grafana/alloy:v1.17.1
           args:
             - run
             - /etc/alloy/config.alloy


### PR DESCRIPTION
## Summary
- `k8s/events/alloy-deployment.yaml` hardcoded the Alloy container image to `v1.16.0`, the only scenario in the repo still on that version. Every other scenario is pinned to `v1.17.1` via the centralized `image-versions.env` (this one is a raw Kubernetes manifest, so it can't reference that file directly).
- Bumps the image to `grafana/alloy:v1.17.1` to match.

## Test plan
- [x] Confirmed no other file under `k8s/events/` references the old version.
- [x] Diff is a single-line image tag change; manifest structure unchanged.

Closes #358

🤖 Generated with [Claude Code](https://claude.com/claude-code)