### PR TITLE
fix: use config.path instead of deprecated config.file in otel-examples

### DIFF
--- a/otel-examples/cost-control/config-otel.yaml
+++ b/otel-examples/cost-control/config-otel.yaml
@@ -9,7 +9,7 @@
 extensions:
   alloyengine:
     config:
-      file: /etc/alloy/config.alloy
+      path: /etc/alloy/config.alloy
     flags:
       server.http.listen-addr: 0.0.0.0:12345
 

--- a/otel-examples/count-connector/config-otel.yaml
+++ b/otel-examples/count-connector/config-otel.yaml
@@ -9,7 +9,7 @@
 extensions:
   alloyengine:
     config:
-      file: /etc/alloy/config.alloy
+      path: /etc/alloy/config.alloy
     flags:
       server.http.listen-addr: 0.0.0.0:12345
 

--- a/otel-examples/filelog-processing/config-otel.yaml
+++ b/otel-examples/filelog-processing/config-otel.yaml
@@ -8,7 +8,7 @@
 extensions:
   alloyengine:
     config:
-      file: /etc/alloy/config.alloy
+      path: /etc/alloy/config.alloy
     flags:
       server.http.listen-addr: 0.0.0.0:12345
 

--- a/otel-examples/host-metrics/config-otel.yaml
+++ b/otel-examples/host-metrics/config-otel.yaml
@@ -9,7 +9,7 @@
 extensions:
   alloyengine:
     config:
-      file: /etc/alloy/config.alloy
+      path: /etc/alloy/config.alloy
     flags:
       server.http.listen-addr: 0.0.0.0:12345
 

--- a/otel-examples/kafka-buffer/config-otel.yaml
+++ b/otel-examples/kafka-buffer/config-otel.yaml
@@ -12,7 +12,7 @@
 extensions:
   alloyengine:
     config:
-      file: /etc/alloy/config.alloy
+      path: /etc/alloy/config.alloy
     flags:
       server.http.listen-addr: 0.0.0.0:12345
 

--- a/otel-examples/multi-pipeline-fanout/config-otel.yaml
+++ b/otel-examples/multi-pipeline-fanout/config-otel.yaml
@@ -10,7 +10,7 @@
 extensions:
   alloyengine:
     config:
-      file: /etc/alloy/config.alloy
+      path: /etc/alloy/config.alloy
     flags:
       server.http.listen-addr: 0.0.0.0:12345
 

--- a/otel-examples/ottl-transform/config-otel.yaml
+++ b/otel-examples/ottl-transform/config-otel.yaml
@@ -9,7 +9,7 @@
 extensions:
   alloyengine:
     config:
-      file: /etc/alloy/config.alloy
+      path: /etc/alloy/config.alloy
     flags:
       server.http.listen-addr: 0.0.0.0:12345
 

--- a/otel-examples/pii-redaction/config-otel.yaml
+++ b/otel-examples/pii-redaction/config-otel.yaml
@@ -9,7 +9,7 @@
 extensions:
   alloyengine:
     config:
-      file: /etc/alloy/config.alloy
+      path: /etc/alloy/config.alloy
     flags:
       server.http.listen-addr: 0.0.0.0:12345
 

--- a/otel-examples/resource-enrichment/config-otel.yaml
+++ b/otel-examples/resource-enrichment/config-otel.yaml
@@ -9,7 +9,7 @@
 extensions:
   alloyengine:
     config:
-      file: /etc/alloy/config.alloy
+      path: /etc/alloy/config.alloy
     flags:
       server.http.listen-addr: 0.0.0.0:12345
 

--- a/otel-examples/routing-multi-tenant/config-otel.yaml
+++ b/otel-examples/routing-multi-tenant/config-otel.yaml
@@ -12,7 +12,7 @@
 extensions:
   alloyengine:
     config:
-      file: /etc/alloy/config.alloy
+      path: /etc/alloy/config.alloy
     flags:
       server.http.listen-addr: 0.0.0.0:12345
 


### PR DESCRIPTION
## Summary
- All 10 `otel-examples/*/config-otel.yaml` files configure the `alloyengine` extension using the deprecated `config.file` key. `file` still works as a fallback when `path` is unset, but the current/supported key is `config.path`.
- Renames the key (value and indentation unchanged) in all 10 scenarios: `ottl-transform`, `resource-enrichment`, `cost-control`, `routing-multi-tenant`, `host-metrics`, `multi-pipeline-fanout`, `pii-redaction`, `filelog-processing`, `count-connector`, `kafka-buffer`.

## Test plan
- [x] `grep -rn "file: /etc/alloy/config.alloy" otel-examples/` returns zero matches.
- [x] `grep -rln "path: /etc/alloy/config.alloy" otel-examples/` returns exactly 10 matches.
- [x] Diff per file is a single-line key rename; no other content touched.

Closes #357

🤖 Generated with [Claude Code](https://claude.com/claude-code)