### PR TITLE
Improve the docs-review Skill

### DIFF
--- a/.claude/skills/README.md
+++ b/.claude/skills/README.md
@@ -7,9 +7,9 @@ For technical writers, engineers, and contributors who use Cursor, VS Code, or C
 
 ## Skills
 
-| Skill | Purpose |
-| ----- | ------- |
-| [`docs-review/SKILL.md`](docs-review/SKILL.md) | Create or review scenario README files for style and technical accuracy |
+| Skill                                                  | Purpose                                                                        |
+| ------------------------------------------------------ | ------------------------------------------------------------------------------ |
+| [`docs-review/SKILL.md`](docs-review/SKILL.md)         | Create or review scenario README files for style and technical accuracy        |
 | [`merge-chore-prs/SKILL.md`](merge-chore-prs/SKILL.md) | Approve and merge open Renovate `chore(deps)` pull requests via the GitHub CLI |
 
 ### What you control
@@ -20,12 +20,13 @@ Skills draft and review content but never commit, push, or publish on their own.
 
 The `shared/` directory is the single source of truth for cross-cutting references. Skills load these by relative path.
 
-| File | Purpose |
-| ---- | ------- |
-| [`shared/repo-context.md`](shared/repo-context.md) | Repository layout, workflow, and baseline README examples |
-| [`shared/style-guide.md`](shared/style-guide.md) | Writers Toolkit rules and README template |
-| [`shared/best-practices.md`](shared/best-practices.md) | Config-first workflow and common pitfalls |
-| [`shared/alloy-verification.md`](shared/alloy-verification.md) | Verify Alloy claims against external docs |
-| [`shared/technical-verification.md`](shared/technical-verification.md) | Technical review workflow for README claims |
-| [`shared/verification-checklist.md`](shared/verification-checklist.md) | Handoff checklist |
-| [`shared/README.md`](shared/README.md) | Overview of the shared directory |
+| File                                                                   | Purpose                                                                                    |
+| ---------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| [`shared/repo-context.md`](shared/repo-context.md)                     | Repository layout, workflow, and baseline README examples                                  |
+| [`shared/style-guide.md`](shared/style-guide.md)                       | Writers Toolkit rules and README template                                                  |
+| [`shared/best-practices.md`](shared/best-practices.md)                 | Config-first workflow and common pitfalls                                                  |
+| [`generated-content-review.md`](generated-content-review.md)           | Detailed AI-tell patterns and reporting categories, beyond the basics in best-practices.md |
+| [`shared/alloy-verification.md`](shared/alloy-verification.md)         | Verify Alloy claims against external docs                                                  |
+| [`shared/technical-verification.md`](shared/technical-verification.md) | Technical review workflow for README claims                                                |
+| [`shared/verification-checklist.md`](shared/verification-checklist.md) | Handoff checklist                                                                          |
+| [`shared/README.md`](shared/README.md)                                 | Overview of the shared directory                                                           |

--- a/.claude/skills/docs-review/SKILL.md
+++ b/.claude/skills/docs-review/SKILL.md
@@ -51,8 +51,9 @@ Create and review use the same style, structure, and verification rules.
 4. Omit optional template sections that do not apply.
 5. Follow [`../shared/technical-verification.md`](../shared/technical-verification.md).
 6. Verify Alloy component claims with [`../shared/alloy-verification.md`](../shared/alloy-verification.md).
-7. Run through [`../shared/verification-checklist.md`](../shared/verification-checklist.md).
-8. Present the draft README to the user. Do not commit.
+7. Check the draft against [`../shared/generated-content-review.md`](../shared/generated-content-review.md).
+8. Run through [`../shared/verification-checklist.md`](../shared/verification-checklist.md).
+9. Present the draft README to the user. Do not commit.
 
 ## Step 3: Review an existing README
 
@@ -76,8 +77,9 @@ Create and review use the same style, structure, and verification rules.
 5. Verify Alloy component claims with [`../shared/alloy-verification.md`](../shared/alloy-verification.md).
 6. Apply [`../shared/style-guide.md`](../shared/style-guide.md) and [`../shared/best-practices.md`](../shared/best-practices.md).
 7. Confirm every command, query, credential, env var, and demo manifest from the original README is still present unless the configs changed.
-8. Run through [`../shared/verification-checklist.md`](../shared/verification-checklist.md).
-9. Apply fixes to `README.md` only. Present results to the user. Do not commit.
+8. Check the draft against [`../shared/generated-content-review.md`](../shared/generated-content-review.md).
+9. Run through [`../shared/verification-checklist.md`](../shared/verification-checklist.md).
+10. Apply fixes to `README.md` only. Present results to the user. Do not commit.
 
 ## Style and format requirements
 
@@ -91,7 +93,7 @@ Apply every rule in [`../shared/style-guide.md`](../shared/style-guide.md). In p
 - "Check" not "confirm" in troubleshoot steps
 - Every fenced code block must have a language tag
 
-Remove AI-tell phrasing listed in [`../shared/best-practices.md`](../shared/best-practices.md).
+Remove AI-tell phrasing listed in [`../shared/generated-content-review.md`](../shared/generated-content-review.md).
 
 ## Technical verification
 

--- a/.claude/skills/docs-review/SKILL.md
+++ b/.claude/skills/docs-review/SKILL.md
@@ -122,11 +122,12 @@ Present a summary that includes:
 
 ## Reference
 
-| File | Purpose |
-| ---- | ------- |
-| [`../shared/repo-context.md`](../shared/repo-context.md) | Repository layout and baseline READMEs |
-| [`../shared/style-guide.md`](../shared/style-guide.md) | Style rules and README template |
-| [`../shared/best-practices.md`](../shared/best-practices.md) | Config-first workflow and pitfalls |
-| [`../shared/technical-verification.md`](../shared/technical-verification.md) | Technical review steps |
-| [`../shared/alloy-verification.md`](../shared/alloy-verification.md) | Alloy docs cross-check |
-| [`../shared/verification-checklist.md`](../shared/verification-checklist.md) | Pre-submit checklist |
+| File                                                                             | Purpose                                                                                    |
+| -------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| [`../shared/repo-context.md`](../shared/repo-context.md)                         | Repository layout and baseline READMEs                                                     |
+| [`../shared/style-guide.md`](../shared/style-guide.md)                           | Style rules and README template                                                            |
+| [`../shared/best-practices.md`](../shared/best-practices.md)                     | Config-first workflow and pitfalls                                                         |
+| [`../shared/generated-content-review.md`](../shared/generated-content-review.md) | Detailed AI-tell patterns and reporting categories, beyond the basics in best-practices.md |
+| [`../shared/technical-verification.md`](../shared/technical-verification.md)     | Technical review steps                                                                     |
+| [`../shared/alloy-verification.md`](../shared/alloy-verification.md)             | Alloy docs cross-check                                                                     |
+| [`../shared/verification-checklist.md`](../shared/verification-checklist.md)     | Pre-submit checklist                                                                       |

--- a/.claude/skills/docs-review/SKILL.md
+++ b/.claude/skills/docs-review/SKILL.md
@@ -26,17 +26,17 @@ Read these shared files in order:
 3. [`../shared/best-practices.md`](../shared/best-practices.md)
 
 Then read every configuration file in the target scenario directory.
-See **Config files to read** in [`../shared/best-practices.md`](../shared/best-practices.md).
+See **Config-first workflow** in [`../shared/best-practices.md`](../shared/best-practices.md) for the file list by deployment type.
 
 Ask the user for the scenario directory path if it is not clear from context.
 
 ## Step 1: Choose create or review
 
-| Condition                                        | Path       |
-| ------------------------------------------------ | ---------- |
-| `README.md` is missing, or is 0 bytes            | **Create** |
+| Condition                                                                                                                                                        | Path       |
+| ---------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------- |
+| `README.md` is missing, or is 0 bytes                                                                                                                            | **Create** |
 | `README.md` exists but every `##` heading is either absent or contains only placeholder text (for example a bracketed note, a single TODO line, or no body text) | **Create** |
-| `README.md` already exists with scenario content | **Review** |
+| `README.md` already exists with scenario content                                                                                                                 | **Review** |
 
 If you're unsure which row applies, treat it as **Review**.
 The preservation rules in review mode won't damage a file that turns out to be thin, but the Create path skips preservation checks entirely and can destroy real content if misapplied.
@@ -99,7 +99,7 @@ Remove AI-tell phrasing listed in [`../shared/generated-content-review.md`](../s
 
 Scenario config files outrank the README when they disagree.
 Fix the README to match the configs.
-If a config looks wrong, flag it for the contributor instead of changing it.
+Flag a config for the contributor instead of changing it if configs disagree with each other, reference something missing from the scenario directory, or contradict the Alloy component reference.
 
 For Alloy component names, arguments, and behavior, verify against the latest reference:
 
@@ -114,11 +114,12 @@ Present a summary that includes:
 1. **Task** — create or review
 2. **Scenario directory**
 3. **Changes made** — or the full draft for create
-4. **Style issues** found and fixed
-5. **Technical verification** — claims checked against configs and Alloy docs, with any divergences
-6. **Preservation** — on review, any content from the original README that was kept, restored, or intentionally dropped
-7. **Open questions** — config problems or claims you could not verify
-8. **Checklist** — note any items from [`../shared/verification-checklist.md`](../shared/verification-checklist.md) the user should confirm before submitting
+4. **Style-guide violations** found and fixed
+5. **Likely AI-origin content issues** found, using the categories in [`../shared/generated-content-review.md`](../shared/generated-content-review.md)
+6. **Technical verification** — claims checked against configs and Alloy docs, with any divergences
+7. **Preservation** — on review, any content from the original README that was kept, restored, or intentionally dropped
+8. **Open questions** — config problems or claims you could not verify
+9. **Checklist** — note any items from [`../shared/verification-checklist.md`](../shared/verification-checklist.md) the user should confirm before submitting
 
 ## Reference
 

--- a/.claude/skills/docs-review/SKILL.md
+++ b/.claude/skills/docs-review/SKILL.md
@@ -35,7 +35,7 @@ Ask the user for the scenario directory path if it is not clear from context.
 | Condition                                        | Path       |
 | ------------------------------------------------ | ---------- |
 | `README.md` is missing, or is 0 bytes            | **Create** |
-| `README.md` exists but every `## `heading is either absent or contains only placeholder text (for example a bracketed note, a single TODO line, or no body text) | **Create** |
+| `README.md` exists but every `##` heading is either absent or contains only placeholder text (for example a bracketed note, a single TODO line, or no body text) | **Create** |
 | `README.md` already exists with scenario content | **Review** |
 
 If you're unsure which row applies, treat it as **Review**.

--- a/.claude/skills/docs-review/SKILL.md
+++ b/.claude/skills/docs-review/SKILL.md
@@ -34,8 +34,12 @@ Ask the user for the scenario directory path if it is not clear from context.
 
 | Condition                                        | Path       |
 | ------------------------------------------------ | ---------- |
-| `README.md` is missing, empty, or a stub         | **Create** |
+| `README.md` is missing, or is 0 bytes            | **Create** |
+| `README.md` exists but every `## `heading is either absent or contains only placeholder text (for example a bracketed note, a single TODO line, or no body text) | **Create** |
 | `README.md` already exists with scenario content | **Review** |
+
+If you're unsure which row applies, treat it as **Review**.
+The preservation rules in review mode won't damage a file that turns out to be thin, but the Create path skips preservation checks entirely and can destroy real content if misapplied.
 
 Create and review use the same style, structure, and verification rules.
 

--- a/.claude/skills/docs-review/SKILL.md
+++ b/.claude/skills/docs-review/SKILL.md
@@ -63,10 +63,10 @@ Create and review use the same style, structure, and verification rules.
 
 3. Classify the change:
 
-   - **Style/editorial** — wording and structure only, no new technical claims
-   - **Technical** — commands, ports, component names, queries, credentials, or pipeline behavior
+   - **Style/editorial** — the edit touches only wording, grammar, heading text, or paragraph structure, and every command, port, component name, query, credential, and URL in the README is byte-for-byte unchanged from the current file
+   - **Technical** — anything else, including edits that touch a heading immediately above a code block, reorder steps, or change which sections exist
 
-   When in doubt, treat it as **technical**.
+   Default to **technical**. Only classify as style/editorial if you can point to the specific lines changed and confirm none of them fall in the technical list above.
 
 4. Follow [`../shared/technical-verification.md`](../shared/technical-verification.md).
 5. Verify Alloy component claims with [`../shared/alloy-verification.md`](../shared/alloy-verification.md).

--- a/.claude/skills/shared/README.md
+++ b/.claude/skills/shared/README.md
@@ -6,14 +6,15 @@ This repository documents scenarios through one README per directory. These file
 
 ## Files
 
-| File                                                     | Purpose                                                           |
-| -------------------------------------------------------- | ----------------------------------------------------------------- |
-| [`repo-context.md`](repo-context.md)                     | Repository layout, contributor workflow, baseline README examples |
-| [`style-guide.md`](style-guide.md)                       | Writers Toolkit rules and README template                         |
-| [`best-practices.md`](best-practices.md)                 | Config-first workflow, pitfalls, and good patterns                |
-| [`alloy-verification.md`](alloy-verification.md)         | How to verify Alloy claims against external docs                  |
-| [`technical-verification.md`](technical-verification.md) | End-to-end technical review workflow for README claims            |
-| [`verification-checklist.md`](verification-checklist.md) | Handoff checklist before submitting README changes                |
+| File                                                         | Purpose                                                                                    |
+| ------------------------------------------------------------ | ------------------------------------------------------------------------------------------ |
+| [`repo-context.md`](repo-context.md)                         | Repository layout, contributor workflow, baseline README examples                          |
+| [`style-guide.md`](style-guide.md)                           | Writers Toolkit rules and README template                                                  |
+| [`best-practices.md`](best-practices.md)                     | Config-first workflow, pitfalls, and good patterns                                         |
+| [`generated-content-review.md`](generated-content-review.md) | Detailed AI-tell patterns and reporting categories, beyond the basics in best-practices.md |
+| [`alloy-verification.md`](alloy-verification.md)             | How to verify Alloy claims against external docs                                           |
+| [`technical-verification.md`](technical-verification.md)     | End-to-end technical review workflow for README claims                                     |
+| [`verification-checklist.md`](verification-checklist.md)     | Handoff checklist before submitting README changes                                         |
 
 ## Workflow
 

--- a/.claude/skills/shared/README.md
+++ b/.claude/skills/shared/README.md
@@ -6,14 +6,14 @@ This repository documents scenarios through one README per directory. These file
 
 ## Files
 
-| File | Purpose |
-| ---- | ------- |
-| [`repo-context.md`](repo-context.md) | Repository layout, contributor workflow, baseline README examples |
-| [`style-guide.md`](style-guide.md) | Writers Toolkit rules and README template |
-| [`best-practices.md`](best-practices.md) | Config-first workflow, pitfalls, and good patterns |
-| [`alloy-verification.md`](alloy-verification.md) | How to verify Alloy claims against external docs |
-| [`technical-verification.md`](technical-verification.md) | End-to-end technical review workflow for README claims |
-| [`verification-checklist.md`](verification-checklist.md) | Handoff checklist before submitting README changes |
+| File                                                     | Purpose                                                           |
+| -------------------------------------------------------- | ----------------------------------------------------------------- |
+| [`repo-context.md`](repo-context.md)                     | Repository layout, contributor workflow, baseline README examples |
+| [`style-guide.md`](style-guide.md)                       | Writers Toolkit rules and README template                         |
+| [`best-practices.md`](best-practices.md)                 | Config-first workflow, pitfalls, and good patterns                |
+| [`alloy-verification.md`](alloy-verification.md)         | How to verify Alloy claims against external docs                  |
+| [`technical-verification.md`](technical-verification.md) | End-to-end technical review workflow for README claims            |
+| [`verification-checklist.md`](verification-checklist.md) | Handoff checklist before submitting README changes                |
 
 ## Workflow
 
@@ -23,7 +23,8 @@ This repository documents scenarios through one README per directory. These file
 2. Read the scenario config files
 3. Draft with the README template in [`style-guide.md`](style-guide.md)
 4. Follow [`best-practices.md`](best-practices.md)
-5. Run [`verification-checklist.md`](verification-checklist.md)
+5. Check the draft against [`generated-content-review.md`](generated-content-review.md)
+6. Run [`verification-checklist.md`](verification-checklist.md)
 
 ### Review an existing README
 
@@ -32,7 +33,8 @@ This repository documents scenarios through one README per directory. These file
 3. Compare against the previous README to preserve commands, queries, and credentials
 4. Apply [`style-guide.md`](style-guide.md) and [`best-practices.md`](best-practices.md)
 5. Follow [`technical-verification.md`](technical-verification.md) and [`alloy-verification.md`](alloy-verification.md)
-6. Run [`verification-checklist.md`](verification-checklist.md)
+6. Check the draft against [`generated-content-review.md`](generated-content-review.md)
+7. Run [`verification-checklist.md`](verification-checklist.md)
 
 ## Skills that use these files
 

--- a/.claude/skills/shared/alloy-verification.md
+++ b/.claude/skills/shared/alloy-verification.md
@@ -10,6 +10,10 @@ https://grafana.com/docs/alloy/latest/reference/components/
 
 Search for the exact block type named in `config.alloy`, for example `loki.source.file`, `prometheus.scrape`, or `otelcol.receiver.otlp`.
 
+If the fetch to this URL fails, times out, or returns content that doesn't look like the component reference, do not fall back to memory for component names, arguments, or behavior.
+Treat every Alloy claim in scope as unverified and flag it in the handoff instead.
+Retry the fetch once before flagging.
+
 ## Secondary source
 
 Verify deployment commands, ports, service names, and URLs against files in the scenario directory:

--- a/.claude/skills/shared/best-practices.md
+++ b/.claude/skills/shared/best-practices.md
@@ -20,7 +20,7 @@ Read the scenario configuration before writing or editing prose.
 
 Don't invent components, ports, commands, or URLs that aren't supported by these files.
 Don't edit these files.
-If there is a potential problem in the scenarion configurations, flag it for the contributor to investigate.
+Flag a config for the contributor instead of documenting it as-is if any of the following are true: two config files disagree with each other (for example a port in `docker-compose.yml` that doesn't match what `config.alloy` forwards to), a referenced file or service doesn't exist in the scenario directory, or a value contradicts the Alloy component reference per [`alloy-verification.md`](alloy-verification.md).
 
 ## Create or review with the same rules
 
@@ -68,14 +68,7 @@ Style, structure, and verification rules are identical for both tasks.
 
 ### AI-tell phrasing
 
-Replace patterns such as:
-
-- "This scenario demonstrates" → "This scenario shows"
-- "will install" / "will be used to" → active present tense
-- "pre-configured" → "configured"
-- "See" → "Refer to"
-- "Confirm" in troubleshoot steps → "Check"
-- Blockquote notes about abstracting configuration
+Refer to [`generated-content-review.md`](generated-content-review.md) for AI-tell patterns and how to report them.
 
 ### Weak examples
 

--- a/.claude/skills/shared/generated-content-review.md
+++ b/.claude/skills/shared/generated-content-review.md
@@ -4,54 +4,58 @@ Use this file to catch phrasing and structural patterns typical of AI-drafted te
 
 This file is self-contained. It doesn't assume any other Grafana repository is checked out locally.
 
-Two things can be true of the same sentence: it can be a generated-content tell *and* a style-guide violation. When a row below says "Also a style-guide rule," treat it as an ordinary style fix — cite the style guide, not this file. Reserve "this reads as AI-drafted" framing for rows marked **README-specific**, since those aren't covered anywhere else.
+Two things can be true of the same sentence: it can be a generated-content tell and a style-guide violation.
+The Note column says where else, if anywhere, a pattern is independently defined — it's not a scope label, since every row in this file already applies only to READMEs.
+When a row says "Also a style-guide rule," the same rule exists in style-guide.md on its own; cite that file, not this one, and report it as a style-guide violation under Handoff item 4.
+When a row says "AI-origin only," there's no independent style-guide rule for it anywhere else in the skill — it's a judgment call unique to this file, and it belongs under Handoff item 5.
 
 ## 1. Structural padding
 
-|                                                  Pattern                                                  |                                       Fix                                       |      Note       |
-| --------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- | --------------- |
-| A closing paragraph restates what earlier sections already said                                           | Delete it, or replace with an actual next step                                  | README-specific |
-| A section ends with an unearned importance claim ("This ensures reliable, scalable telemetry collection") | Cut it, or replace with the real, specific consequence                          | README-specific |
-| Three-adjective padding ("fast, reliable, and efficient")                                                 | Keep the one adjective that's true and checkable; cut the rest                  | README-specific |
-| Every `##` section follows an identical rigid shape regardless of content                                 | Let structure follow the template in `style-guide.md`, not a mechanical outline | README-specific |
+| Pattern                                                                                                   | Fix                                                                             | Note           |
+| --------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- | -------------- |
+| A closing paragraph restates what earlier sections already said                                           | Delete it, or replace with an actual next step                                  | AI-origin only |
+| A section ends with an unearned importance claim ("This ensures reliable, scalable telemetry collection") | Cut it, or replace with the real, specific consequence                          | AI-origin only |
+| Three-adjective padding ("fast, reliable, and efficient")                                                 | Keep the one adjective that's true and checkable; cut the rest                  | AI-origin only |
+| Every `##` section follows an identical rigid shape regardless of content                                 | Let structure follow the template in `style-guide.md`, not a mechanical outline | AI-origin only |
 
 ## 2. Sentence-level tics
 
-|                                                 Pattern                                                 |                                    Fix                                    |                         Note                          |
+| Pattern                                                                                                 | Fix                                                                       | Note                                                  |
 | ------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- | ----------------------------------------------------- |
-| Negative parallelism ("It's not just a collector, it's a full observability pipeline")                  | State the fact plainly                                                    | README-specific                                       |
-| Overused connective tissue ("Additionally," "Furthermore," "It's worth noting that")                    | Cut the connector if the sentence reads fine without it                   | README-specific                                       |
-| Vague, unsupported intensifiers ("significantly," "notably," "seamlessly")                              | Cut the word, or replace with the specific number or condition            | README-specific                                       |
-| Editorializing filler verbs ("ensures," "empowers," "leverages," "enables seamless")                    | Replace with the actual mechanism: "sends," "writes," "drops," "forwards" | README-specific                                       |
-| "-ing" analytical tack-ons ("...improving observability," "...highlighting the pipeline's flexibility") | Cut the clause; let the fact stand alone                                  | README-specific                                       |
+| Negative parallelism ("It's not just a collector, it's a full observability pipeline")                  | State the fact plainly                                                    | AI-origin only                                        |
+| Overused connective tissue ("Additionally," "Furthermore," "It's worth noting that")                    | Cut the connector if the sentence reads fine without it                   | AI-origin only                                        |
+| Vague, unsupported intensifiers ("significantly," "notably," "seamlessly")                              | Cut the word, or replace with the specific number or condition            | AI-origin only                                        |
+| Editorializing filler verbs ("ensures," "empowers," "leverages," "enables seamless")                    | Replace with the actual mechanism: "sends," "writes," "drops," "forwards" | AI-origin only                                        |
+| "-ing" analytical tack-ons ("...improving observability," "...highlighting the pipeline's flexibility") | Cut the clause; let the fact stand alone                                  | AI-origin only                                        |
 | Passive voice ("Data is collected by the receiver")                                                     | Rewrite active: "The receiver collects data"                              | Also a style-guide rule — active voice, second person |
 | Future tense as default ("Alloy will forward the metrics")                                              | Present tense: "Alloy forwards the metrics"                               | Also a style-guide rule — present tense               |
-| "This scenario demonstrates"                                                                            | "This scenario shows"                                                     | Also in `best-practices.md`                           |
-| "will install" / "will be used to"                                                                      | Active present tense                                                      | Also in `best-practices.md`                           |
-| "pre-configured"                                                                                        | "configured"                                                              | Also in `best-practices.md`                           |
+| "This scenario demonstrates"                                                                            | "This scenario shows"                                                     | AI-origin only                                        |
+| "will install" / "will be used to"                                                                      | Active present tense                                                      | AI-origin only                                        |
+| "pre-configured"                                                                                        | "configured"                                                              | AI-origin only                                        |
 | "See"                                                                                                   | "Refer to"                                                                | Also a style-guide rule                               |
 | "Confirm" in troubleshoot steps                                                                         | "Check"                                                                   | Also a style-guide rule                               |
 
 ## 3. Formatting tics
 
-|                                                      Pattern                                                      |                                                            Fix                                                             |                            Note                            |
+| Pattern                                                                                                           | Fix                                                                                                                        | Note                                                       |
 | ----------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
-| A numbered procedure flattened into a bullet list                                                                 | Convert back to a numbered list — steps in **Run the scenario** and **Try it out** are sequential and depend on each other | README-specific                                            |
+| A numbered procedure flattened into a bullet list                                                                 | Convert back to a numbered list — steps in **Run the scenario** and **Try it out** are sequential and depend on each other | AI-origin only                                             |
 | Bold applied to phrases that aren't UI text                                                                       | Remove the bold, or use italic if the word genuinely needs emphasis                                                        | Also a style-guide rule — bold UI text only                |
-| Em dash used repeatedly as a substitute for commas or periods                                                     | Vary punctuation to match the actual grammatical relationship                                                              | README-specific                                            |
+| Em dash used repeatedly as a substitute for commas or periods                                                     | Vary punctuation to match the actual grammatical relationship                                                              | AI-origin only                                             |
 | Title case in headings ("Understand The Architecture")                                                            | Sentence case: "Understand the architecture"                                                                               | Also a style-guide rule                                    |
 | Leftover chat artifacts ("Certainly! Here's the updated section:", "I hope this helps!", `[Insert example here]`) | Remove outright                                                                                                            | Highest-confidence flag on this list — not a judgment call |
-| Blockquote note styled like `> **Note:**`                                                                         | Rewrite as a plain sentence or a short intro paragraph; this repo's READMEs don't use an admonition shortcode              | README-specific                                            |
+| Blockquote note styled like `> **Note:**`                                                                         | Rewrite as a plain sentence or a short intro paragraph; this repo's READMEs don't use an admonition shortcode              | AI-origin only                                             |
 
 ## 4. Content-level tells
 
-|                                                       Pattern                                                        |                                                  Fix                                                  |                                                          Note                                                           |
+| Pattern                                                                                                              | Fix                                                                                                   | Note                                                                                                                    |
 | -------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
 | Confident but unverified specifics (wrong port, wrong component name, wrong default)                                 | Verify against the scenario config files and the Alloy component reference before accepting the claim | Route through [`technical-verification.md`](technical-verification.md); this is a verification issue, not a wording fix |
-| Generic troubleshooting boilerplate ("Check your configuration file for errors," "Ensure the service is running")    | Replace with the actual failure mode and actual fix for this scenario                                 | README-specific — matches the "Weak examples" pitfall in `best-practices.md`                                            |
-| False completeness ("A comprehensive guide to configuring Alloy") on a scenario README that only covers one pipeline | Scope the claim to what the scenario actually does, or cut it                                         | README-specific                                                                                                         |
-| Invented or stale cross-references (a **Next steps** link to a component or scenario that doesn't exist)             | Verify every link resolves before handoff                                                             | README-specific — add to the pre-handoff pass alongside [`verification-checklist.md`](verification-checklist.md)        |
+| Generic troubleshooting boilerplate ("Check your configuration file for errors," "Ensure the service is running")    | Replace with the actual failure mode and actual fix for this scenario                                 | AI-origin only                                                                                                          |
+| False completeness ("A comprehensive guide to configuring Alloy") on a scenario README that only covers one pipeline | Scope the claim to what the scenario actually does, or cut it                                         | AI-origin only                                                                                                          |
+| Invented or stale cross-references (a **Next steps** link to a component or scenario that doesn't exist)             | Verify every link resolves before handoff                                                             | AI-origin only — add to the pre-handoff pass alongside [`verification-checklist.md`](verification-checklist.md)         |
 | Query examples with labels or jobs that don't appear in `config.alloy`                                               | Take query examples from labels and jobs actually defined in the config                               | Also in `best-practices.md` under "Weak examples"                                                                       |
+| A caveat claiming the config is simplified or abstracted for the demo, when nothing in the scenario configs says so  | Cut it, or verify it against the actual configs before keeping it                                     | AI-origin only                                                                                                          |
 
 ## What NOT to flag
 
@@ -61,7 +65,9 @@ Two things can be true of the same sentence: it can be a generated-content tell 
 
 ## How to report findings
 
-Split findings into two kinds, same as technical vs. style in `SKILL.md` Step 3:
+Split findings into two kinds. These map directly to items 4 and 5 in `SKILL.md`'s Handoff section.
 
 1. **Style-guide violation** — objective, cite the rule in `style-guide.md`, safe to fix directly.
-2. **Likely AI-origin content issue** — formulaic padding, unverified specifics, invented references, leftover chat artifacts. These need a judgment call or a source check, not just a find-and-replace. Only this category should carry "this looks AI-drafted" framing in the handoff summary.
+2. **Likely AI-origin content issue** — formulaic padding, unverified specifics, invented references, leftover chat artifacts.
+   These need a judgment call or a source check, not just a find-and-replace.
+   Only this category should carry "this looks AI-drafted" framing in the handoff summary.

--- a/.claude/skills/shared/generated-content-review.md
+++ b/.claude/skills/shared/generated-content-review.md
@@ -1,0 +1,67 @@
+# Generated-content review
+
+Use this file to catch phrasing and structural patterns typical of AI-drafted text, on top of the [`style-guide.md`](style-guide.md) rules.
+
+This file is self-contained. It doesn't assume any other Grafana repository is checked out locally.
+
+Two things can be true of the same sentence: it can be a generated-content tell *and* a style-guide violation. When a row below says "Also a style-guide rule," treat it as an ordinary style fix — cite the style guide, not this file. Reserve "this reads as AI-drafted" framing for rows marked **README-specific**, since those aren't covered anywhere else.
+
+## 1. Structural padding
+
+|                                                  Pattern                                                  |                                       Fix                                       |      Note       |
+| --------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- | --------------- |
+| A closing paragraph restates what earlier sections already said                                           | Delete it, or replace with an actual next step                                  | README-specific |
+| A section ends with an unearned importance claim ("This ensures reliable, scalable telemetry collection") | Cut it, or replace with the real, specific consequence                          | README-specific |
+| Three-adjective padding ("fast, reliable, and efficient")                                                 | Keep the one adjective that's true and checkable; cut the rest                  | README-specific |
+| Every `##` section follows an identical rigid shape regardless of content                                 | Let structure follow the template in `style-guide.md`, not a mechanical outline | README-specific |
+
+## 2. Sentence-level tics
+
+|                                                 Pattern                                                 |                                    Fix                                    |                         Note                          |
+| ------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- | ----------------------------------------------------- |
+| Negative parallelism ("It's not just a collector, it's a full observability pipeline")                  | State the fact plainly                                                    | README-specific                                       |
+| Overused connective tissue ("Additionally," "Furthermore," "It's worth noting that")                    | Cut the connector if the sentence reads fine without it                   | README-specific                                       |
+| Vague, unsupported intensifiers ("significantly," "notably," "seamlessly")                              | Cut the word, or replace with the specific number or condition            | README-specific                                       |
+| Editorializing filler verbs ("ensures," "empowers," "leverages," "enables seamless")                    | Replace with the actual mechanism: "sends," "writes," "drops," "forwards" | README-specific                                       |
+| "-ing" analytical tack-ons ("...improving observability," "...highlighting the pipeline's flexibility") | Cut the clause; let the fact stand alone                                  | README-specific                                       |
+| Passive voice ("Data is collected by the receiver")                                                     | Rewrite active: "The receiver collects data"                              | Also a style-guide rule — active voice, second person |
+| Future tense as default ("Alloy will forward the metrics")                                              | Present tense: "Alloy forwards the metrics"                               | Also a style-guide rule — present tense               |
+| "This scenario demonstrates"                                                                            | "This scenario shows"                                                     | Also in `best-practices.md`                           |
+| "will install" / "will be used to"                                                                      | Active present tense                                                      | Also in `best-practices.md`                           |
+| "pre-configured"                                                                                        | "configured"                                                              | Also in `best-practices.md`                           |
+| "See"                                                                                                   | "Refer to"                                                                | Also a style-guide rule                               |
+| "Confirm" in troubleshoot steps                                                                         | "Check"                                                                   | Also a style-guide rule                               |
+
+## 3. Formatting tics
+
+|                                                      Pattern                                                      |                                                            Fix                                                             |                            Note                            |
+| ----------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
+| A numbered procedure flattened into a bullet list                                                                 | Convert back to a numbered list — steps in **Run the scenario** and **Try it out** are sequential and depend on each other | README-specific                                            |
+| Bold applied to phrases that aren't UI text                                                                       | Remove the bold, or use italic if the word genuinely needs emphasis                                                        | Also a style-guide rule — bold UI text only                |
+| Em dash used repeatedly as a substitute for commas or periods                                                     | Vary punctuation to match the actual grammatical relationship                                                              | README-specific                                            |
+| Title case in headings ("Understand The Architecture")                                                            | Sentence case: "Understand the architecture"                                                                               | Also a style-guide rule                                    |
+| Leftover chat artifacts ("Certainly! Here's the updated section:", "I hope this helps!", `[Insert example here]`) | Remove outright                                                                                                            | Highest-confidence flag on this list — not a judgment call |
+| Blockquote note styled like `> **Note:**`                                                                         | Rewrite as a plain sentence or a short intro paragraph; this repo's READMEs don't use an admonition shortcode              | README-specific                                            |
+
+## 4. Content-level tells
+
+|                                                       Pattern                                                        |                                                  Fix                                                  |                                                          Note                                                           |
+| -------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| Confident but unverified specifics (wrong port, wrong component name, wrong default)                                 | Verify against the scenario config files and the Alloy component reference before accepting the claim | Route through [`technical-verification.md`](technical-verification.md); this is a verification issue, not a wording fix |
+| Generic troubleshooting boilerplate ("Check your configuration file for errors," "Ensure the service is running")    | Replace with the actual failure mode and actual fix for this scenario                                 | README-specific — matches the "Weak examples" pitfall in `best-practices.md`                                            |
+| False completeness ("A comprehensive guide to configuring Alloy") on a scenario README that only covers one pipeline | Scope the claim to what the scenario actually does, or cut it                                         | README-specific                                                                                                         |
+| Invented or stale cross-references (a **Next steps** link to a component or scenario that doesn't exist)             | Verify every link resolves before handoff                                                             | README-specific — add to the pre-handoff pass alongside [`verification-checklist.md`](verification-checklist.md)        |
+| Query examples with labels or jobs that don't appear in `config.alloy`                                               | Take query examples from labels and jobs actually defined in the config                               | Also in `best-practices.md` under "Weak examples"                                                                       |
+
+## What NOT to flag
+
+- Em dashes on their own — only overuse as connective glue is the issue, not the character itself.
+- Passive voice, gerund headings, sentence-case headings, bold-for-UI-only — these are ordinary style-guide rules. Cite `style-guide.md`, don't frame them as generated-content tells.
+- General promotional language in **Explore the services** or **Next steps** — covered by the "avoid marketing clichés and hyperbole" instinct baked into `best-practices.md`'s good patterns section, not a separate generated-content category.
+
+## How to report findings
+
+Split findings into two kinds, same as technical vs. style in `SKILL.md` Step 3:
+
+1. **Style-guide violation** — objective, cite the rule in `style-guide.md`, safe to fix directly.
+2. **Likely AI-origin content issue** — formulaic padding, unverified specifics, invented references, leftover chat artifacts. These need a judgment call or a source check, not just a find-and-replace. Only this category should carry "this looks AI-drafted" framing in the handoff summary.

--- a/.claude/skills/shared/style-guide.md
+++ b/.claude/skills/shared/style-guide.md
@@ -71,7 +71,10 @@ List prerequisites, tools, and ports that must be free.
 
 ## Compare with a related scenario
 
-Optional. Include a comparison table when a closely related scenario exists in the repository.
+Optional. Include this section only when repo-context.md's baseline README table lists another scenario with the same deployment pattern (Docker vs. Kubernetes) and overlapping telemetry type (logs, metrics, traces).
+Name that scenario directly.
+If no such scenario is listed there, omit this section.
+Don't search for or invent a comparison.
 
 ## Understand the architecture
 
@@ -99,7 +102,9 @@ Steps to generate telemetry, run queries or open dashboards, and inspect the pip
 
 ## Customize the scenario
 
-Common configuration changes and the command to apply them.
+Include this section if any of the following appear in the scenario's configs: an environment variable, a `.env` setting, a commented out configuration line, a port mapping, a file path, a scrape or scrape_interval value, a retention setting, a backend endpoint URL, or a label or job name used for filtering.
+For each one, name the setting and explain what changing it does, matching the style of existing scenario READMEs rather than citing file names or line numbers.
+Omit this section only if none of the items above appear anywhere in `config.alloy`, the compose file, backend configs, or Helm values.
 
 ## Troubleshoot common problems
 

--- a/.claude/skills/shared/style-guide.md
+++ b/.claude/skills/shared/style-guide.md
@@ -43,6 +43,7 @@ Write for someone who wants to run the scenario end to end with minimal prior Al
 - Use ", for example," for examples
 - Use relative links for other scenarios in this repository
 - Use "refer to" instead of "see."
+- Use "check" instead of "confirm" in troubleshoot fix steps
 - Separate code and output blocks
 - Use `<VARIABLE>` in commands and _VARIABLE_ in prose for placeholders
 
@@ -71,10 +72,12 @@ List prerequisites, tools, and ports that must be free.
 
 ## Compare with a related scenario
 
-Optional. Include this section only when repo-context.md's baseline README table lists another scenario with the same deployment pattern (Docker vs. Kubernetes) and overlapping telemetry type (logs, metrics, traces).
-Name that scenario directly.
-If no such scenario is listed there, omit this section.
-Don't search for or invent a comparison.
+Optional. Include this section only if you can name a specific sibling scenario directory in the repository that shares this scenario's deployment pattern (Docker vs. Kubernetes) and its primary telemetry type (logs, metrics, traces, profiles).
+List the repository's top-level scenario directories, not just the baseline examples in repo-context.md, since real comparisons in this repo aren't limited to that table.
+Confirm the overlap by reading the candidate sibling's `README.md` or config files.
+Don't infer a match from the directory name alone.
+If no such scenario exists, omit this section.
+Don't invent a comparison.
 
 ## Understand the architecture
 
@@ -86,7 +89,9 @@ Numbered setup steps. Include clone, deploy or install commands, and a step to c
 
 ## Access the services
 
-Optional. Explain how to reach services that are not available on localhost.
+Optional. Docker Compose scenarios publish ports directly to localhost, so this section is normally not needed. Skip it.
+Include this section only for Kubernetes scenarios, or any scenario where a service isn't exposed on localhost and needs an extra step such as `kubectl port-forward` before its URL in **Explore the services** works.
+State the specific reason, for example "Grafana and the Alloy UI don't listen on localhost," and give the exact command for each service.
 
 ## Explore the services
 
@@ -102,7 +107,7 @@ Steps to generate telemetry, run queries or open dashboards, and inspect the pip
 
 ## Customize the scenario
 
-Include this section if any of the following appear in the scenario's configs: an environment variable, a `.env` setting, a commented out configuration line, a port mapping, a file path, a scrape or scrape_interval value, a retention setting, a backend endpoint URL, or a label or job name used for filtering.
+Optional. Include this section if any of the following appear in the scenario's configs: an environment variable, a `.env` setting, a commented out configuration line, a port mapping, a file path, a scrape or scrape_interval value, a retention setting, a backend endpoint URL, or a label or job name used for filtering.
 For each one, name the setting and explain what changing it does, matching the style of existing scenario READMEs rather than citing file names or line numbers.
 Omit this section only if none of the items above appear anywhere in `config.alloy`, the compose file, backend configs, or Helm values.
 
@@ -120,4 +125,3 @@ Links to related Alloy documentation, sibling scenarios, and other examples in t
 ```
 
 Omit optional sections that do not apply to the scenario.
-Skip **Access the services** when all services are already reachable on localhost.

--- a/.claude/skills/shared/technical-verification.md
+++ b/.claude/skills/shared/technical-verification.md
@@ -16,7 +16,7 @@ Flag statements about:
 
 Read the scenario directory configs listed in [`repo-context.md`](repo-context.md).
 
-Use the **Scenario config verification** and **Preservation check** sections of [`verification-checklist.md`](verification-checklist.md).
+Use the **Scenario config verification** and **Preservation check (rewrite only)** sections of [`verification-checklist.md`](verification-checklist.md).
 
 ## 3. Verify Alloy claims against external docs
 

--- a/.claude/skills/shared/verification-checklist.md
+++ b/.claude/skills/shared/verification-checklist.md
@@ -39,6 +39,7 @@ Follow [`alloy-verification.md`](alloy-verification.md).
 - [ ] Sentence case for headings and emphasis used as subheadings
 - [ ] Contractions used naturally
 - [ ] "Refer to" used instead of "see"
+- [ ] "Check" used instead of "confirm" in troubleshoot steps
 - [ ] No gerunds in headings
 - [ ] No parentheses or brackets in prose
 - [ ] Brief overview after major headings where helpful
@@ -57,6 +58,14 @@ Follow [`alloy-verification.md`](alloy-verification.md).
 - [ ] Credentials and default URLs preserved
 - [ ] Query examples preserved or intentionally replaced with equivalent coverage
 - [ ] Install order and Helm release names unchanged unless configs changed
+
+## Generated-content review
+
+Follow [`generated-content-review.md`](generated-content-review.md).
+
+- [ ] Checked for structural padding, sentence-level tics, formatting tics, and content-level tells
+- [ ] Leftover chat artifacts and invented or stale cross-references specifically checked
+- [ ] Findings split into style-guide violations and likely AI-origin content issues, not lumped together
 
 ## Final review
 


### PR DESCRIPTION
Vague steps in the original Skill content led to occasional logical hallucinations when the skill was applied to README files. These changes tighten up the logical decision points, fix some typos, clarify a few points and also add a new generated content review that goes deeper into clearing out some of the grammatical AI-tells (which should simplify the Human Review stage after the README docs are generated).