### PR TITLE
feat: add log-to-metrics scenario

### DIFF
--- a/.github/scenario-list.txt
+++ b/.github/scenario-list.txt
@@ -11,6 +11,7 @@ kafka
 linux
 log-api-gateway
 log-secret-filtering
+log-to-metrics
 logs-file
 logs-tcp
 mail-house

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ These scenarios focus on log collection, log parsing, log routing, and log redac
 | [Log API gateway](log-api-gateway/) | Use Alloy as a centralized log gateway that accepts logs via a Loki-compatible push API endpoint. |
 | [Log routing](routing/) | Route logs from multiple sources to different Loki tenants based on log content and origin. |
 | [Log secret filtering](log-secret-filtering/) | Redact sensitive credentials and secrets from logs with pattern rules before storage. |
+| [Log-to-metrics](log-to-metrics/) | Extract a request counter and latency histogram from application logs while forwarding the raw logs to Loki. |
 | [Logs from file](logs-file/) | Tail log files with Alloy. |
 | [Logs over TCP](logs-tcp/) | Receive and process TCP logs in JSON format. |
 | [Popular logging frameworks](app-instrumentation/logging/popular-logging-frameworks/) | Parse logs from popular logging frameworks across 7 programming languages. |

--- a/log-to-metrics/README.md
+++ b/log-to-metrics/README.md
@@ -1,0 +1,119 @@
+# Derive metrics from application logs with Alloy
+
+This scenario uses `loki.process` and its `stage.metrics` block to turn HTTP request log lines into Prometheus metrics while it continues to send the original logs to Loki.
+A bundled Python generator writes request logs, so the complete example runs without an external application.
+Grafana starts with a dashboard that shows the source logs, request rate, and p95 request latency together.
+
+## Before you begin
+
+Ensure you have the following:
+
+- [Docker][docker] and [Docker Compose][docker-compose].
+- Ports 3000, 3100, 9090, and 12345 free on the host.
+
+[docker]: https://docs.docker.com/get-docker/
+[docker-compose]: https://docs.docker.com/compose/install/
+
+## Understand the architecture
+
+```text
+                         +-------------------> Loki --------+
+                         |                    (raw logs)     |
+log-generator --> Alloy -+                                   +--> Grafana
+   (file)       (regex + |                    (metrics)      |
+                metrics) +--> self-scrape --> Prometheus ---+
+```
+
+- **log-generator** writes synthetic request lines to a shared file every 500 milliseconds.
+- **Alloy** tails the file, extracts `method`, `status`, and `duration`, and updates a counter and histogram.
+- **Loki** stores the original request logs with low-cardinality `method` and `status` labels.
+- **Prometheus** receives only metrics whose names begin with `log_derived_` through remote write.
+- **Grafana** provisions both data sources and a dashboard automatically.
+
+`stage.metrics` exposes generated metrics on Alloy's `/metrics` endpoint.
+The `prometheus.scrape` component scrapes that endpoint, a relabel rule keeps only this scenario's derived metrics, and `prometheus.remote_write` sends them to Prometheus.
+
+## Run the scenario
+
+1. Clone the repository if you haven't already: `git clone https://github.com/grafana/alloy-scenarios.git`
+
+2. Install the scenario with one of these options:
+
+   **Option 1: From the scenario directory**
+
+   Use the default image tags in `docker-compose.yml`.
+
+   - Navigate to this scenario: `cd alloy-scenarios/log-to-metrics`
+   - Deploy the scenario: `docker compose up -d`
+
+   **Option 2: From the repository root**
+
+   Use pinned image versions from `image-versions.env`.
+
+   - Deploy the scenario: `./run-example.sh log-to-metrics`
+
+3. From the `log-to-metrics` directory, check that all containers are up: `docker compose ps`
+
+   You should see `log-generator`, `alloy`, `loki`, `prometheus`, and `grafana`.
+
+## Explore the results
+
+Open Grafana at http://localhost:3000, with no login required, and select the **Metrics derived from logs** dashboard.
+Allow about 30 seconds for the first rate and histogram queries to populate.
+
+You can also inspect each signal directly:
+
+- In the Prometheus UI at http://localhost:9090, query `log_derived_requests_total` or `log_derived_request_duration_seconds_bucket`.
+- In Grafana Explore, select Loki and query `{job="log-to-metrics"}`.
+- In the Alloy UI at http://localhost:12345, inspect `loki.process.requests` and `prometheus.scrape.derived_metrics`.
+- Run `docker compose logs -f log-generator` to watch the source request lines.
+
+Each generated line has this form:
+
+```text
+2026-01-01T12:00:00+00:00 method=GET path=/api/products status=200 duration=0.083s
+```
+
+The regular expression stage extracts fields from that line.
+The metrics stage then creates:
+
+- `log_derived_requests_total`, incremented once for every parsed request log.
+- `log_derived_request_duration_seconds`, a histogram populated from the `duration` field.
+
+## Adapt the pipeline
+
+Edit `stage.regex` in `config.alloy` to match your application's log format.
+Keep metric labels bounded: values such as HTTP method and status code are safe examples, while request paths, user IDs, and trace IDs can create unbounded cardinality.
+Change the histogram buckets to match the latency range of your service.
+
+The generated metrics reset when Alloy reloads its configuration and disappear after five minutes without matching logs because `max_idle_duration` is set to `5m`.
+
+## Troubleshoot common problems
+
+### The dashboard has logs but no metrics
+
+Open http://localhost:12345/metrics and search for `log_derived_`.
+If the metrics exist there, inspect `prometheus.scrape.derived_metrics` and `prometheus.remote_write.local` in the Alloy UI.
+Verify that Prometheus was started with `--web.enable-remote-write-receiver`.
+
+### No logs appear
+
+Run `docker compose logs log-generator` and verify that it emits request lines.
+Then inspect `loki.source.file.requests` in the Alloy UI and confirm that `./logs/requests.log` exists in the scenario directory.
+
+### A container exits at startup
+
+Run `docker compose logs <service>` for the failing service.
+For Alloy, configuration errors include the component and line number that failed validation.
+
+## Stop the scenario
+
+Run `docker compose down` from the `log-to-metrics` directory.
+Add `--volumes` if you also want to remove Docker-managed data.
+
+## Next steps
+
+- [`loki.process` reference](https://grafana.com/docs/alloy/latest/reference/components/loki/loki.process/)
+- [`prometheus.scrape` reference](https://grafana.com/docs/alloy/latest/reference/components/prometheus/prometheus.scrape/)
+- [Logs from file scenario](../logs-file/)
+- [OpenTelemetry span metrics scenario](../otel-span-metrics/)

--- a/log-to-metrics/app/generate_logs.py
+++ b/log-to-metrics/app/generate_logs.py
@@ -1,0 +1,32 @@
+import datetime
+import random
+import time
+
+
+METHODS = ["GET", "GET", "GET", "POST"]
+PATHS = ["/api/cart", "/api/checkout", "/api/products"]
+STATUSES = [200, 200, 200, 200, 404, 500]
+
+
+with open("/logs/requests.log", "w"):
+    pass
+
+while True:
+    method = random.choice(METHODS)
+    path = random.choice(PATHS)
+    status = random.choice(STATUSES)
+    duration = min(random.lognormvariate(-2.3, 0.55), 2.0)
+    if status >= 500:
+        duration += 0.4
+
+    timestamp = datetime.datetime.now(datetime.timezone.utc).isoformat()
+    line = (
+        f"{timestamp} method={method} path={path} "
+        f"status={status} duration={duration:.3f}s"
+    )
+
+    print(line, flush=True)
+    with open("/logs/requests.log", "a") as log_file:
+        log_file.write(f"{line}\n")
+
+    time.sleep(0.5)

--- a/log-to-metrics/config.alloy
+++ b/log-to-metrics/config.alloy
@@ -1,0 +1,77 @@
+livedebugging {
+	enabled = true
+}
+
+local.file_match "request_logs" {
+	path_targets = [{"__path__" = "/var/log/demo/requests.log", "job" = "log-to-metrics"}]
+	sync_period  = "2s"
+}
+
+loki.source.file "requests" {
+	targets       = local.file_match.request_logs.targets
+	forward_to    = [loki.process.requests.receiver]
+	tail_from_end = true
+}
+
+loki.process "requests" {
+	forward_to = [loki.write.local.receiver]
+
+	stage.regex {
+		expression = "method=(?P<method>\\S+) path=(?P<path>\\S+) status=(?P<status>\\d{3}) duration=(?P<duration>[0-9.]+)s"
+	}
+
+	stage.labels {
+		values = {
+			method = "",
+			status = "",
+		}
+	}
+
+	stage.metrics {
+		metric.counter {
+			name              = "requests_total"
+			description       = "Requests observed in application logs"
+			prefix            = "log_derived_"
+			source            = "status"
+			action            = "inc"
+			max_idle_duration = "5m"
+		}
+
+		metric.histogram {
+			name              = "request_duration_seconds"
+			description       = "Request duration extracted from application logs"
+			prefix            = "log_derived_"
+			source            = "duration"
+			buckets           = [0.05, 0.1, 0.25, 0.5, 1.0, 2.0]
+			max_idle_duration = "5m"
+		}
+	}
+}
+
+loki.write "local" {
+	endpoint {
+		url = "http://loki:3100/loki/api/v1/push"
+	}
+}
+
+prometheus.scrape "derived_metrics" {
+	targets         = [{"__address__" = "127.0.0.1:12345"}]
+	forward_to      = [prometheus.relabel.derived_metrics.receiver]
+	scrape_interval = "5s"
+}
+
+prometheus.relabel "derived_metrics" {
+	forward_to = [prometheus.remote_write.local.receiver]
+
+	rule {
+		source_labels = ["__name__"]
+		regex         = "log_derived_.*"
+		action        = "keep"
+	}
+}
+
+prometheus.remote_write "local" {
+	endpoint {
+		url = "http://prometheus:9090/api/v1/write"
+	}
+}

--- a/log-to-metrics/docker-compose.coda.yml
+++ b/log-to-metrics/docker-compose.coda.yml
@@ -1,0 +1,7 @@
+services:
+  log-generator:
+    image: python:${PYTHON_VERSION:-3.11-slim}
+    volumes:
+      - ./app/generate_logs.py:/app/generate_logs.py
+      - ./logs:/logs
+    command: python3 /app/generate_logs.py

--- a/log-to-metrics/docker-compose.yml
+++ b/log-to-metrics/docker-compose.yml
@@ -1,0 +1,55 @@
+services:
+  # Continuously writes synthetic HTTP request logs to a shared file.
+  log-generator:
+    image: python:${PYTHON_VERSION:-3.11-slim}
+    volumes:
+      - ./app/generate_logs.py:/app/generate_logs.py
+      - ./logs:/logs
+    command: python3 /app/generate_logs.py
+    depends_on:
+      - alloy
+
+  # Tails the log file, derives metrics, and ships both signals.
+  alloy:
+    image: grafana/alloy:${GRAFANA_ALLOY_VERSION:-v1.17.1}
+    ports:
+      - 12345:12345/tcp
+    volumes:
+      - ./config.alloy:/etc/alloy/config.alloy
+      - ./logs:/var/log/demo
+    command: run --server.http.listen-addr=0.0.0.0:12345 --storage.path=/var/lib/alloy/data /etc/alloy/config.alloy
+    depends_on:
+      - loki
+      - prometheus
+
+  loki:
+    image: grafana/loki:${GRAFANA_LOKI_VERSION:-3.7.3}
+    ports:
+      - 3100:3100/tcp
+    volumes:
+      - ./loki-config.yaml:/etc/loki/local-config.yaml
+    command: -config.file=/etc/loki/local-config.yaml
+
+  prometheus:
+    image: prom/prometheus:${PROMETHEUS_VERSION:-v3.13.1}
+    command:
+      - --web.enable-remote-write-receiver
+      - --config.file=/etc/prometheus/prometheus.yml
+    ports:
+      - 9090:9090/tcp
+    volumes:
+      - ./prom-config.yaml:/etc/prometheus/prometheus.yml
+
+  grafana:
+    image: grafana/grafana:${GRAFANA_VERSION:-13.1.0}
+    environment:
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_BASIC_ENABLED=false
+    volumes:
+      - ./grafana:/etc/grafana/provisioning
+    ports:
+      - 3000:3000/tcp
+    depends_on:
+      - loki
+      - prometheus

--- a/log-to-metrics/grafana/dashboards/dashboards.yaml
+++ b/log-to-metrics/grafana/dashboards/dashboards.yaml
@@ -1,0 +1,12 @@
+apiVersion: 1
+providers:
+  - name: 'log-to-metrics'
+    orgId: 1
+    folder: ''
+    type: file
+    disableDeletion: true
+    updateIntervalSeconds: 10
+    allowUiUpdates: false
+    options:
+      path: /etc/grafana/provisioning/dashboards
+      foldersFromFilesStructure: false

--- a/log-to-metrics/grafana/dashboards/log-to-metrics.json
+++ b/log-to-metrics/grafana/dashboards/log-to-metrics.json
@@ -1,0 +1,53 @@
+{
+  "uid": "log-to-metrics",
+  "title": "Metrics derived from logs",
+  "schemaVersion": 39,
+  "refresh": "5s",
+  "time": { "from": "now-15m", "to": "now" },
+  "panels": [
+    {
+      "id": 1,
+      "type": "timeseries",
+      "title": "Request rate from logs",
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": { "defaults": { "unit": "reqps" }, "overrides": [] },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "sum(rate(log_derived_requests_total[1m]))",
+          "legendFormat": "requests/s"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "type": "timeseries",
+      "title": "Request latency p95 from logs",
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": { "defaults": { "unit": "s" }, "overrides": [] },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "histogram_quantile(0.95, sum by (le) (rate(log_derived_request_duration_seconds_bucket[1m])))",
+          "legendFormat": "p95"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "type": "logs",
+      "title": "Source request logs",
+      "gridPos": { "h": 12, "w": 24, "x": 0, "y": 8 },
+      "datasource": { "type": "loki", "uid": "loki" },
+      "targets": [
+        {
+          "refId": "A",
+          "expr": "{job=\"log-to-metrics\"}",
+          "queryType": "range"
+        }
+      ]
+    }
+  ]
+}

--- a/log-to-metrics/grafana/datasources/datasources.yaml
+++ b/log-to-metrics/grafana/datasources/datasources.yaml
@@ -1,0 +1,23 @@
+apiVersion: 1
+datasources:
+  - name: Prometheus
+    uid: prometheus
+    type: prometheus
+    access: proxy
+    orgId: 1
+    url: http://prometheus:9090
+    basicAuth: false
+    isDefault: true
+    version: 1
+    editable: false
+
+  - name: Loki
+    uid: loki
+    type: loki
+    access: proxy
+    orgId: 1
+    url: http://loki:3100
+    basicAuth: false
+    isDefault: false
+    version: 1
+    editable: false

--- a/log-to-metrics/loki-config.yaml
+++ b/log-to-metrics/loki-config.yaml
@@ -1,0 +1,39 @@
+auth_enabled: false
+
+limits_config:
+  allow_structured_metadata: true
+  volume_enabled: true
+
+server:
+  http_listen_port: 3100
+
+common:
+  ring:
+    instance_addr: 0.0.0.0
+    kvstore:
+      store: inmemory
+  replication_factor: 1
+  path_prefix: /tmp/loki
+
+schema_config:
+  configs:
+    - from: 2020-05-15
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
+storage_config:
+  tsdb_shipper:
+    active_index_directory: /tmp/loki/index
+    cache_location: /tmp/loki/index_cache
+  filesystem:
+    directory: /tmp/loki/chunks
+
+pattern_ingester:
+  enabled: true
+
+ingester:
+  max_chunk_age: 2h

--- a/log-to-metrics/prom-config.yaml
+++ b/log-to-metrics/prom-config.yaml
@@ -1,0 +1,5 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs: []


### PR DESCRIPTION
## Summary
- Add a `log-to-metrics` scenario that turns HTTP request log lines into Prometheus metrics with `loki.process` `stage.metrics` (counter + histogram) while still shipping raw logs to Loki.
- Include a Python log generator, LGMT docker-compose stack, provisioned Grafana dashboard, and README walkthrough.
- Register the scenario in the root README Logs table and `.github/scenario-list.txt`.

Fixes #267

## Test plan
- [ ] `cd log-to-metrics && docker compose up -d` (or `./run-example.sh log-to-metrics`)
- [ ] Grafana dashboard **Metrics derived from logs** shows request rate, p95 latency, and source logs
- [ ] Prometheus has `log_derived_requests_total` / `log_derived_request_duration_seconds_bucket`
- [ ] Loki query `{job="log-to-metrics"}` returns the same request lines
- [ ] `config.alloy` stays ≤80 lines; image tags match `image-versions.env` fallbacks