### PR TITLE
feat: add StatsD metrics scenario

### DIFF
--- a/.github/scenario-list.txt
+++ b/.github/scenario-list.txt
@@ -33,6 +33,7 @@ redis-monitoring
 routing
 self-monitoring
 snmp
+statsd-metrics
 syslog
 systemd-journal
 trace-delivery

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ These scenarios collect and forward metrics with Alloy.
 | [OpenTelemetry SDK metrics across languages](app-instrumentation/metrics/opentelemetry-sdk/) | Instrument five languages with the OpenTelemetry metrics SDK and push them through Alloy to Prometheus. |
 | [Prometheus client metrics across languages](app-instrumentation/metrics/prometheus-client/) | Expose `/metrics` with native Prometheus client libraries in five languages and scrape them with Alloy. The pull-model counterpart to the OpenTelemetry SDK scenario. |
 | [OTel metrics pipeline](otel-metrics-pipeline/) | Forward OpenTelemetry metrics from applications through Alloy. Alloy batches and transforms samples before it sends them to Prometheus. |
+| [StatsD metrics](statsd-metrics/) | Receive legacy StatsD counter, gauge, and timer packets in Alloy and remote-write mapped Prometheus metrics. |
 
 ### Profiling
 

--- a/statsd-metrics/README.md
+++ b/statsd-metrics/README.md
@@ -1,0 +1,105 @@
+# Collect StatsD metrics with Grafana Alloy
+
+This scenario shows how to bring metrics from a legacy StatsD application into Prometheus without changing the application.
+The bundled sender emits a counter, gauge, and timer to Alloy over UDP.
+Alloy's `prometheus.exporter.statsd` component maps those packets to Prometheus metrics, `prometheus.scrape` collects them, and `prometheus.remote_write` stores them in Prometheus.
+
+## Before you begin
+
+Ensure that [Docker][docker] and [Docker Compose][docker-compose] are installed, and that ports 3000, 8125/UDP, 9090, and 12345 are available.
+
+[docker]: https://docs.docker.com/get-docker/
+[docker-compose]: https://docs.docker.com/compose/install/
+
+## Understand the architecture
+
+```text
++---------------+  StatsD/UDP   +--------------------------------+  remote write  +------------+     +---------+
+| legacy sender |-------------->| Alloy                          |--------------->| Prometheus |<----| Grafana |
++---------------+               | StatsD exporter -> scrape     |                +------------+     +---------+
+                                +--------------------------------+
+```
+
+- **Sender** emits representative StatsD counter, gauge, and timer packets.
+- **Alloy** receives UDP packets on port 8125 and applies the mappings in `statsd-mapping.yaml`.
+- **Prometheus** receives the scraped samples through its remote-write receiver.
+- **Grafana** includes a provisioned Prometheus data source for queries.
+
+## Run the scenario
+
+From the repository root, start the scenario with one of these options:
+
+```sh
+cd statsd-metrics
+docker compose up -d
+```
+
+Or use the repository's pinned image versions:
+
+```sh
+./run-example.sh statsd-metrics
+cd statsd-metrics
+```
+
+Verify that all four services are running:
+
+```sh
+docker compose ps
+```
+
+## Explore the metrics
+
+Open Grafana at http://localhost:3000 or Prometheus at http://localhost:9090, then run these PromQL queries:
+
+- `legacy_checkout_requests_total` — monotonically increasing request counter.
+- `legacy_checkout_queue_depth` — current queue depth gauge.
+- `legacy_checkout_request_duration_seconds_bucket` — histogram buckets produced from the StatsD timer.
+- `histogram_quantile(0.95, sum by (le) (rate(legacy_checkout_request_duration_seconds_bucket[5m])))` — 95th-percentile checkout latency.
+
+The Alloy UI is available at http://localhost:12345. Use live debugging to inspect `prometheus.exporter.statsd.legacy_app` and `prometheus.scrape.statsd`.
+
+## Understand the mapping
+
+`statsd-mapping.yaml` converts dot-separated StatsD names into stable Prometheus names:
+
+| StatsD packet | Prometheus metric |
+| --- | --- |
+| `legacy.checkout.requests:1|c` | `legacy_checkout_requests_total` |
+| `legacy.checkout.queue_depth:42|g` | `legacy_checkout_queue_depth` |
+| `legacy.checkout.request_duration:125|ms` | `legacy_checkout_request_duration_seconds` histogram |
+
+StatsD timers are converted from milliseconds to seconds. The explicit histogram buckets make latency percentile queries possible.
+
+## Send metrics from another application
+
+The UDP port is exposed on the host, so an application outside Compose can send StatsD packets to `localhost:8125`.
+Update `statsd-mapping.yaml` before sending new metric names, then restart Alloy:
+
+```sh
+docker compose restart alloy
+```
+
+## Troubleshoot
+
+If the metrics do not appear, check the sender and Alloy logs:
+
+```sh
+docker compose logs sender alloy
+```
+
+Confirm that Alloy is listening on UDP port 8125 and that the metric name matches a mapping rule exactly.
+If a custom sender runs on the host, use `localhost:8125`; services in the Compose network should send to `alloy:8125`.
+
+## Stop the scenario
+
+Run this from the scenario directory:
+
+```sh
+docker compose down
+```
+
+## Next steps
+
+- [`prometheus.exporter.statsd` reference](https://grafana.com/docs/alloy/latest/reference/components/prometheus/prometheus.exporter.statsd/)
+- [`prometheus.scrape` reference](https://grafana.com/docs/alloy/latest/reference/components/prometheus/prometheus.scrape/)
+- [`prometheus.remote_write` reference](https://grafana.com/docs/alloy/latest/reference/components/prometheus/prometheus.remote_write/)

--- a/statsd-metrics/app/sender.py
+++ b/statsd-metrics/app/sender.py
@@ -1,0 +1,24 @@
+"""Continuously send representative legacy StatsD metrics over UDP."""
+
+import socket
+import time
+
+
+STATSD_ADDRESS = ("alloy", 8125)
+METRICS = (
+    "legacy.checkout.requests:1|c",
+    "legacy.checkout.queue_depth:42|g",
+    "legacy.checkout.request_duration:125|ms",
+)
+
+
+def main() -> None:
+    with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as client:
+        while True:
+            for metric in METRICS:
+                client.sendto(metric.encode("utf-8"), STATSD_ADDRESS)
+            time.sleep(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/statsd-metrics/config.alloy
+++ b/statsd-metrics/config.alloy
@@ -1,0 +1,24 @@
+// Receive legacy StatsD packets, expose them as Prometheus targets, and
+// remote-write the scraped metrics to the local Prometheus instance.
+livedebugging {
+	enabled = true
+}
+
+prometheus.exporter.statsd "legacy_app" {
+	listen_udp          = "0.0.0.0:8125"
+	mapping_config_path = "/etc/alloy/statsd-mapping.yaml"
+}
+
+prometheus.scrape "statsd" {
+	targets         = prometheus.exporter.statsd.legacy_app.targets
+	forward_to      = [prometheus.remote_write.local.receiver]
+	job_name        = "statsd-metrics"
+	scrape_interval = "5s"
+	scrape_timeout  = "4s"
+}
+
+prometheus.remote_write "local" {
+	endpoint {
+		url = "http://prometheus:9090/api/v1/write"
+	}
+}

--- a/statsd-metrics/docker-compose.yml
+++ b/statsd-metrics/docker-compose.yml
@@ -1,0 +1,42 @@
+services:
+  sender:
+    image: python:${PYTHON_VERSION:-3.11-slim}
+    command: python3 /app/sender.py
+    volumes:
+      - ./app/sender.py:/app/sender.py:ro
+    restart: unless-stopped
+
+  alloy:
+    image: grafana/alloy:${GRAFANA_ALLOY_VERSION:-v1.17.1}
+    command: run --server.http.listen-addr=0.0.0.0:12345 --storage.path=/var/lib/alloy/data /etc/alloy/config.alloy
+    ports:
+      - 8125:8125/udp
+      - 12345:12345/tcp
+    volumes:
+      - ./config.alloy:/etc/alloy/config.alloy:ro
+      - ./statsd-mapping.yaml:/etc/alloy/statsd-mapping.yaml:ro
+    depends_on:
+      - prometheus
+
+  prometheus:
+    image: prom/prometheus:${PROMETHEUS_VERSION:-v3.13.1}
+    command:
+      - --web.enable-remote-write-receiver
+      - --config.file=/etc/prometheus/prometheus.yml
+    ports:
+      - 9090:9090/tcp
+    volumes:
+      - ./prom-config.yaml:/etc/prometheus/prometheus.yml:ro
+
+  grafana:
+    image: grafana/grafana:${GRAFANA_VERSION:-13.1.0}
+    environment:
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_BASIC_ENABLED=false
+    ports:
+      - 3000:3000/tcp
+    volumes:
+      - ./grafana:/etc/grafana/provisioning:ro
+    depends_on:
+      - prometheus

--- a/statsd-metrics/grafana/datasources/datasources.yaml
+++ b/statsd-metrics/grafana/datasources/datasources.yaml
@@ -1,0 +1,12 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    orgId: 1
+    url: http://prometheus:9090
+    basicAuth: false
+    isDefault: true
+    version: 1
+    editable: false

--- a/statsd-metrics/prom-config.yaml
+++ b/statsd-metrics/prom-config.yaml
@@ -1,0 +1,3 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s

--- a/statsd-metrics/statsd-mapping.yaml
+++ b/statsd-metrics/statsd-mapping.yaml
@@ -1,0 +1,17 @@
+# Give the legacy StatsD names stable Prometheus metric names and define the
+# timer as a histogram so latency quantiles can be queried in PromQL.
+defaults:
+  match_type: glob
+
+mappings:
+  - match: "legacy.checkout.requests"
+    name: "legacy_checkout_requests_total"
+
+  - match: "legacy.checkout.queue_depth"
+    name: "legacy_checkout_queue_depth"
+
+  - match: "legacy.checkout.request_duration"
+    name: "legacy_checkout_request_duration_seconds"
+    observer_type: histogram
+    histogram_options:
+      buckets: [0.05, 0.1, 0.25, 0.5, 1, 2.5]


### PR DESCRIPTION
## Problem

Alloy scenarios did not show how to migrate a legacy StatsD application to a Prometheus-backed pipeline. Users could not see the supported `prometheus.exporter.statsd` path, including how StatsD names and timers map to Prometheus metrics.

Closes #262.

## Solution

- Add a self-contained `statsd-metrics` scenario with a dependency-free UDP sender.
- Receive StatsD on Alloy port 8125, map a counter, gauge, and timer through `statsd-mapping.yaml`, scrape the exporter, and remote-write to Prometheus.
- Provision Grafana's Prometheus data source and document architecture, PromQL queries, custom sender use, and troubleshooting.
- Register the scenario in the root README and validation matrix.

## Testing

- `alloy fmt --test statsd-metrics/config.alloy` (Alloy v1.17.1)
- `alloy validate` with the same configuration and mounted mapping path (Alloy v1.17.1)
- Started Alloy successfully; its readiness endpoint returned 200 and the StatsD exporter component initialized.
- Sent counter, gauge, and timer packets through `statsd_exporter` v0.28.0, the version used by Alloy v1.17.1; verified the mapped counter, gauge, histogram buckets, and `0.125`-second timer sum.
- `python -m compileall -q statsd-metrics/app/sender.py`
- Parsed the Compose, mapping, Prometheus, and Grafana YAML files with PyYAML.

Docker is not installed on this host, so I could not run `docker compose up`; the repository's `validate-scenarios` workflow will run the Compose smoke test for this scenario.