### PR TITLE
feat: add Pushgateway metrics scenario

### DIFF
--- a/.github/scenario-list.txt
+++ b/.github/scenario-list.txt
@@ -28,6 +28,7 @@ otel-span-metrics
 otel-tail-sampling
 otel-tracing-service-graphs
 postgres-monitoring
+prometheus-pushgateway
 promtail-to-alloy-migration
 redis-monitoring
 routing

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ These scenarios collect and forward metrics with Alloy.
 | [Metric cardinality control](metric-cardinality-control/) | Compare original Prometheus metrics with a cardinality-controlled `prometheus.relabel` path that drops noisy series and volatile labels and normalizes dynamic routes. |
 | [OpenTelemetry SDK metrics across languages](app-instrumentation/metrics/opentelemetry-sdk/) | Instrument five languages with the OpenTelemetry metrics SDK and push them through Alloy to Prometheus. |
 | [Prometheus client metrics across languages](app-instrumentation/metrics/prometheus-client/) | Expose `/metrics` with native Prometheus client libraries in five languages and scrape them with Alloy. The pull-model counterpart to the OpenTelemetry SDK scenario. |
+| [Prometheus Pushgateway](prometheus-pushgateway/) | Scrape metrics retained for short-lived batch jobs by Prometheus Pushgateway and remote-write them through Alloy. |
 | [OTel metrics pipeline](otel-metrics-pipeline/) | Forward OpenTelemetry metrics from applications through Alloy. Alloy batches and transforms samples before it sends them to Prometheus. |
 
 ### Profiling

--- a/image-versions.env
+++ b/image-versions.env
@@ -28,6 +28,8 @@ GRAFANA_PYROSCOPE_VERSION=2.1.1
 # Prometheus images
 # renovate: datasource=docker depName=prom/prometheus
 PROMETHEUS_VERSION=v3.13.1
+# renovate: datasource=docker depName=prom/pushgateway
+PUSHGATEWAY_VERSION=v1.11.3
 # renovate: datasource=docker depName=quay.io/prometheus/node-exporter
 NODE_EXPORTER_VERSION=v1.9.1
 

--- a/prometheus-pushgateway/README.md
+++ b/prometheus-pushgateway/README.md
@@ -1,0 +1,96 @@
+# Collect batch-job metrics through Pushgateway
+
+This scenario shows how Alloy collects metrics from short-lived jobs that cannot be scraped directly.
+The bundled batch job pushes `job_last_success_timestamp` to Prometheus Pushgateway, where Alloy scrapes it and remote-writes it to Prometheus.
+
+## Before you begin
+
+Ensure that [Docker][docker] and [Docker Compose][docker-compose] are installed, and that ports 3000, 9090, 9091, and 12345 are available.
+
+[docker]: https://docs.docker.com/get-docker/
+[docker-compose]: https://docs.docker.com/compose/install/
+
+## Understand the architecture
+
+```text
++-----------+  push metric  +-------------+  scrape  +-------+  remote write  +------------+     +---------+
+| batch job |-------------->| Pushgateway |--------->| Alloy |--------------->| Prometheus |<----| Grafana |
++-----------+               +-------------+          +-------+                +------------+     +---------+
+```
+
+- **Batch job** sends one completion timestamp to Pushgateway, then remains idle so the example stays observable.
+- **Pushgateway** retains the last metric from the job.
+- **Alloy** scrapes Pushgateway every five seconds and forwards samples with `prometheus.remote_write`.
+- **Prometheus** stores the samples, and **Grafana** provides a ready-to-use Prometheus data source.
+
+## Run the scenario
+
+From the repository root, start the scenario with either command:
+
+```sh
+cd prometheus-pushgateway
+docker compose up -d
+```
+
+```sh
+./run-example.sh prometheus-pushgateway
+cd prometheus-pushgateway
+```
+
+Confirm every service is running:
+
+```sh
+docker compose ps
+```
+
+## Explore the metric
+
+Open Grafana at http://localhost:3000 or Prometheus at http://localhost:9090 and run:
+
+```promql
+job_last_success_timestamp{job="demo_batch"}
+```
+
+The value is the Unix timestamp at which the bundled job completed.
+Use the following query to calculate its age:
+
+```promql
+time() - job_last_success_timestamp{job="demo_batch"}
+```
+
+Pushgateway is available at http://localhost:9091 and the Alloy UI at http://localhost:12345.
+
+## Use this pattern with your own job
+
+Push a metric when the job finishes successfully:
+
+```sh
+printf 'job_last_success_timestamp %s\n' "$(date +%s)" \
+  | curl --data-binary @- http://pushgateway:9091/metrics/job/your_batch_job
+```
+
+Use grouping labels only when they identify the logical job. Avoid per-run labels such as a timestamp or random execution ID, because Pushgateway retains every label set and they create unbounded Prometheus cardinality.
+
+## Troubleshoot
+
+If the metric is absent, inspect the job, Pushgateway, and Alloy logs:
+
+```sh
+docker compose logs batch-job pushgateway alloy
+```
+
+Check http://localhost:9091/metrics to confirm Pushgateway received the metric, then check `up{job="pushgateway"}` in Prometheus. A value of `0` means Alloy cannot reach Pushgateway.
+
+## Stop the scenario
+
+Run this from the scenario directory:
+
+```sh
+docker compose down
+```
+
+## Next steps
+
+- [Pushgateway documentation](https://github.com/prometheus/pushgateway)
+- [`prometheus.scrape` reference](https://grafana.com/docs/alloy/latest/reference/components/prometheus/prometheus.scrape/)
+- [`prometheus.remote_write` reference](https://grafana.com/docs/alloy/latest/reference/components/prometheus/prometheus.remote_write/)

--- a/prometheus-pushgateway/config.alloy
+++ b/prometheus-pushgateway/config.alloy
@@ -1,0 +1,20 @@
+// Scrape metrics retained by Pushgateway and remote-write them to Prometheus.
+livedebugging {
+	enabled = true
+}
+
+prometheus.scrape "pushgateway" {
+	targets = [
+		{"__address__" = "pushgateway:9091"},
+	]
+	forward_to      = [prometheus.remote_write.local.receiver]
+	job_name        = "pushgateway"
+	scrape_interval = "5s"
+	scrape_timeout  = "4s"
+}
+
+prometheus.remote_write "local" {
+	endpoint {
+		url = "http://prometheus:9090/api/v1/write"
+	}
+}

--- a/prometheus-pushgateway/docker-compose.yml
+++ b/prometheus-pushgateway/docker-compose.yml
@@ -1,0 +1,53 @@
+services:
+  pushgateway:
+    image: prom/pushgateway:${PUSHGATEWAY_VERSION:-v1.11.3}
+    ports:
+      - 9091:9091/tcp
+
+  batch-job:
+    image: curlimages/curl:${CURL_VERSION:-8.21.0}
+    entrypoint: /bin/sh
+    command:
+      - -ec
+      - |
+        until printf 'job_last_success_timestamp %s\n' "$(date +%s)" \
+          | curl --fail --silent --show-error --data-binary @- http://pushgateway:9091/metrics/job/demo_batch; do
+          sleep 1
+        done
+        exec sleep infinity
+    depends_on:
+      - pushgateway
+
+  alloy:
+    image: grafana/alloy:${GRAFANA_ALLOY_VERSION:-v1.17.1}
+    command: run --server.http.listen-addr=0.0.0.0:12345 --storage.path=/var/lib/alloy/data /etc/alloy/config.alloy
+    ports:
+      - 12345:12345/tcp
+    volumes:
+      - ./config.alloy:/etc/alloy/config.alloy:ro
+    depends_on:
+      - pushgateway
+      - prometheus
+
+  prometheus:
+    image: prom/prometheus:${PROMETHEUS_VERSION:-v3.13.1}
+    command:
+      - --web.enable-remote-write-receiver
+      - --config.file=/etc/prometheus/prometheus.yml
+    ports:
+      - 9090:9090/tcp
+    volumes:
+      - ./prom-config.yaml:/etc/prometheus/prometheus.yml:ro
+
+  grafana:
+    image: grafana/grafana:${GRAFANA_VERSION:-13.1.0}
+    environment:
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_BASIC_ENABLED=false
+    ports:
+      - 3000:3000/tcp
+    volumes:
+      - ./grafana:/etc/grafana/provisioning:ro
+    depends_on:
+      - prometheus

--- a/prometheus-pushgateway/grafana/datasources/datasources.yaml
+++ b/prometheus-pushgateway/grafana/datasources/datasources.yaml
@@ -1,0 +1,12 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    orgId: 1
+    url: http://prometheus:9090
+    basicAuth: false
+    isDefault: true
+    version: 1
+    editable: false

--- a/prometheus-pushgateway/prom-config.yaml
+++ b/prometheus-pushgateway/prom-config.yaml
@@ -1,0 +1,3 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s


### PR DESCRIPTION
## Problem

Short-lived batch jobs, cron jobs, and serverless tasks can finish before Prometheus or Alloy has a chance to scrape their metrics. The scenarios repository did not include a working Pushgateway pattern for this case.

Closes #263.

## Solution

- Add a self-contained `prometheus-pushgateway` scenario.
- A bundled job publishes `job_last_success_timestamp` to Pushgateway and then remains idle so the example can be inspected.
- Alloy scrapes Pushgateway every five seconds and remote-writes the metric to Prometheus; Grafana has a provisioned Prometheus data source.
- Add the new Pushgateway image version to centralized Renovate-managed versions and register the scenario for validation.

## Testing

- `alloy fmt --test prometheus-pushgateway/config.alloy` (Alloy v1.17.1)
- `alloy validate prometheus-pushgateway/config.alloy` (Alloy v1.17.1)
- Parsed the Compose, Prometheus, and Grafana YAML files with PyYAML.
- Verified `prom/pushgateway:v1.11.3` is an available Docker Hub tag.

Docker is not installed on this host, so I could not run `docker compose up`; the repository's `validate-scenarios` workflow will run the Compose smoke test for this scenario.