### PR TITLE
feat: add DNS service discovery scenario

### DIFF
--- a/.github/scenario-list.txt
+++ b/.github/scenario-list.txt
@@ -1,6 +1,7 @@
 aws-firehose-logs
 blackbox-probing
 continuous-profiling
+dns-service-discovery
 docker-monitoring
 elasticsearch-monitoring
 faro-frontend-observability

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ These scenarios collect and forward metrics with Alloy.
 | -------- | ----------- |
 | [Alloy clustering](alloy-clustering/) | Run a three-node Alloy cluster that consistent-hashes `prometheus.scrape` targets across nodes. Stop a node and its targets redistribute to the survivors within seconds. |
 | [Blackbox probing](blackbox-probing/) | Monitor endpoint availability and response times with synthetic HTTP probes. |
+| [DNS service discovery](dns-service-discovery/) | Discover and scrape two Prometheus targets from DNS SRV records with `discovery.dns`. |
 | [Prometheus Operator Probes](k8s/prometheus-operator-probes/) | Scrape Prometheus Operator `Probe` resources with Alloy as the blackbox prober (`/probe` path). |
 | [Metric cardinality control](metric-cardinality-control/) | Compare original Prometheus metrics with a cardinality-controlled `prometheus.relabel` path that drops noisy series and volatile labels and normalizes dynamic routes. |
 | [OpenTelemetry SDK metrics across languages](app-instrumentation/metrics/opentelemetry-sdk/) | Instrument five languages with the OpenTelemetry metrics SDK and push them through Alloy to Prometheus. |

--- a/dns-service-discovery/Corefile
+++ b/dns-service-discovery/Corefile
@@ -1,0 +1,9 @@
+demo.local:53 {
+    errors
+    file /etc/coredns/db.demo.local
+}
+
+. {
+    errors
+    forward . 127.0.0.11
+}

--- a/dns-service-discovery/README.md
+++ b/dns-service-discovery/README.md
@@ -1,0 +1,99 @@
+# Discover Prometheus targets through DNS SRV records
+
+This scenario shows how Alloy discovers scrape targets from DNS instead of a static target list.
+CoreDNS serves two SRV records for demo exporters; Alloy resolves them with `discovery.dns`, adds a stable job label with `discovery.relabel`, then scrapes both targets and remote-writes the samples to Prometheus.
+
+## Before you begin
+
+Ensure that [Docker][docker] and [Docker Compose][docker-compose] are installed, and that ports 3000, 9090, and 12345 are free.
+
+[docker]: https://docs.docker.com/get-docker/
+[docker-compose]: https://docs.docker.com/compose/install/
+
+## Understand the architecture
+
+```text
+                  SRV records
++---------+  _metrics._tcp.demo.local  +-------+  scrape  +------------+     +---------+
+| CoreDNS |--------------------------->| Alloy |--------->| Prometheus |<----| Grafana |
++---------+                            +---+---+          +------------+     +---------+
+                                           |
+                                  discovers two exporters
+                                  +--------+ +--------+
+                                  |   A    | |   B    |
+                                  +--------+ +--------+
+```
+
+CoreDNS returns `exporter-a.demo.local:8000` and `exporter-b.demo.local:8000` for `_metrics._tcp.demo.local`.
+The exporters use fixed addresses only inside this isolated Compose network so the zone file is deterministic; real deployments would point DNS records at their own hosts.
+
+## Run the scenario
+
+From the repository root, use either command:
+
+```sh
+cd dns-service-discovery
+docker compose up -d
+```
+
+```sh
+./run-example.sh dns-service-discovery
+cd dns-service-discovery
+```
+
+Verify all services are running:
+
+```sh
+docker compose ps
+```
+
+## Explore the discovered targets
+
+Open Grafana at http://localhost:3000 or Prometheus at http://localhost:9090 and run:
+
+```promql
+up{job="dns-service-discovery"}
+```
+
+Expect two healthy time series. To see the exporter identities, run:
+
+```promql
+dns_discovery_demo_info{job="dns-service-discovery"}
+```
+
+The Alloy UI at http://localhost:12345 shows the targets flowing through `discovery.dns.metrics`, `discovery.relabel.metrics`, and `prometheus.scrape.metrics`.
+
+## Customize the DNS records
+
+Edit `db.demo.local` to change SRV targets, then restart CoreDNS:
+
+```sh
+docker compose restart coredns
+```
+
+Alloy refreshes DNS every five seconds. In a production environment, replace the demo zone with the DNS service already used by your VM or service-discovery platform.
+
+## Troubleshoot
+
+If only one or no targets appear, inspect the DNS and Alloy logs:
+
+```sh
+docker compose logs coredns alloy
+```
+
+Confirm the SRV records use a trailing dot on the target host names and that the SRV port matches the exporters' listening port.
+If `up` is `0`, ensure the discovered host names resolve to reachable addresses in the same network as Alloy.
+
+## Stop the scenario
+
+Run this from the scenario directory:
+
+```sh
+docker compose down
+```
+
+## Next steps
+
+- [`discovery.dns` reference](https://grafana.com/docs/alloy/latest/reference/components/discovery/discovery.dns/)
+- [`discovery.relabel` reference](https://grafana.com/docs/alloy/latest/reference/components/discovery/discovery.relabel/)
+- [`prometheus.scrape` reference](https://grafana.com/docs/alloy/latest/reference/components/prometheus/prometheus.scrape/)

--- a/dns-service-discovery/app/exporter.py
+++ b/dns-service-discovery/app/exporter.py
@@ -1,0 +1,27 @@
+"""Minimal Prometheus exporter used by the DNS discovery scenario."""
+
+import os
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+
+INSTANCE = os.environ["INSTANCE"]
+
+
+class MetricsHandler(BaseHTTPRequestHandler):
+    def do_GET(self) -> None:  # noqa: N802 - HTTP handler API requires this name.
+        if self.path != "/metrics":
+            self.send_error(404)
+            return
+
+        body = f'dns_discovery_demo_info{{instance="{INSTANCE}"}} 1\n'.encode()
+        self.send_response(200)
+        self.send_header("Content-Type", "text/plain; version=0.0.4")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, format: str, *args: object) -> None:
+        return
+
+
+HTTPServer(("0.0.0.0", 8000), MetricsHandler).serve_forever()

--- a/dns-service-discovery/config.alloy
+++ b/dns-service-discovery/config.alloy
@@ -1,0 +1,33 @@
+// Resolve SRV records, attach a stable job label, then scrape the discovered
+// exporters and remote-write their metrics to Prometheus.
+livedebugging {
+	enabled = true
+}
+
+discovery.dns "metrics" {
+	names            = ["_metrics._tcp.demo.local"]
+	type             = "SRV"
+	refresh_interval = "5s"
+}
+
+discovery.relabel "metrics" {
+	targets = discovery.dns.metrics.targets
+
+	rule {
+		target_label = "job"
+		replacement  = "dns-service-discovery"
+	}
+}
+
+prometheus.scrape "metrics" {
+	targets         = discovery.relabel.metrics.output
+	forward_to      = [prometheus.remote_write.local.receiver]
+	scrape_interval = "5s"
+	scrape_timeout  = "4s"
+}
+
+prometheus.remote_write "local" {
+	endpoint {
+		url = "http://prometheus:9090/api/v1/write"
+	}
+}

--- a/dns-service-discovery/db.demo.local
+++ b/dns-service-discovery/db.demo.local
@@ -1,0 +1,8 @@
+$ORIGIN demo.local.
+@ 60 IN SOA ns.demo.local. hostmaster.demo.local. 1 7200 3600 1209600 60
+@ 60 IN NS ns.demo.local.
+ns 60 IN A 172.30.0.53
+exporter-a 60 IN A 172.30.0.11
+exporter-b 60 IN A 172.30.0.12
+_metrics._tcp 60 IN SRV 10 10 8000 exporter-a.demo.local.
+_metrics._tcp 60 IN SRV 10 10 8000 exporter-b.demo.local.

--- a/dns-service-discovery/docker-compose.yml
+++ b/dns-service-discovery/docker-compose.yml
@@ -1,0 +1,80 @@
+services:
+  coredns:
+    image: coredns/coredns:${COREDNS_VERSION:-1.14.6}
+    command: -conf /etc/coredns/Corefile
+    volumes:
+      - ./Corefile:/etc/coredns/Corefile:ro
+      - ./db.demo.local:/etc/coredns/db.demo.local:ro
+    networks:
+      dns_demo:
+        ipv4_address: 172.30.0.53
+
+  exporter-a:
+    image: python:${PYTHON_VERSION:-3.11-slim}
+    command: python3 /app/exporter.py
+    environment:
+      - INSTANCE=exporter-a
+    volumes:
+      - ./app/exporter.py:/app/exporter.py:ro
+    networks:
+      dns_demo:
+        ipv4_address: 172.30.0.11
+
+  exporter-b:
+    image: python:${PYTHON_VERSION:-3.11-slim}
+    command: python3 /app/exporter.py
+    environment:
+      - INSTANCE=exporter-b
+    volumes:
+      - ./app/exporter.py:/app/exporter.py:ro
+    networks:
+      dns_demo:
+        ipv4_address: 172.30.0.12
+
+  alloy:
+    image: grafana/alloy:${GRAFANA_ALLOY_VERSION:-v1.17.1}
+    command: run --server.http.listen-addr=0.0.0.0:12345 --storage.path=/var/lib/alloy/data /etc/alloy/config.alloy
+    dns:
+      - 172.30.0.53
+    ports:
+      - 12345:12345/tcp
+    volumes:
+      - ./config.alloy:/etc/alloy/config.alloy:ro
+    depends_on:
+      - coredns
+      - prometheus
+    networks:
+      - dns_demo
+
+  prometheus:
+    image: prom/prometheus:${PROMETHEUS_VERSION:-v3.13.1}
+    command:
+      - --web.enable-remote-write-receiver
+      - --config.file=/etc/prometheus/prometheus.yml
+    ports:
+      - 9090:9090/tcp
+    volumes:
+      - ./prom-config.yaml:/etc/prometheus/prometheus.yml:ro
+    networks:
+      - dns_demo
+
+  grafana:
+    image: grafana/grafana:${GRAFANA_VERSION:-13.1.0}
+    environment:
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_BASIC_ENABLED=false
+    ports:
+      - 3000:3000/tcp
+    volumes:
+      - ./grafana:/etc/grafana/provisioning:ro
+    depends_on:
+      - prometheus
+    networks:
+      - dns_demo
+
+networks:
+  dns_demo:
+    ipam:
+      config:
+        - subnet: 172.30.0.0/24

--- a/dns-service-discovery/grafana/datasources/datasources.yaml
+++ b/dns-service-discovery/grafana/datasources/datasources.yaml
@@ -1,0 +1,12 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    orgId: 1
+    url: http://prometheus:9090
+    basicAuth: false
+    isDefault: true
+    version: 1
+    editable: false

--- a/dns-service-discovery/prom-config.yaml
+++ b/dns-service-discovery/prom-config.yaml
@@ -1,0 +1,3 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s

--- a/image-versions.env
+++ b/image-versions.env
@@ -34,6 +34,8 @@ NODE_EXPORTER_VERSION=v1.9.1
 # Other images
 # renovate: datasource=docker depName=python
 PYTHON_VERSION=3.11-slim
+# renovate: datasource=docker depName=coredns/coredns
+COREDNS_VERSION=1.14.6
 
 # nginx-monitoring scenario
 # renovate: datasource=docker depName=nginx


### PR DESCRIPTION
## Problem

The scenario collection had no DNS service-discovery example, so users of VM fleets or DNS-backed discovery systems could not see how to replace a static scrape target list with Alloy's `discovery.dns` pipeline.

Closes #264.

## Solution

- Add a self-contained CoreDNS-backed DNS SRV discovery scenario.
- CoreDNS serves two `_metrics._tcp.demo.local` SRV records for lightweight demo exporters.
- Alloy resolves the records with `discovery.dns`, adds a stable label through `discovery.relabel`, scrapes both targets, and remote-writes them to Prometheus.
- Add the Renovate-managed CoreDNS image version and register the scenario for CI validation.

## Testing

- `alloy fmt --test dns-service-discovery/config.alloy` (Alloy v1.17.1)
- `alloy validate dns-service-discovery/config.alloy` (Alloy v1.17.1)
- `python -m compileall -q dns-service-discovery/app/exporter.py`
- Parsed Compose, Prometheus, and Grafana YAML with PyYAML.
- Started the bundled CoreDNS zone with CoreDNS v1.14.6 and resolved both expected SRV records with dnspython.

Docker is not installed on this host, so the full Compose smoke test was not run locally. The repository's `validate-scenarios` workflow will run it for this scenario.