### PR TITLE
Add security reporting guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,3 +67,4 @@ Checklist for a new scenario:
 - Alloy HTTP server runs on port 12345
 - Python demo apps use OpenTelemetry SDK for instrumentation (`telemetry.py` pattern)
 - Backend configs (loki, prometheus, tempo) are minimal single-instance dev configs — not production-ready
+- Security issues should be reported via [Grafana's security issue reporting page](https://grafana.com/legal/report-a-security-issue/) and not directly in this repository.


### PR DESCRIPTION
## What changed

- Added guidance to the repository's agent instructions directing security issues to Grafana's security reporting page instead of the repository.

## Why

This makes the expected reporting channel explicit for coding agents working in the repository.

## Validation

- `git diff --check`
- Confirmed the commit changes only one agent instruction file with one added line.
