### PR TITLE
Add Datadog receiver migration scenario

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ These scenarios collect and forward metrics with Alloy.
 | -------- | ----------- |
 | [Alloy clustering](alloy-clustering/) | Run a three-node Alloy cluster that consistent-hashes `prometheus.scrape` targets across nodes. Stop a node and its targets redistribute to the survivors within seconds. |
 | [Blackbox probing](blackbox-probing/) | Monitor endpoint availability and response times with synthetic HTTP probes. |
+| [Datadog receiver migration](datadog-receiver-migration/) | Ingest Datadog Agent metrics and traces with `otelcol.receiver.datadog` and forward them to Prometheus and Tempo. |
 | [DNS service discovery](dns-service-discovery/) | Discover and scrape two Prometheus targets from DNS SRV records with `discovery.dns`. |
 | [Prometheus Operator Probes](k8s/prometheus-operator-probes/) | Scrape Prometheus Operator `Probe` resources with Alloy as the blackbox prober (`/probe` path). |
 | [Metric cardinality control](metric-cardinality-control/) | Compare original Prometheus metrics with a cardinality-controlled `prometheus.relabel` path that drops noisy series and volatile labels and normalizes dynamic routes. |

--- a/datadog-receiver-migration/README.md
+++ b/datadog-receiver-migration/README.md
@@ -1,0 +1,27 @@
+# datadog-receiver-migration
+
+This scenario demonstrates a migration path from Datadog to Grafana Alloy using the `otelcol.receiver.datadog` component. It allows teams to put Alloy in place of, or in front of, the Datadog Agent, forwarding Datadog format metrics and traces to Prometheus and Tempo without requiring a Datadog account or vendor lock-in.
+
+## What is demonstrated
+* Using `otelcol.receiver.datadog` to ingest Datadog Agent metrics and traces.
+* Forwarding Datadog metrics to Prometheus using `otelcol.exporter.prometheus`.
+* Forwarding Datadog traces to Tempo using `otelcol.exporter.otlp`.
+
+## Architecture
+1. **Generator**: A Python application using DogStatsD and `ddtrace` to generate traces and metrics.
+2. **Datadog Agent**: Receives metrics and traces from the generator and forwards them to Alloy instead of Datadog HQ.
+3. **Grafana Alloy**: Acts as the backend for the Datadog Agent, receiving its payloads via `otelcol.receiver.datadog` and exporting them to Prometheus and Tempo.
+4. **Prometheus & Tempo**: Store the metrics and traces respectively.
+5. **Grafana**: Visualizes the stored data.
+
+## Running the scenario
+1. Start the environment:
+   ```bash
+   docker compose up -d
+   ```
+2. Open Grafana at http://localhost:3000
+3. Navigate to Explore to see the Datadog traces in Tempo and the `example_work_count` / `example_work_duration` metrics in Prometheus.
+4. Clean up the environment:
+   ```bash
+   docker compose down -v
+   ```

--- a/datadog-receiver-migration/config.alloy
+++ b/datadog-receiver-migration/config.alloy
@@ -1,0 +1,33 @@
+otelcol.receiver.datadog "default" {
+	endpoint = "0.0.0.0:8126"
+	output {
+		metrics = [otelcol.processor.deltatocumulative.default.input]
+		traces  = [otelcol.exporter.otlp.tempo.input]
+	}
+}
+
+otelcol.processor.deltatocumulative "default" {
+	max_stale = "5m"
+	output {
+		metrics = [otelcol.exporter.prometheus.default.input]
+	}
+}
+
+otelcol.exporter.prometheus "default" {
+	forward_to = [prometheus.remote_write.default.receiver]
+}
+
+prometheus.remote_write "default" {
+	endpoint {
+		url = "http://prometheus:9090/api/v1/write"
+	}
+}
+
+otelcol.exporter.otlp "tempo" {
+	client {
+		endpoint = "tempo:4317"
+		tls {
+			insecure = true
+		}
+	}
+}

--- a/datadog-receiver-migration/docker-compose.yml
+++ b/datadog-receiver-migration/docker-compose.yml
@@ -1,0 +1,95 @@
+services:
+  generator:
+    build: ./generator
+    environment:
+      - DD_AGENT_HOST=datadog-agent
+    depends_on:
+      - datadog-agent
+
+  datadog-agent:
+    image: datadog/agent:${DATADOG_AGENT_VERSION:-7.82.2}
+    environment:
+      - DD_API_KEY=dummy
+      - DD_SITE=datadoghq.com
+      - DD_DD_URL=http://alloy:8126
+      - DD_APM_DD_URL=http://alloy:8126
+      - DD_LOGS_ENABLED=false
+      - DD_APM_ENABLED=true
+      - DD_APM_NON_LOCAL_TRAFFIC=true
+      - DD_DOGSTATSD_NON_LOCAL_TRAFFIC=true
+      - DD_HOSTNAME=datadog-agent
+    depends_on:
+      - alloy
+
+  alloy:
+    image: grafana/alloy:${GRAFANA_ALLOY_VERSION:-v1.18.1}
+    volumes:
+      - ./config.alloy:/etc/alloy/config.alloy
+    command: run --server.http.listen-addr=0.0.0.0:12345 --stability.level=experimental /etc/alloy/config.alloy
+    ports:
+      - 8126:8126
+    depends_on:
+      - prometheus
+      - tempo
+
+  prometheus:
+    image: prom/prometheus:${PROMETHEUS_VERSION:-v3.13.1}
+    command:
+      - --web.enable-remote-write-receiver
+      - --config.file=/etc/prometheus/prometheus.yml
+    volumes:
+      - ./prom-config.yaml:/etc/prometheus/prometheus.yml
+    ports:
+      - 9090:9090
+
+  tempo:
+    image: grafana/tempo:${GRAFANA_TEMPO_VERSION:-2.10.7}
+    command: ["-config.file=/etc/tempo.yaml"]
+    volumes:
+      - ./tempo-config.yaml:/etc/tempo.yaml
+    ports:
+      - 3200:3200
+
+  grafana:
+    image: grafana/grafana:${GRAFANA_VERSION:-13.1.0}
+    environment:
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_BASIC_ENABLED=false
+    ports:
+      - 3000:3000
+    entrypoint:
+      - sh
+      - -euc
+      - |
+        mkdir -p /etc/grafana/provisioning/datasources
+        cat <<EOF > /etc/grafana/provisioning/datasources/ds.yaml
+        apiVersion: 1
+        datasources:
+        - name: Prometheus
+          type: prometheus
+          orgId: 1
+          url: http://prometheus:9090
+          basicAuth: false
+          isDefault: true
+          version: 1
+          editable: false
+        - name: Tempo
+          type: tempo
+          access: proxy
+          orgId: 1
+          url: http://tempo:3200
+          basicAuth: false
+          isDefault: false
+          version: 1
+          editable: false
+          jsonData:
+            serviceMap:
+              datasourceUid: 'Prometheus'
+            nodeGraph:
+              enabled: true
+        EOF
+        /run.sh
+    depends_on:
+      - prometheus
+      - tempo

--- a/datadog-receiver-migration/generator/Dockerfile
+++ b/datadog-receiver-migration/generator/Dockerfile
@@ -1,0 +1,7 @@
+ARG PYTHON_VERSION=3.11-slim
+FROM python:${PYTHON_VERSION}
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY main.py .
+CMD ["python", "main.py"]

--- a/datadog-receiver-migration/generator/main.py
+++ b/datadog-receiver-migration/generator/main.py
@@ -1,0 +1,22 @@
+import os
+import time
+import random
+from datadog import initialize, statsd
+from ddtrace import tracer
+
+options = {
+    'statsd_host': os.environ.get('DD_AGENT_HOST', 'datadog-agent'),
+    'statsd_port': 8125
+}
+initialize(**options)
+
+@tracer.wrap()
+def do_work():
+    time.sleep(random.uniform(0.1, 0.5))
+    statsd.increment('example.work.count', 1, tags=["env:dev"])
+    statsd.gauge('example.work.duration', random.uniform(10, 100), tags=["env:dev"])
+
+if __name__ == "__main__":
+    while True:
+        do_work()
+        time.sleep(1)

--- a/datadog-receiver-migration/generator/requirements.txt
+++ b/datadog-receiver-migration/generator/requirements.txt
@@ -1,0 +1,2 @@
+datadog
+ddtrace

--- a/datadog-receiver-migration/prom-config.yaml
+++ b/datadog-receiver-migration/prom-config.yaml
@@ -1,0 +1,6 @@
+global:
+  scrape_interval: 15s
+
+storage:
+  tsdb:
+    out_of_order_time_window: 30m

--- a/datadog-receiver-migration/tempo-config.yaml
+++ b/datadog-receiver-migration/tempo-config.yaml
@@ -1,0 +1,18 @@
+server:
+  http_listen_port: 3200
+  log_level: info
+
+distributor:
+  receivers:
+    otlp:
+      protocols:
+        grpc:
+          endpoint: "0.0.0.0:4317"
+
+storage:
+  trace:
+    backend: local
+    wal:
+      path: /var/tempo/wal
+    local:
+      path: /var/tempo/blocks

--- a/image-versions.env
+++ b/image-versions.env
@@ -71,3 +71,6 @@ PROMTAIL_VERSION=3.6.11
 # azure-event-hubs-logs scenario
 # renovate: datasource=docker depName=apache/kafka
 APACHE_KAFKA_VERSION=4.3.1
+# datadog-receiver-migration scenario
+# renovate: datasource=docker depName=datadog/agent
+DATADOG_AGENT_VERSION=7.82.2


### PR DESCRIPTION
## Summary

Adds a new `datadog-receiver-migration` scenario demonstrating migration from the Datadog Agent to Grafana Alloy using `otelcol.receiver.datadog`.

## What this demonstrates

- Datadog Agent sends metrics and traces to Alloy.
- Alloy receives the Datadog telemetry through `otelcol.receiver.datadog`.
- Datadog Delta Sum metrics are converted to cumulative metrics using `otelcol.processor.deltatocumulative`.
- Metrics are forwarded to Prometheus.
- Traces are forwarded to Tempo.
- No Datadog account is required.

## Validation

Validated the scenario with a clean Docker Compose rebuild:

- `example_work_count` reaches Prometheus.
- `example_work_duration` reaches Prometheus.
- `main.do_work` traces reach Tempo.
- All containers start successfully.
- Docker Compose configuration validates successfully.
- No unrelated/debug artifacts are included.

Grafana screenshots are included showing the metrics in Prometheus and `main.do_work` traces in Tempo.


<img width="1920" height="1080" alt="1" src="https://github.com/user-attachments/assets/5ac119bc-8841-400e-9cd9-25adad0ec881" />
<img width="1915" height="1023" alt="2" src="https://github.com/user-attachments/assets/ed6db349-9c1c-464d-baab-f3a3edabf305" />



Closes #272